### PR TITLE
Reposition expo-targets as Expo negative-space extensions

### DIFF
--- a/.skeleton/config.yaml
+++ b/.skeleton/config.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=node_modules/@csark0812/skeleton/schemas/config.schema.json
+
+scan:
+  include:
+    - "docs/**"
+    - "README.md"
+    - ".skeleton/registry.md"
+    - "AGENTS.md"
+  exclude:
+    - "refs/**"
+    - "apps/**"
+    - "packages/**/README.md"
+    - "CHANGELOG.md"
+    - "**/node_modules/**"
+    - "tests/**"
+  banned: []
+  retiredSkills: []
+
+daysUntilStale: 180

--- a/.skeleton/registry.md
+++ b/.skeleton/registry.md
@@ -1,0 +1,18 @@
+# Registry
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+**Source of truth for** topic routing in this repo. Edit rows here; edit content in canonical files only.
+
+## Documentation
+
+| Topic | Canonical file |
+| ----- | -------------- |
+| Package overview | [README.md](../README.md) |
+| Agent cold-start | [AGENTS.md](../AGENTS.md) |
+| Getting started | [getting-started.md](../docs/getting-started.md) |
+| Widgets handoff / coexistence | [widgets.md](../docs/widgets.md) |
+| React Native extensions | [react-native-extensions.md](../docs/react-native-extensions.md) |
+| Configuration | [configuration.md](../docs/configuration.md) |
+| API | [api.md](../docs/api.md) |
+| Roadmap / deprecation policy | [deprecations.md](../docs/deprecations.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS
+
+**Source of truth for** agent cold-start in this repo.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+## Product posture
+
+expo-targets owns **Expo’s negative space**: React Native share/action/clip/messages extensions, App Clips, stickers, wallet, and other Apple targets Expo does not ship. Android widgets are **bridge-grade** until Expo covers Android.
+
+- **New React/iOS widgets and Live Activities** → official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) (SDK 56+). See [docs/widgets.md](docs/widgets.md).
+- **Native iOS widgets** via this lib are soft-deprecated (shared-spine investment only).
+- **Do not add** new config-only extension types. See [docs/deprecations.md](docs/deprecations.md).
+
+## Docs SSOT
+
+Canonical docs are listed in [`.skeleton/registry.md`](.skeleton/registry.md). Edit those files only; keep `**Source of truth for**` banners and `doc-meta` comments.
+
+Validation:
+
+```bash
+bun run audit:self
+bun run validate:changed
+```
+
+## Safe commands
+
+- `bun install`, `bun run lint`, `bun run typecheck`, `bun test`, Skeleton audits
+- Do **not** start/stop/restart dev servers (`bun run dev`, `expo start`, etc.)
+
+## Packages
+
+| Package                       | Role                                                 |
+| ----------------------------- | ---------------------------------------------------- |
+| `packages/expo-targets`       | Config plugin, runtime, Metro helper, native modules |
+| `packages/create-expo-target` | Interactive scaffolder                               |
+| `packages/expo-targets-cli`   | Bare RN `expo-targets sync`                          |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Product posture:** expo-targets leads with extensions Expo does not ship (share/action/clip/messages, etc.). Soft-deprecate native iOS widgets in favor of official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) for React/iOS widgets and Live Activities. See `docs/widgets.md` and `docs/deprecations.md`.
+- `create-expo-target`: Share/Action/Clip lead the menu; Widget demoted with an `expo-widgets` handoff confirm; React Native defaults to **Yes** for share/action/clip.
+- Docs governed by `@csark0812/skeleton` (registry + `AGENTS.md`).
+
+### Deprecated
+
+- Native `type: "widget"` scaffolding and runtime usage warn in minors (CLI + `createTarget`). Removal reserved for a future major or when Expo covers Android widgets.
+
 ### Added
+
+- Skeleton docs SSOT (`@csark0812/skeleton`), `docs/widgets.md`, `docs/deprecations.md`.
+- Sharper RN extension runtime errors when `ExpoTargetsExtension` is missing; `getExtensionNativeModule()` helper.
+- `withTargetsMetro` entry validation/logging; `scanTargetsDirectory` export; Metro unit tests.
 
 ## [0.2.0] - 2025-12-09
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # expo-targets
 
-Add **iOS widgets**, **App Clips**, **iMessage stickers**, **share extensions**, and **wallet extensions** to your Expo app — no native experience required.
+**Source of truth for** package overview.
 
-> **⚠️ Important:** Requires development builds (`npx expo run:ios`). Does not work with Expo Go.
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+Add **share extensions**, **action extensions**, **App Clips**, **iMessage apps**, **stickers**, **wallet extensions**, and other Apple targets Expo does not ship — including React Native UIs where supported.
+
+> **Widgets:** For new React/iOS widgets and Live Activities, prefer official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) (SDK 56+). Native/Android widgets in this library are soft-deprecated / bridge-grade. See [Widgets handoff](./docs/widgets.md).
+
+> **Important:** Requires development builds (`npx expo run:ios`). Does not work with Expo Go.
 >
 > **Prerequisites:** macOS, Xcode 14+, Expo SDK 50+, iOS 14+. [Full requirements →](./docs/getting-started.md#prerequisites)
 
@@ -34,109 +40,107 @@ npm install expo-targets
 
 > **Why App Groups?** App Groups enable data sharing between your main app and extensions. The ID must start with `group.` — convention is `group.{your.bundle.identifier}`.
 
-### 3. Create a Widget
+### 3. Create a Share Extension (React Native)
 
 ```bash
 npx create-expo-target
-# Choose: Widget → my-widget → iOS
+# Choose: Share Extension → my-share → iOS → Yes (Use React Native)
 ```
 
 This creates:
 
 ```
-targets/my-widget/
-├── expo-target.config.json   # Widget configuration
-├── index.ts                  # Pre-configured target instance
-└── ios/
-    └── Widget.swift          # SwiftUI widget code
+targets/my-share/
+├── expo-target.config.json   # Extension configuration
+├── index.tsx                 # createTarget + RN entry
+└── ios/                      # Native host (generated at prebuild)
 ```
 
-### 4. Build & Run
+### 4. Configure Metro
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTargetsMetro } = require("expo-targets/metro");
+
+module.exports = withTargetsMetro(getDefaultConfig(__dirname));
+```
+
+See [React Native Extensions](./docs/react-native-extensions.md).
+
+### 5. Build & Run
 
 ```bash
 npx expo prebuild
 npx expo run:ios
 ```
 
-> **Building a Share/Action Extension with React Native?** You'll also need to configure Metro. See [React Native Extensions](./docs/react-native-extensions.md#4-configure-metro).
-
-### 5. Update from Your App
+### 6. Use the extension APIs
 
 ```typescript
-// Option A: Import the generated target instance
-import { myWidget } from './targets/my-widget';
+import { close, openHostApp, getSharedData } from "expo-targets";
 
-myWidget.setData({ message: 'Hello from React Native!' });
-myWidget.refresh();
-
-// Option B: Create your own instance
-import { createTarget } from 'expo-targets';
-
-const myWidget = createTarget('MyWidget'); // Must match config "name" field
-myWidget.setData({ message: 'Hello!' });
-myWidget.refresh();
+const data = getSharedData(); // Content shared into the extension
+openHostApp("/path"); // Open the host app
+close(); // Dismiss the extension
 ```
-
-🎉 **That's it!** Long-press your home screen, tap **+**, search for your app, and add the widget.
 
 ---
 
 ## Supported Extensions
 
-| Type                   | iOS | Android | Description             |
-| ---------------------- | --- | ------- | ----------------------- |
-| `widget`               | ✅  | ✅      | Home screen widgets     |
-| `clip`                 | ✅  | —       | App Clips               |
-| `stickers`             | ✅  | —       | iMessage sticker packs  |
-| `messages`             | ✅  | —       | iMessage apps           |
-| `share`                | ✅  | 🔜      | Share extensions        |
-| `action`               | ✅  | 🔜      | Action extensions       |
-| `wallet`               | 📋  | —       | Wallet extensions       |
-| `safari`               | 📋  | —       | Safari web extensions   |
-| `notification-content` | 📋  | 🔜      | Rich notification UI    |
-| `notification-service` | 📋  | 🔜      | Notification processing |
-| `intent`               | 📋  | —       | Siri intents            |
-| `intent-ui`            | 📋  | —       | Siri intent UI          |
+| Type                   | iOS  | Android | Description             |
+| ---------------------- | ---- | ------- | ----------------------- |
+| `share`                | ✅   | 🔜      | Share extensions        |
+| `action`               | ✅   | 🔜      | Action extensions       |
+| `clip`                 | ✅   | —       | App Clips               |
+| `stickers`             | ✅   | —       | iMessage sticker packs  |
+| `messages`             | ✅   | —       | iMessage apps           |
+| `wallet`               | ✅   | —       | Wallet extensions       |
+| `widget`               | ✅\* | ✅†     | Home screen widgets     |
+| `safari`               | 📋   | —       | Safari web extensions   |
+| `notification-content` | 📋   | 🔜      | Rich notification UI    |
+| `notification-service` | 📋   | 🔜      | Notification processing |
+| `intent`               | 📋   | —       | Siri intents            |
+| `intent-ui`            | 📋   | —       | Siri intent UI          |
 
 **Legend:** ✅ Production ready · 📋 Config-only\* · 🔜 Planned · — Not applicable
 
-> \*Config-only types generate the Xcode target structure but require you to write all Swift code yourself. See [Configuration → Extension Types](./docs/configuration.md#extension-types-reference).
+> \*Config-only types generate the Xcode target structure but require you to write all Swift code yourself. **No new config-only types** are being added. See [Deprecations](./docs/deprecations.md).
+>
+> \*`widget` (iOS): soft-deprecated — prefer [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) for React widgets. †Android widgets: bridge-grade. Details: [widgets.md](./docs/widgets.md).
 
 ---
 
 ## How It Works
 
-expo-targets uses **App Groups** to share data between your app and extensions:
+expo-targets uses **App Groups** to share data between your app and extensions, and (for RN extensions) a Metro + native host path to load your React tree inside the extension process.
 
 ```
 ┌─────────────────┐        ┌─────────────────┐
-│   Your App      │        │   Widget        │
+│   Your App      │        │   Extension     │
 │                 │        │                 │
-│  widget.set()   │───────▶│  UserDefaults   │
-│  widget.refresh()        │  reads data     │
+│  target.set()   │───────▶│  UserDefaults / │
+│  getSharedData  │◀───────│  RN host        │
 └─────────────────┘        └─────────────────┘
 ```
-
-Your JavaScript code writes to shared storage, and your Swift widget reads from it. Simple.
 
 ---
 
 ## Examples
 
-Clone the repo and explore working examples:
-
 ```bash
 git clone https://github.com/csark0812/expo-targets.git
-cd expo-targets/apps/widgets-showcase
+cd expo-targets/apps/extensions-showcase
 npm install && npx expo run:ios
 ```
 
-| Example                                           | What it shows                          |
-| ------------------------------------------------- | -------------------------------------- |
-| [widgets-showcase](./apps/widgets-showcase)       | Basic to advanced widgets              |
-| [extensions-showcase](./apps/extensions-showcase) | React Native share/action extensions   |
-| [clips-and-stickers](./apps/clips-and-stickers)   | App Clips + iMessage stickers          |
-| [bare-rn-widgets](./apps/bare-rn-widgets)         | Adding widgets to existing RN projects |
+| Example                                           | What it shows                         |
+| ------------------------------------------------- | ------------------------------------- |
+| [extensions-showcase](./apps/extensions-showcase) | React Native share/action extensions  |
+| [clips-and-stickers](./apps/clips-and-stickers)   | App Clips + iMessage stickers         |
+| [widgets-showcase](./apps/widgets-showcase)       | Native widgets (legacy / bridge path) |
+| [bare-rn-share](./apps/bare-rn-share)             | Share extension on bare RN            |
 
 See [apps/README.md](./apps/README.md) for the full list.
 
@@ -144,10 +148,12 @@ See [apps/README.md](./apps/README.md) for the full list.
 
 ## Documentation
 
-- **[Getting Started](./docs/getting-started.md)** — Build your first widget in 5 minutes
-- **[Configuration](./docs/configuration.md)** — All config options explained
+- **[Getting Started](./docs/getting-started.md)** — Build a React Native share extension
+- **[React Native Extensions](./docs/react-native-extensions.md)** — RN runtime contract + Metro
+- **[Widgets handoff](./docs/widgets.md)** — `expo-widgets` vs this library
+- **[Configuration](./docs/configuration.md)** — All config options
 - **[API Reference](./docs/api.md)** — JavaScript/TypeScript API
-- **[React Native Extensions](./docs/react-native-extensions.md)** — Using RN in share/action extensions
+- **[Deprecations](./docs/deprecations.md)** — Soft-deprecate and freeze policy
 
 ---
 
@@ -155,72 +161,47 @@ See [apps/README.md](./apps/README.md) for the full list.
 
 ### Expo Managed (Recommended)
 
-Best for most projects. Expo manages your native `ios/` folder via prebuild:
-
 ```bash
 npx expo prebuild
 npx expo run:ios
 ```
 
-Use this if:
-
-- Starting a new project
-- Your `ios/` folder is generated (not in git)
-- You use `expo prebuild` regularly
-
 ### Bare React Native
 
-For existing projects with a custom `ios/` folder you maintain manually:
-
 ```bash
-npx expo-targets sync    # Add targets to existing ios/ folder
+npx expo-targets sync
 cd ios && pod install
 npx react-native run-ios
 ```
-
-Use this if:
-
-- You have an existing React Native project with native modifications
-- Your `ios/` folder is committed to git
-- You can't use `expo prebuild` (it would overwrite your changes)
 
 ---
 
 ## API at a Glance
 
 ```typescript
-import { createTarget, refreshAllTargets } from 'expo-targets';
+import { createTarget, close, openHostApp, getSharedData } from "expo-targets";
 
-// Create a target instance
-const widget = createTarget('MyWidget');
+// RN extension entry
+export const share = createTarget<"share">("MyShare", ShareExtension);
 
-// Storage
-widget.set('key', value); // Set a single value
-widget.get<T>('key'); // Get a value
-widget.setData({ key: value }); // Set multiple values
-widget.getData<T>(); // Get all data
-widget.clear(); // Clear all data
-
-// Lifecycle
-widget.refresh(); // Refresh this widget
-refreshAllTargets(); // Refresh all widgets
+const data = getSharedData();
+openHostApp("/inbox");
+close();
 ```
 
-For share/action extensions:
+Shared storage (widgets and other targets):
 
 ```typescript
-import { close, openHostApp, getSharedData } from 'expo-targets';
-
-const data = getSharedData(); // Get shared content
-openHostApp('/path'); // Open main app
-close(); // Close extension
+const target = createTarget("MyTarget");
+target.setData({ key: "value" });
+target.refresh();
 ```
 
 ---
 
 ## Contributing
 
-Contributions welcome! This project is actively maintained.
+Contributions welcome. See [AGENTS.md](./AGENTS.md) for agent/docs conventions.
 
 ## License
 
@@ -228,4 +209,6 @@ MIT
 
 ## Credits
 
-Inspired by [@bacons/apple-targets](https://github.com/EvanBacon/expo-apple-targets), [expo-widgets](https://github.com/bittingz/expo-widgets), and [expo-share-extension](https://github.com/MaxAst/expo-share-extension).
+Inspired by [@bacons/apple-targets](https://github.com/EvanBacon/expo-apple-targets) and [expo-share-extension](https://github.com/MaxAst/expo-share-extension).
+
+Widget-related prior art: official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) (preferred for React/iOS widgets today) and community [bittingz/expo-widgets](https://github.com/bittingz/expo-widgets) (historical inspiration only — not the Expo SDK package).

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
+        "@csark0812/skeleton": "^1.5.5",
         "typescript": "~5.3.3",
       },
     },
@@ -393,6 +394,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
+    "@csark0812/skeleton": ["@csark0812/skeleton@1.5.5", "", { "dependencies": { "ajv": "^8.17.1", "github-slugger": "^2.0.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "yaml": "^2.8.0" }, "bin": { "skeleton": "dist/cli.js" } }, "sha512-YNXotMr5fWLqM3LJi+3IrTgrXrfJtBXnpeKaQA21tZp/qp/1N5r5VAGRX0ap9m9pPmkrZrm2fBhMu2624qCu3g=="],
+
     "@expo-targets/cli": ["@expo-targets/cli@workspace:packages/expo-targets-cli"],
 
     "@expo/cli": ["@expo/cli@54.0.16", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.8", "@expo/code-signing-certificates": "^0.0.5", "@expo/config": "~12.0.10", "@expo/config-plugins": "~54.0.2", "@expo/devcert": "^1.1.2", "@expo/env": "~2.0.7", "@expo/image-utils": "^0.8.7", "@expo/json-file": "^10.0.7", "@expo/mcp-tunnel": "~0.1.0", "@expo/metro": "~54.1.0", "@expo/metro-config": "~54.0.9", "@expo/osascript": "^2.3.7", "@expo/package-manager": "^1.9.8", "@expo/plist": "^0.4.7", "@expo/prebuild-config": "^54.0.6", "@expo/schema-utils": "^0.1.7", "@expo/spawn-async": "^1.7.2", "@expo/ws-tunnel": "^1.0.1", "@expo/xcpretty": "^4.3.0", "@react-native/dev-middleware": "0.81.5", "@urql/core": "^5.0.6", "@urql/exchange-retry": "^1.3.0", "accepts": "^1.3.8", "arg": "^5.0.2", "better-opn": "~3.0.2", "bplist-creator": "0.1.0", "bplist-parser": "^0.3.1", "chalk": "^4.0.0", "ci-info": "^3.3.0", "compression": "^1.7.4", "connect": "^3.7.0", "debug": "^4.3.4", "env-editor": "^0.4.1", "expo-server": "^1.0.4", "freeport-async": "^2.0.0", "getenv": "^2.0.0", "glob": "^10.4.2", "lan-network": "^0.1.6", "minimatch": "^9.0.0", "node-forge": "^1.3.1", "npm-package-arg": "^11.0.0", "ora": "^3.4.0", "picomatch": "^3.0.1", "pretty-bytes": "^5.6.0", "pretty-format": "^29.7.0", "progress": "^2.0.3", "prompts": "^2.3.2", "qrcode-terminal": "0.11.0", "require-from-string": "^2.0.2", "requireg": "^0.2.2", "resolve": "^1.22.2", "resolve-from": "^5.0.0", "resolve.exports": "^2.0.3", "semver": "^7.6.0", "send": "^0.19.0", "slugify": "^1.3.4", "source-map-support": "~0.5.21", "stacktrace-parser": "^0.1.10", "structured-headers": "^0.4.1", "tar": "^7.4.3", "terminal-link": "^2.1.1", "undici": "^6.18.2", "wrap-ansi": "^7.0.0", "ws": "^8.12.1" }, "peerDependencies": { "expo": "*", "expo-router": "*", "react-native": "*" }, "optionalPeers": ["expo-router", "react-native"], "bin": { "expo-internal": "build/bin/cli" } }, "sha512-hY/OdRaJMs5WsVPuVSZ+RLH3VObJmL/pv5CGCHEZHN2PxZjSZSdctyKV8UcFBXTF0yIKNAJ9XLs1dlNYXHh4Cw=="],
@@ -561,6 +564,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -573,6 +578,10 @@
 
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/prompts": ["@types/prompts@2.4.9", "", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
@@ -580,6 +589,8 @@
     "@types/react": ["@types/react@19.1.17", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -602,6 +613,8 @@
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "all-targets-demo": ["all-targets-demo@workspace:apps/all-targets-demo"],
 
@@ -663,6 +676,8 @@
 
     "badgin": ["badgin@1.2.3", "", {}, "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "bare-rn-share": ["bare-rn-share@workspace:apps/bare-rn-share"],
@@ -709,7 +724,11 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001757", "", {}, "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
@@ -767,6 +786,8 @@
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
@@ -781,9 +802,13 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
@@ -863,17 +888,25 @@
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "extensions-showcase": ["extensions-showcase@workspace:apps/extensions-showcase"],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-xml-parser": ["fast-xml-parser@4.5.3", "", { "dependencies": { "strnum": "^1.1.1" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -916,6 +949,8 @@
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "getenv": ["getenv@1.0.0", "", {}, "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -991,6 +1026,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
@@ -1041,6 +1078,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
@@ -1089,15 +1128,41 @@
 
     "logkitty": ["logkitty@0.7.1", "", { "dependencies": { "ansi-fragments": "^0.2.1", "dayjs": "^1.8.15", "yargs": "^15.1.0" }, "bin": { "logkitty": "bin/logkitty.js" } }, "sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
@@ -1132,6 +1197,62 @@
     "metro-transform-plugins": ["metro-transform-plugins@0.83.2", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-5WlW25WKPkiJk2yA9d8bMuZrgW7vfA4f4MBb9ZeHbTB3eIAoNN8vS8NENgG/X/90vpTB06X66OBvxhT3nHwP6A=="],
 
     "metro-transform-worker": ["metro-transform-worker@0.83.2", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.2", "metro-babel-transformer": "0.83.2", "metro-cache": "0.83.2", "metro-cache-key": "0.83.2", "metro-minify-terser": "0.83.2", "metro-source-map": "0.83.2", "metro-transform-plugins": "0.83.2", "nullthrows": "^1.1.1" } }, "sha512-G5DsIg+cMZ2KNfrdLnWMvtppb3+Rp1GMyj7Bvd9GgYc/8gRmvq1XVEF9XuO87Shhb03kFhGqMTgZerz3hZ1v4Q=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -1233,7 +1354,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
@@ -1294,6 +1415,14 @@
     "regjsgen": ["regjsgen@0.8.0", "", {}, "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q=="],
 
     "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
+
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1421,11 +1550,15 @@
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
@@ -1447,7 +1580,17 @@
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
     "unique-string": ["unique-string@2.0.0", "", { "dependencies": { "crypto-random-string": "^2.0.0" } }, "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -1466,6 +1609,10 @@
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vlq": ["vlq@1.0.1", "", {}, "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="],
 
@@ -1521,6 +1668,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1544,6 +1693,8 @@
     "@expo/cli/@expo/plist": ["@expo/plist@0.4.7", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.2.3", "xmlbuilder": "^15.1.1" } }, "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA=="],
 
     "@expo/cli/getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
+
+    "@expo/cli/picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
 
     "@expo/cli/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -1680,6 +1831,8 @@
     "log-symbols/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "logkitty/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,19 +1,25 @@
 # API Reference
 
+**Source of truth for** the JavaScript/TypeScript runtime API.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+> Widget targets: soft-deprecated — see [widgets.md](./widgets.md). Prefer this API for share/action/clip/messages and shared storage.
+
 ## createTarget
 
 Creates a target instance for communicating with your extension.
 
 ```typescript
-import { createTarget } from 'expo-targets';
+import { createTarget } from "expo-targets";
 
 // For widgets and non-RN extensions
-const widget = createTarget('MyWidget');
+const widget = createTarget("MyWidget");
 
 // For React Native extensions (share, action, clip, messages)
 // Pass the component as second argument - handles AppRegistry automatically
-import ShareExtension from './ShareExtension';
-export const share = createTarget<'share'>('ShareExt', ShareExtension);
+import ShareExtension from "./ShareExtension";
+export const share = createTarget<"share">("ShareExt", ShareExtension);
 ```
 
 **Parameters:**
@@ -31,15 +37,15 @@ The `createTarget` function uses TypeScript overloads to provide the correct ret
 
 ```typescript
 // For messages extensions - returns MessagesExtensionTarget with messaging APIs
-const messages = createTarget<'messages'>('MyMessages');
-messages.sendMessage({ caption: 'Hello!' }); // ✅ Type-safe
+const messages = createTarget<"messages">("MyMessages");
+messages.sendMessage({ caption: "Hello!" }); // ✅ Type-safe
 
 // For share/action/clip extensions - returns ExtensionTarget with close/openHostApp
-const share = createTarget<'share'>('MyShare');
+const share = createTarget<"share">("MyShare");
 share.close(); // ✅ Type-safe
 
 // For widgets and other types - returns NonExtensionTarget
-const widget = createTarget<'widget'>('MyWidget');
+const widget = createTarget<"widget">("MyWidget");
 widget.close(); // ❌ TypeScript error: close doesn't exist
 ```
 
@@ -59,7 +65,7 @@ widget.close(); // ❌ TypeScript error: close doesn't exist
 
 ```typescript
 try {
-  const widget = createTarget('MyWidget');
+  const widget = createTarget("MyWidget");
 } catch (error) {
   // Possible errors:
   // - 'Target "MyWidget" not found. Ensure it's defined in app.json under "extra.targets"'
@@ -84,17 +90,17 @@ All targets (widgets, extensions, etc.) share these core methods:
 
 ```typescript
 // Set a single value
-widget.set('message', 'Hello');
-widget.set('count', 42);
-widget.set('user', { name: 'John', age: 30 });
+widget.set("message", "Hello");
+widget.set("count", 42);
+widget.set("user", { name: "John", age: 30 });
 
 // Get a value (returns undefined if not set)
-const message = widget.get<string>('message');
-const count = widget.get<number>('count');
-const user = widget.get<{ name: string }>('user');
+const message = widget.get<string>("message");
+const count = widget.get<number>("count");
+const user = widget.get<{ name: string }>("user");
 
 // Remove a value
-widget.remove('message');
+widget.remove("message");
 
 // Clear all data for this target
 widget.clear();
@@ -105,7 +111,7 @@ widget.clear();
 ```typescript
 // Set multiple values at once (more efficient than multiple set() calls)
 widget.setData({
-  message: 'Hello',
+  message: "Hello",
   count: 42,
   timestamp: Date.now(),
 });
@@ -129,11 +135,11 @@ widget.refresh();
 
 ```typescript
 // Correct pattern
-widget.setData({ message: 'Updated!' });
+widget.setData({ message: "Updated!" });
 widget.refresh(); // Widget reloads with new data
 
 // Missing refresh - widget won't update immediately
-widget.setData({ message: 'Updated!' });
+widget.setData({ message: "Updated!" });
 // Widget still shows old data until iOS decides to refresh
 ```
 
@@ -142,13 +148,13 @@ widget.setData({ message: 'Updated!' });
 ## Utility Functions
 
 ```typescript
-import { refreshAllTargets, clearSharedData } from 'expo-targets';
+import { refreshAllTargets, clearSharedData } from "expo-targets";
 
 // Refresh all widgets and controls (useful after bulk updates)
 refreshAllTargets();
 
 // Clear all data for a specific App Group
-clearSharedData('group.com.yourapp');
+clearSharedData("group.com.yourapp");
 ```
 
 ---
@@ -158,13 +164,13 @@ clearSharedData('group.com.yourapp');
 For share, action, and clip extensions running React Native:
 
 ```typescript
-import { close, openHostApp, getSharedData } from 'expo-targets';
+import { close, openHostApp, getSharedData } from "expo-targets";
 
 // Get content shared to the extension
 const data = getSharedData();
 
 // Open the main app with a deep link
-openHostApp('/shared-content');
+openHostApp("/shared-content");
 
 // Close the extension and return to the previous app
 close();
@@ -193,16 +199,16 @@ const data = getSharedData();
 const data = getSharedData();
 
 if (data?.url) {
-  console.log('Shared URL:', data.url);
+  console.log("Shared URL:", data.url);
 }
 
 if (data?.images?.length) {
-  console.log('Shared images:', data.images);
+  console.log("Shared images:", data.images);
   // images are file:// paths you can use with Image component
 }
 
 if (data?.text) {
-  console.log('Shared text:', data.text);
+  console.log("Shared text:", data.text);
 }
 ```
 
@@ -212,10 +218,10 @@ Opens your main app with a deep link. **No additional configuration required** �
 
 ```typescript
 // Opens: com.yourcompany.yourapp://shared
-openHostApp('/shared');
+openHostApp("/shared");
 
 // Opens: com.yourcompany.yourapp://item/123
-openHostApp('/item/123');
+openHostApp("/item/123");
 
 // Opens app at root (no path)
 openHostApp();
@@ -287,9 +293,9 @@ interface SharedData {
 For iMessage apps (`type: "messages"`), use the type parameter to get full API access:
 
 ```typescript
-import { createTarget } from 'expo-targets';
+import { createTarget } from "expo-targets";
 
-const messages = createTarget<'messages'>('MyMessagesApp');
+const messages = createTarget<"messages">("MyMessagesApp");
 ```
 
 ### Presentation
@@ -299,8 +305,8 @@ const messages = createTarget<'messages'>('MyMessagesApp');
 const style = messages.getPresentationStyle(); // 'compact' | 'expanded' | null
 
 // Request to expand or collapse the extension
-messages.requestPresentationStyle('expanded');
-messages.requestPresentationStyle('compact'); // Use instead of close()
+messages.requestPresentationStyle("expanded");
+messages.requestPresentationStyle("compact"); // Use instead of close()
 ```
 
 ### Sending Messages
@@ -308,9 +314,9 @@ messages.requestPresentationStyle('compact'); // Use instead of close()
 ```typescript
 // Send a message to the conversation
 messages.sendMessage({
-  caption: 'Check this out!',
-  subcaption: 'Sent from MyApp',
-  imageUrl: 'https://example.com/image.png',
+  caption: "Check this out!",
+  subcaption: "Sent from MyApp",
+  imageUrl: "https://example.com/image.png",
 });
 
 // Interactive messages with session tracking
@@ -318,10 +324,10 @@ const sessionId = messages.createSession();
 if (sessionId) {
   messages.sendUpdate(
     {
-      caption: 'Game Score: 10-5',
-      subcaption: 'Tap to play',
+      caption: "Game Score: 10-5",
+      subcaption: "Tap to play",
     },
-    sessionId
+    sessionId,
   );
 }
 ```
@@ -342,10 +348,10 @@ const info = messages.getConversationInfo();
 ```typescript
 // Listen for presentation style changes
 const subscription = messages.addEventListener(
-  'onPresentationStyleChange',
+  "onPresentationStyleChange",
   (style) => {
-    console.log('Style changed to:', style); // 'compact' | 'expanded'
-  }
+    console.log("Style changed to:", style); // 'compact' | 'expanded'
+  },
 );
 
 // Later: cleanup
@@ -367,15 +373,15 @@ interface MessagesExtensionTarget {
   getSharedData(): SharedData | null;
 
   // Messages-specific
-  getPresentationStyle(): 'compact' | 'expanded' | null;
-  requestPresentationStyle(style: 'compact' | 'expanded'): void;
+  getPresentationStyle(): "compact" | "expanded" | null;
+  requestPresentationStyle(style: "compact" | "expanded"): void;
   sendMessage(layout: MessageLayout): void;
   sendUpdate(layout: MessageLayout, sessionId: string): void;
   createSession(): string | null;
   getConversationInfo(): ConversationInfo | null;
   addEventListener(
-    eventName: 'onPresentationStyleChange',
-    listener: (style: 'compact' | 'expanded') => void
+    eventName: "onPresentationStyleChange",
+    listener: (style: "compact" | "expanded") => void,
   ): { remove: () => void };
 }
 
@@ -399,25 +405,25 @@ interface ConversationInfo {
 Low-level storage access for advanced use cases:
 
 ```typescript
-import { AppGroupStorage } from 'expo-targets';
+import { AppGroupStorage } from "expo-targets";
 
-const storage = new AppGroupStorage('group.com.yourapp');
+const storage = new AppGroupStorage("group.com.yourapp");
 
 // Individual key operations
-storage.set('key', 'value');
-storage.get<string>('key');
-storage.remove('key');
+storage.set("key", "value");
+storage.get<string>("key");
+storage.remove("key");
 storage.clear();
 
 // Batch operations
-storage.setData({ key1: 'value1', key2: 'value2' });
+storage.setData({ key1: "value1", key2: "value2" });
 storage.getData<{ key1: string; key2: string }>();
 
 // List all keys
 const keys = storage.getKeys();
 
 // Trigger refresh for a specific widget
-storage.refresh('WidgetName');
+storage.refresh("WidgetName");
 ```
 
 **When to use AppGroupStorage directly:**
@@ -529,7 +535,7 @@ import type {
   PresentationStyle,
   MessageLayout,
   ConversationInfo,
-} from 'expo-targets';
+} from "expo-targets";
 ```
 
 ### ExtensionType
@@ -538,29 +544,29 @@ All supported extension types:
 
 ```typescript
 type ExtensionType =
-  | 'widget'
-  | 'clip'
-  | 'stickers'
-  | 'messages'
-  | 'share'
-  | 'action'
-  | 'wallet'
-  | 'wallet-ui'
-  | 'safari'
-  | 'notification-content'
-  | 'notification-service'
-  | 'intent'
-  | 'intent-ui'
-  | 'app-intent'
-  | 'spotlight'
-  | 'bg-download'
-  | 'quicklook-thumbnail'
-  | 'location-push'
-  | 'credentials-provider'
-  | 'account-auth'
-  | 'device-activity-monitor'
-  | 'matter'
-  | 'watch';
+  | "widget"
+  | "clip"
+  | "stickers"
+  | "messages"
+  | "share"
+  | "action"
+  | "wallet"
+  | "wallet-ui"
+  | "safari"
+  | "notification-content"
+  | "notification-service"
+  | "intent"
+  | "intent-ui"
+  | "app-intent"
+  | "spotlight"
+  | "bg-download"
+  | "quicklook-thumbnail"
+  | "location-push"
+  | "credentials-provider"
+  | "account-auth"
+  | "device-activity-monitor"
+  | "matter"
+  | "watch";
 ```
 
 ### Target Types

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,11 @@
 # Configuration Reference
 
+**Source of truth for** `expo-target.config` options and extension types.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+> **Config-only freeze:** do not add new config-only extension types. See [deprecations.md](./deprecations.md). For widgets policy see [widgets.md](./widgets.md).
+
 Every target is configured with an `expo-target.config.json` file in its directory.
 
 ## Basic Structure
@@ -430,10 +436,10 @@ npx expo run:android
 ### 4. Update from React Native
 
 ```typescript
-import { createTarget } from 'expo-targets';
+import { createTarget } from "expo-targets";
 
-const widget = createTarget('MyWidget');
-widget.setData({ message: 'Hello from React Native!' });
+const widget = createTarget("MyWidget");
+widget.setData({ message: "Hello from React Native!" });
 widget.refresh();
 ```
 
@@ -845,7 +851,7 @@ Use `.js` or `.ts` for dynamic configs that need to access your Expo app configu
 
 ```typescript
 // expo-target.config.ts
-import type { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from "expo/config";
 
 /**
  * Dynamic config function receives the resolved Expo app config.
@@ -853,14 +859,14 @@ import type { ExpoConfig } from 'expo/config';
  */
 export default function (config: ExpoConfig) {
   return {
-    type: 'widget',
-    name: 'MyWidget',
-    platforms: ['ios'],
+    type: "widget",
+    name: "MyWidget",
+    platforms: ["ios"],
     // Derive App Group from bundle identifier
-    appGroup: `group.${config.ios?.bundleIdentifier || 'com.example.app'}`,
+    appGroup: `group.${config.ios?.bundleIdentifier || "com.example.app"}`,
     ios: {
       // Inherit deployment target from main app
-      deploymentTarget: config.ios?.deploymentTarget || '14.0',
+      deploymentTarget: config.ios?.deploymentTarget || "14.0",
     },
   };
 }
@@ -912,7 +918,7 @@ export default function (config: ExpoConfig) {
 
 **Legend:** ✅ Production ready · 📋 Config-only (bring your own Swift/Kotlin) · 🔜 Planned · — Not applicable
 
-> **Combined targets:** For `wallet` and `intent` types, you can use the `ios.wallet.ui` or `ios.intents.ui` config options to generate both the main extension and its UI companion from a single config file. The CLI generates combined wallet extensions by default. See [Wallet Extension](#wallet-extension) and [Intent Extension](#example-intent-extension-sirishortcuts--legacy) sections for details.
+> **Combined targets:** For `wallet` and `intent` types, you can use the `ios.wallet.ui` or `ios.intents.ui` config options to generate both the main extension and its UI companion from a single config file. The CLI generates combined wallet extensions by default. See [Wallet Extension](#wallet-extension) and [Intent UI Extension](#intent-ui-extension) sections for details.
 
 ### iOS Limitations
 
@@ -996,12 +1002,12 @@ That's it! The Swift handler, popup.html, manifest.json, and other resources are
 **Entry file (`src/SafariExtension.tsx`):**
 
 ```tsx
-import { createTarget, useBrowserTab, useBrowserStorage } from 'expo-targets';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { createTarget, useBrowserTab, useBrowserStorage } from "expo-targets";
+import { View, Text, Button, StyleSheet } from "react-native";
 
 function SafariPopup({ target }) {
   const tab = useBrowserTab();
-  const [count, setCount] = useBrowserStorage('clickCount', 0);
+  const [count, setCount] = useBrowserStorage("clickCount", 0);
 
   return (
     <View style={styles.container}>
@@ -1015,11 +1021,11 @@ function SafariPopup({ target }) {
 
 const styles = StyleSheet.create({
   container: { padding: 16, minWidth: 300 },
-  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
-  url: { fontSize: 12, color: '#666', marginBottom: 12 },
+  title: { fontSize: 18, fontWeight: "bold", marginBottom: 8 },
+  url: { fontSize: 12, color: "#666", marginBottom: 12 },
 });
 
-export default createTarget('MySafariExt', SafariPopup);
+export default createTarget("MySafariExt", SafariPopup);
 ```
 
 **Available Safari hooks:**
@@ -1035,7 +1041,7 @@ import {
   openTab, // Open new tab
   closePopup, // Close extension popup
   copyToClipboard, // Copy text
-} from 'expo-targets';
+} from "expo-targets";
 ```
 
 **Building the bundle:**

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,32 @@
+# Deprecations and roadmap policy
+
+**Source of truth for** deprecation policy and negative-space roadmap constraints.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+## Widget soft-deprecate
+
+| Stage                    | Behavior                                                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Minors (now)**         | Docs handoff to [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/); CLI + `createTarget` warn when `type === 'widget'`; native widgets keep working |
+| **Future major**         | Widget API / scaffolding may be removed                                                                                                                               |
+| **Expo Android widgets** | When Expo covers Android widgets, this library may drop the widget surface entirely                                                                                   |
+
+iOS widget investment: **shared spine only**. Android widgets: **bridge-grade** until the Expo exit ramp above.
+
+## Config-only types freeze
+
+Do **not** add new config-only extension types (stubs that only generate Xcode targets). Polish production-ready types instead: share, action, clip, messages, stickers, wallet, and the existing config-only set.
+
+## Dual widget engines
+
+Building coexistence where **both** `expo-widgets` and expo-targets generate WidgetKit widgets in one app is **parked**. Reopen only after a **demand bar**: multiple real projects blocked on split ownership. Default: do not schedule.
+
+## Live Activities
+
+Out of scope. Use `expo-widgets`.
+
+## Related
+
+- [widgets.md](./widgets.md) — handoff and coexistence
+- [AGENTS.md](../AGENTS.md) — agent posture summary

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,12 @@
 # Getting Started
 
-Build your first iOS widget in 5 minutes.
+**Source of truth for** first-run setup (React Native share extension).
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+Build a React Native **share extension** with expo-targets.
+
+> **Looking for widgets?** Prefer official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) for React/iOS widgets. Native widgets in this library are soft-deprecated — see [widgets.md](./widgets.md).
 
 ## Prerequisites
 
@@ -45,17 +51,15 @@ Add the plugin and App Groups to your `app.json`:
 }
 ```
 
-> **⚠️ App Groups are Critical**
+> **App Groups are Critical**
 >
-> App Groups enable data sharing between your app and widgets. If the IDs don't match exactly, **data sharing fails silently** — your widget will show default values instead of app data.
+> App Groups enable data sharing between your app and extensions. IDs must match exactly or sharing fails.
 >
-> - The ID must start with `group.`
-> - Convention: use `group.{your.bundle.identifier}` (e.g., `group.com.yourcompany.myapp`)
-> - **Must match exactly** in: `app.json`, target config, and Swift code
+> - Must start with `group.`
+> - Convention: `group.{your.bundle.identifier}`
+> - Must match in `app.json`, target config, and native code
 
-## Step 3: Create a Widget
-
-Run the CLI:
+## Step 3: Create a Share Extension
 
 ```bash
 npx create-expo-target
@@ -63,379 +67,129 @@ npx create-expo-target
 
 Choose:
 
-- **Type:** Widget
-- **Name:** hello-widget
+- **Type:** Share Extension
+- **Name:** my-share
+- **Use React Native:** Yes
 
 This creates:
 
 ```
-targets/hello-widget/
-├── expo-target.config.json   # Configuration
-├── index.ts                  # Pre-configured target instance
-└── ios/
-    └── Widget.swift          # SwiftUI code
+targets/my-share/
+├── expo-target.config.json
+├── index.tsx                 # createTarget + component registration
+└── …                         # Native host generated at prebuild
 ```
 
-### Generated Files Explained
-
-**`expo-target.config.json`** — Tells expo-targets how to build this extension:
+Example config:
 
 ```json
 {
-  "type": "widget",
-  "name": "HelloWidget",
-  "displayName": "Hello Widget",
+  "type": "share",
+  "name": "MyShare",
+  "displayName": "My Share",
   "platforms": ["ios"],
-  "appGroup": "group.com.yourcompany.yourapp",
+  "appGroup": "group.com.yourcompany.myapp",
+  "entry": "./targets/my-share/index.tsx",
+  "excludedPackages": ["expo-updates", "expo-dev-client"],
   "ios": {
     "deploymentTarget": "14.0"
   }
 }
 ```
 
-**`index.ts`** — Pre-configured target instance you can import directly:
-
-```typescript
-import { createTarget } from 'expo-targets';
-
-export const helloWidget = createTarget('HelloWidget');
-```
-
-**`ios/Widget.swift`** — The complete SwiftUI widget (see [full code below](#complete-widget-swift-code)).
-
-### ⚠️ After Running create-expo-target
-
-The CLI generates placeholder App Group IDs. **You must update them to match your `app.json`:**
-
-1. Open `targets/hello-widget/expo-target.config.json`
-2. Change `"appGroup": "group.com.yourcompany.yourapp"` to match your `app.json`
-3. Open `targets/hello-widget/ios/Widget.swift`
-4. Find `let appGroup = "YOUR_APP_GROUP_HERE"` and update it
+Update the placeholder `appGroup` to match your `app.json`.
 
 ### Naming Conventions
 
-All these names must match exactly (except the folder name, which is just organizational):
+| Location            | Format     | Example                        | Notes                     |
+| ------------------- | ---------- | ------------------------------ | ------------------------- |
+| Target folder       | kebab-case | `targets/my-share/`            | Organizational            |
+| Config `name` field | PascalCase | `"name": "MyShare"`            | Canonical identifier      |
+| `createTarget()`    | Same name  | `createTarget('MyShare', …)`   | Must match config exactly |
+| `entry`             | Path       | `./targets/my-share/index.tsx` | Relative to project root  |
 
-| Location            | Format              | Example                            | Notes                                 |
-| ------------------- | ------------------- | ---------------------------------- | ------------------------------------- |
-| Target folder       | kebab-case          | `targets/hello-widget/`            | Just for organization                 |
-| Config `name` field | PascalCase          | `"name": "HelloWidget"`            | **The canonical identifier**          |
-| Swift `kind`        | Same as config name | `let kind: String = "HelloWidget"` | Must match config `name` exactly      |
-| JavaScript usage    | Same as config name | `createTarget('HelloWidget')`      | Must match config `name` exactly      |
-| `index.ts` export   | camelCase           | `export const helloWidget = ...`   | Just for convenience, can be anything |
+## Step 4: Configure Metro
 
-**Critical:** The config `name` field, Swift `kind`, and `createTarget()` argument must all match exactly. If they don't, data sharing will fail silently.
+```js
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTargetsMetro } = require("expo-targets/metro");
 
-> **Note:** For React Native extensions (share, action, clip, messages), pass your component as the second argument to `createTarget()`. See [React Native Extensions](./react-native-extensions.md#naming-conventions) for details.
+module.exports = withTargetsMetro(getDefaultConfig(__dirname));
+```
 
-## Step 4: Build & Run
+`withTargetsMetro` maps each target `entry` so the extension host can load the right bundle. Details: [React Native Extensions](./react-native-extensions.md).
 
-> **What does `prebuild` do?**
->
-> `npx expo prebuild` generates the native `ios/` and `android/` folders from your Expo config. Run this whenever you:
->
-> - Add or modify targets
-> - Change `app.json` configuration
-> - Update target configuration files
-
-> **Note:** This requires `npx expo run:ios` (development builds). Does not work with Expo Go.
+## Step 5: Build & Run
 
 ```bash
 npx expo prebuild
 npx expo run:ios
 ```
 
-## Step 5: Add the Widget to Home Screen
+Share a URL or text from Safari (or another app) into your extension to try it.
 
-1. Long press on the home screen
-2. Tap the **+** button
-3. Search for your app name
-4. Select a widget size and tap **Add Widget**
-
-🎉 **Your widget is now on the home screen!**
-
----
-
-## Update Your Widget from React Native
-
-Open `App.tsx` and add:
+## Step 6: Extension APIs
 
 ```typescript
-import React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { getSharedData, openHostApp, close } from "expo-targets";
 
-// Option A: Import the generated target instance (recommended)
-import { helloWidget } from './targets/hello-widget';
-
-// Option B: Create your own instance
-// import { createTarget } from 'expo-targets';
-// const helloWidget = createTarget('HelloWidget');
-
-function App() {
-  const updateWidget = () => {
-    helloWidget.setData({
-      message: 'Hello from React Native!',
-    });
-    helloWidget.refresh();
-  };
-
-  return (
-    <View style={styles.container}>
-      <Button title="Update Widget" onPress={updateWidget} />
-    </View>
-  );
+const data = getSharedData();
+if (data?.url) {
+  openHostApp(`/inbox?url=${encodeURIComponent(data.url)}`);
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 20 },
-});
-
-export default App;
+close();
 ```
 
-Tap the button, and your widget updates instantly.
-
-> **Which import style should I use?**
->
-> - **Import from `./targets/hello-widget`** — Recommended. The generated `index.ts` is pre-configured with the correct name and can include typed helpers.
-> - **Create with `createTarget()`** — Use when you need the target instance outside the targets folder, or want more control.
->
-> Both approaches work identically — they create the same underlying target instance.
-
----
-
-## Complete Widget Swift Code
-
-Here's the full `Widget.swift` generated by `create-expo-target`. This is a complete, working SwiftUI widget:
-
-```swift
-import WidgetKit
-import SwiftUI
-
-// Data structure for timeline entries
-struct SimpleEntry: TimelineEntry {
-    let date: Date
-    let message: String
-}
-
-// Provides timeline data to the widget
-struct Provider: TimelineProvider {
-    // ⚠️ IMPORTANT: This must match your app.json App Group ID exactly
-    let appGroup = "group.com.yourcompany.myapp"
-
-    // Placeholder shown while widget loads
-    func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), message: "Loading...")
-    }
-
-    // Snapshot for widget gallery preview
-    func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let entry = SimpleEntry(date: Date(), message: loadMessage())
-        completion(entry)
-    }
-
-    // Provides timeline of entries for the widget
-    func getTimeline(in context: Context, completion: @escaping (Timeline<SimpleEntry>) -> ()) {
-        let entry = SimpleEntry(date: Date(), message: loadMessage())
-        // Refresh every 15 minutes (iOS may adjust this)
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
-        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
-        completion(timeline)
-    }
-
-    // Load data from shared App Group storage
-    private func loadMessage() -> String {
-        let defaults = UserDefaults(suiteName: appGroup)
-        return defaults?.string(forKey: "message") ?? "No message yet"
-    }
-}
-
-// The widget's SwiftUI view
-struct WidgetView: View {
-    var entry: Provider.Entry
-
-    var body: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "star.fill")
-                .font(.system(size: 24))
-                .foregroundColor(.blue)
-
-            Text(entry.message)
-                .font(.body)
-                .multilineTextAlignment(.center)
-        }
-        .padding()
-    }
-}
-
-// Widget configuration
-@main
-struct HelloWidget: Widget {
-    // ⚠️ IMPORTANT: This must match the "name" field in expo-target.config.json
-    let kind: String = "HelloWidget"
-
-    var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
-            WidgetView(entry: entry)
-        }
-        .configurationDisplayName("Hello Widget")
-        .description("A simple message widget")
-        .supportedFamilies([.systemSmall, .systemMedium])
-    }
-}
-```
-
-### Customizing Your Widget
-
-**Change the appearance:**
-
-- Edit the `WidgetView` struct to modify layout, colors, and fonts
-- Use SwiftUI views like `Text`, `Image`, `VStack`, `HStack`, `ZStack`
-- Reference colors defined in your config: `Color("AccentColor")`
-
-**Change supported sizes:**
-
-- Modify `.supportedFamilies([...])` to include `.systemSmall`, `.systemMedium`, `.systemLarge`
-
-**Read different data:**
-
-- Add more keys in `loadMessage()` using `defaults?.string(forKey: "yourKey")`
-- For complex data, use `defaults?.data(forKey: "key")` and decode JSON
-
-**Add more data fields:**
-
-- Add properties to `SimpleEntry`
-- Load them in `Provider`
-- Display them in `WidgetView`
+Full contract: [React Native Extensions → Runtime contract](./react-native-extensions.md#runtime-contract).
 
 ---
 
 ## Troubleshooting
 
-### Widget doesn't appear in picker?
+### Extension does not appear in the share sheet
 
-**Error:** Widget not showing when you tap + on home screen
+1. Run `npx expo prebuild` again
+2. Confirm the target exists in the Xcode project
+3. Clean build folder (⇧⌘K) and reinstall the app
 
-**Solutions:**
+### `Target 'X' not found`
 
-1. Run `npx expo prebuild` (regenerates native projects)
-2. Check Xcode that the target exists: Open `.xcworkspace` → Project Navigator should show your widget target
-3. Clean build folder: **Product → Clean Build Folder** (⇧⌘K)
-4. Delete the app from simulator and rebuild
+Ensure `createTarget('X')` matches the config `name` field exactly (case-sensitive).
 
-### Widget shows "No message yet" after calling setData?
+### Bundle / Metro errors for the extension entry
 
-**Error:** Data isn't reaching the widget
+Ensure `metro.config.js` wraps with `withTargetsMetro` and `entry` points at a real file relative to the project root.
 
-**Checklist — App Group IDs must match exactly in all three places:**
+### App Group / data issues
 
-```
-app.json:                    "group.com.yourcompany.myapp"
-expo-target.config.json:     "group.com.yourcompany.myapp"
-Widget.swift (appGroup):     "group.com.yourcompany.myapp"
-```
-
-Also verify:
-
-- You're calling `widget.refresh()` after `setData()`
-- Test on a physical device (simulators cache aggressively)
-- The `kind` in Swift matches the `name` in config
-
-### Build errors?
-
-**Error:** `No such module 'WidgetKit'`
-
-**Solution:** Your deployment target may be too low. Widgets require iOS 14+:
-
-```json
-{
-  "ios": {
-    "deploymentTarget": "14.0"
-  }
-}
-```
-
-**Error:** `Multiple commands produce...` or signing errors
-
-**Solution:**
-
-1. Delete `ios/` folder completely
-2. Re-run `npx expo prebuild`
-3. If still failing, open Xcode and check **Signing & Capabilities** for each target
-
-### Common Error Messages
-
-| Error                                           | Cause                | Fix                                              |
-| ----------------------------------------------- | -------------------- | ------------------------------------------------ |
-| `Target 'X' not found`                          | Target name mismatch | Ensure `createTarget('X')` matches config `name` |
-| `UserDefaults suiteName is nil`                 | Invalid App Group ID | Check App Group starts with `group.`             |
-| `Widget extension has conflicting provisioning` | Signing mismatch     | Re-run prebuild or check Xcode signing settings  |
+Match App Group IDs in `app.json`, `expo-target.config.json`, and any native suite name.
 
 ---
 
 ## Next Steps
 
-- **[Configuration Reference](./configuration.md)** — All configuration options
-- **[API Reference](./api.md)** — Complete JavaScript/TypeScript API
-- **[React Native Extensions](./react-native-extensions.md)** — Build share/action extensions with React Native
-- **[Examples](../apps/)** — Working example apps for every extension type
-
-### Try Other Extension Types
-
-```bash
-npx create-expo-target
-```
-
-**Production-ready types:**
-
-- **Widget** — Home screen widgets
-- **App Clip** — Lightweight app experiences
-- **Share Extension** — Accept shared content from other apps
-- **iMessage Stickers** — Custom sticker packs
-- **Action Extension** — Process content in place
-- **Wallet Extension** — Payment pass provisioning to Apple Wallet
-
-**Config-only types** (bring your own Swift):
-
-- **Intent Extension** — Siri voice commands and Shortcuts (legacy INIntent)
-- **App Intent Extension** — Modern Siri/Shortcuts integration (iOS 16+)
-
-See [Configuration Reference](./configuration.md) for detailed setup of each type.
-
----
+- **[React Native Extensions](./react-native-extensions.md)** — Runtime contract, Metro, messages
+- **[Configuration](./configuration.md)** — All options and extension types
+- **[API Reference](./api.md)** — JavaScript/TypeScript API
+- **[Widgets handoff](./widgets.md)** — When to use `expo-widgets`
+- **[Examples](../apps/)** — Working apps (start with `extensions-showcase`)
 
 ## Workflows: Managed vs Bare
 
 ### Expo Managed (Recommended)
 
-Your `ios/` folder is generated by Expo and not committed to git.
-
 ```bash
-npx expo prebuild   # Generates ios/ folder
-npx expo run:ios    # Builds and runs
+npx expo prebuild
+npx expo run:ios
 ```
-
-**Use this if:**
-
-- Starting a new project
-- Your `ios/` folder is in `.gitignore`
-- You run `expo prebuild` regularly
-- You don't have custom native code modifications
 
 ### Bare React Native
 
-Your `ios/` folder is committed to git and you maintain it manually.
-
 ```bash
-npx expo-targets sync       # Adds targets to existing ios/
+npx expo-targets sync
 cd ios && pod install
-npx react-native run-ios    # Or: npx expo run:ios
+npx react-native run-ios
 ```
 
-**Use this if:**
-
-- You have an existing React Native project
-- Your `ios/` folder has custom native modifications
-- You can't use `expo prebuild` (it would overwrite your changes)
-
-> **Tip:** See [bare-rn-widgets](../apps/bare-rn-widgets/) and [bare-rn-share](../apps/bare-rn-share/) for complete examples.
+> See [bare-rn-share](../apps/bare-rn-share/) for a complete bare example.

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -1,17 +1,60 @@
 # React Native in Extensions
 
+**Source of truth for** React Native extensions (runtime contract, Metro, type support).
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
 Build share extensions, action extensions, App Clips, and iMessage apps using React Native instead of native Swift/Kotlin.
+
+> **Status:** Backbone v1 covers the cross-type [runtime contract](#runtime-contract) and hardened `withTargetsMetro` packaging. Prefer these patterns; type-specific polish continues on top.
 
 ## Supported Types
 
-| Type       | React Native Support | Notes                    |
-| ---------- | -------------------- | ------------------------ |
-| `share`    | ✅ Full support      | Custom UI for sharing    |
-| `action`   | ✅ Full support      | Process content in place |
-| `clip`     | ✅ Full support      | Lightweight app preview  |
-| `messages` | ✅ Full support      | iMessage app with RN UI  |
-| `widget`   | ❌ SwiftUI only      | iOS uses WidgetKit       |
-| `stickers` | ❌ Native only       | Static image assets      |
+| Type       | React Native Support | Notes                                |
+| ---------- | -------------------- | ------------------------------------ |
+| `share`    | ✅ Full support      | Custom UI for sharing                |
+| `action`   | ✅ Full support      | Process content in place             |
+| `clip`     | ✅ Full support      | Lightweight app preview              |
+| `messages` | ✅ Full support      | iMessage app with RN UI              |
+| `widget`   | ❌ SwiftUI only      | Soft-deprecated; prefer expo-widgets |
+| `stickers` | ❌ Native only       | Static image assets                  |
+
+---
+
+## Runtime contract
+
+Stable across **share**, **action**, **clip**, and **messages** (messages adds APIs on top).
+
+### Bootstrap
+
+1. Declare `entry` in `expo-target.config` (path relative to project root).
+2. Wrap Metro with `withTargetsMetro` so the extension host can resolve that entry.
+3. Call `createTarget(name, Component)` in the entry file. The `name` must match config `name` exactly; this registers the component with `AppRegistry`.
+4. Rebuild native (`prebuild` / `sync`) so the extension target embeds expo-targets and loads the RN host.
+
+### Lifecycle (share / action / clip)
+
+| API                  | Role                                   |
+| -------------------- | -------------------------------------- |
+| `getSharedData()`    | Read content passed into the extension |
+| `openHostApp(path?)` | Open the containing app                |
+| `close()`            | Dismiss the extension UI               |
+
+These require the **ExpoTargetsExtension** native module inside the extension process. Calling them from the main app or without a native build throws an actionable error.
+
+### Failure modes
+
+| Symptom                               | Likely cause                                                                            |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `Target "X" not found`                | Config `name` / `createTarget` mismatch, or targets not in `extra.targets` / Info.plist |
+| `App Group not configured`            | Missing `appGroup` on the target                                                        |
+| `requires an "entry" field`           | Passed a Component without `entry` in config                                            |
+| `ExpoTargetsExtension is unavailable` | Not running in the extension, or native module not linked — re-prebuild                 |
+| Metro cannot resolve entry            | Missing `withTargetsMetro`, or `entry` path wrong                                       |
+
+### Messages
+
+Same bootstrap + packaging. Additive APIs: `sendMessage`, `sendUpdate`, `requestPresentationStyle`, conversation helpers — see [API](./api.md).
 
 ---
 
@@ -46,11 +89,11 @@ Key fields:
 
 ```typescript
 // targets/share-ext/index.tsx
-import { createTarget } from 'expo-targets';
-import ShareExtension from './src/ShareExtension';
+import { createTarget } from "expo-targets";
+import ShareExtension from "./src/ShareExtension";
 
 // Pass the component as the second argument - handles registration automatically
-export const shareTarget = createTarget<'share'>('ShareExt', ShareExtension);
+export const shareTarget = createTarget<"share">("ShareExt", ShareExtension);
 ```
 
 The second parameter to `createTarget` automatically calls `AppRegistry.registerComponent()` for you. The name must match the `name` field in your config exactly.
@@ -110,8 +153,8 @@ const styles = StyleSheet.create({
 
 ```javascript
 // metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
-const { withTargetsMetro } = require('expo-targets/metro');
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTargetsMetro } = require("expo-targets/metro");
 
 module.exports = withTargetsMetro(getDefaultConfig(__dirname));
 ```
@@ -119,8 +162,9 @@ module.exports = withTargetsMetro(getDefaultConfig(__dirname));
 The Metro wrapper:
 
 - Discovers targets with an `entry` field in their config
-- Creates separate bundles for each extension
-- Excludes packages listed in `excludedPackages`
+- Validates that each `entry` file exists (warns otherwise)
+- Maps Metro `bundleRoot` (entry path without extension) to the absolute entry file — this must match the native host `jsBundleURL(forBundleRoot:)`
+- Chains any existing `resolveRequest` so other Metro plugins keep working
 
 > **Note:** Pure Swift/SwiftUI extensions (like widgets) do NOT need Metro configuration.
 
@@ -170,7 +214,7 @@ import {
   close, // Close the extension
   openHostApp, // Open main app with deep link
   createTarget, // Access shared storage
-} from 'expo-targets';
+} from "expo-targets";
 ```
 
 ### getSharedData()
@@ -194,9 +238,9 @@ const data = getSharedData();
 Save data in the extension for your main app to read later:
 
 ```typescript
-import { createTarget, close } from 'expo-targets';
+import { createTarget, close } from "expo-targets";
 
-const shareTarget = createTarget('ShareExt');
+const shareTarget = createTarget("ShareExt");
 
 function handleSave() {
   const data = getSharedData();
@@ -216,11 +260,11 @@ Your main app can read this data:
 
 ```typescript
 // In your main app
-import { createTarget } from 'expo-targets';
+import { createTarget } from "expo-targets";
 
-const shareTarget = createTarget('ShareExt');
+const shareTarget = createTarget("ShareExt");
 const data = shareTarget.getData();
-console.log('Last shared:', data?.lastShared);
+console.log("Last shared:", data?.lastShared);
 ```
 
 ### Opening the Main App
@@ -228,11 +272,11 @@ console.log('Last shared:', data?.lastShared);
 Use `openHostApp()` to open your main app with a deep link:
 
 ```typescript
-import { openHostApp } from 'expo-targets';
+import { openHostApp } from "expo-targets";
 
 function handleOpenInApp() {
   // Opens: com.yourcompany.yourapp://shared/123
-  openHostApp('/shared/123');
+  openHostApp("/shared/123");
   // Extension closes automatically after opening host app
 }
 ```
@@ -243,12 +287,12 @@ In your main app, handle the deep link:
 
 ```typescript
 // App.tsx
-import { Linking } from 'react-native';
-import { useEffect } from 'react';
+import { Linking } from "react-native";
+import { useEffect } from "react";
 
 useEffect(() => {
   const handleUrl = ({ url }: { url: string }) => {
-    const path = url.split('://')[1]; // "shared/123"
+    const path = url.split("://")[1]; // "shared/123"
     // Navigate based on path
   };
 
@@ -256,7 +300,7 @@ useEffect(() => {
   Linking.getInitialURL().then((url) => url && handleUrl({ url }));
 
   // Handle warm start
-  const sub = Linking.addEventListener('url', handleUrl);
+  const sub = Linking.addEventListener("url", handleUrl);
   return () => sub.remove();
 }, []);
 ```
@@ -436,13 +480,13 @@ iMessage apps let users interact with your app directly in Messages.
 
 ```typescript
 // targets/my-messages/index.tsx
-import { createTarget } from 'expo-targets';
-import MessagesApp from './MessagesApp';
+import { createTarget } from "expo-targets";
+import MessagesApp from "./MessagesApp";
 
 // Pass component as second argument - name must match config exactly
-export const messagesTarget = createTarget<'messages'>(
-  'MyMessages',
-  MessagesApp
+export const messagesTarget = createTarget<"messages">(
+  "MyMessages",
+  MessagesApp,
 );
 ```
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,0 +1,38 @@
+# Widgets and expo-widgets
+
+**Source of truth for** widgets handoff and coexistence with official Expo widgets.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+## Strong handoff (React / iOS)
+
+For **new iOS home-screen widgets** and **Live Activities** built in React / Expo UI, use official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) (Expo SDK 56+).
+
+Live Activities are **out of scope** for expo-targets — use `expo-widgets`.
+
+## Native iOS widgets in this library
+
+Native SwiftUI / WidgetKit widgets via `type: "widget"` still work and remain in the API, but are **soft-deprecated** as the lead product story:
+
+- Prefer `expo-widgets` for React-first iOS widgets.
+- Investment here is **shared-spine only** (App Groups, config plugin, storage) — not a competing React-widget DX.
+- Deprecation warnings appear in minors when scaffolding or constructing widget targets; removal is reserved for a future major (or when Expo covers Android widgets). See [deprecations.md](./deprecations.md).
+
+## Android widgets
+
+Android home-screen widgets (Glance / RemoteViews) are **bridge-grade**: supported and intentional while Expo’s widgets stack is iOS-only. When Expo ships Android widgets, this surface may be dropped.
+
+## Coexistence with `expo-widgets`
+
+**Split ownership (supported):** use `expo-widgets` for iOS widgets / Live Activities, and expo-targets for share, action, clip, messages, stickers, wallet, and other non-widget targets in the same app.
+
+**Dual widget engines (unsupported for now):** do not configure both packages to generate WidgetKit widget targets in one app. Revisit only if real projects are blocked on split ownership (demand bar).
+
+## Scaffolding
+
+```bash
+npx create-expo-target
+# Widget is demoted in the menu; confirm after the expo-widgets handoff prompt
+```
+
+For React Native extensions (the recommended lead path), see [getting-started.md](./getting-started.md) and [react-native-extensions.md](./react-native-extensions.md).

--- a/package.json
+++ b/package.json
@@ -17,11 +17,17 @@
     "test": "bun install --frozen-lockfile --cwd tests/e2e && bun test --cwd tests/e2e",
     "test:prebuild": "bun test --cwd tests/e2e prebuild",
     "test:runtime": "bun test --cwd tests/e2e runtime",
+    "validate:changed": "skeleton validate changed",
+    "validate:ci": "skeleton validate changed --base origin/main",
+    "audit:docs": "skeleton audit docs",
+    "audit:skills": "skeleton audit skills",
+    "audit:self": "skeleton audit self",
     "android": "expo run:android",
     "ios": "expo run:ios"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
+    "@csark0812/skeleton": "^1.5.5",
     "typescript": "~5.3.3"
   },
   "version": "0.2.7",

--- a/packages/create-expo-target/src/index.ts
+++ b/packages/create-expo-target/src/index.ts
@@ -1,54 +1,72 @@
 #!/usr/bin/env node
-import path from 'node:path';
-import process from 'node:process';
-import fs from 'fs-extra';
-import prompts from 'prompts';
+import path from "node:path";
+import process from "node:process";
+import fs from "fs-extra";
+import prompts from "prompts";
+
+const WIDGET_HANDOFF = `
+For new React/iOS widgets and Live Activities, prefer official expo-widgets (Expo SDK 56+):
+https://docs.expo.dev/versions/latest/sdk/widgets/
+
+Native WidgetKit scaffolds from this CLI are soft-deprecated. Details:
+https://github.com/csark0812/expo-targets/blob/main/docs/widgets.md
+`.trim();
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: pre-existing complexity; tracked for refactor
 async function main() {
   const response = await prompts([
     {
-      type: 'select',
-      name: 'type',
-      message: 'What type of target?',
+      type: "select",
+      name: "type",
+      message: "What type of target?",
       choices: [
-        { title: 'Widget', value: 'widget' },
-        { title: 'App Clip', value: 'clip' },
-        { title: 'iMessage Stickers', value: 'imessage' },
-        { title: 'Messages App', value: 'messages' },
-        { title: 'Share Extension', value: 'share' },
-        { title: 'Action Extension', value: 'action' },
-        { title: 'Siri Intent', value: 'intent' },
-        { title: 'Wallet Extension', value: 'wallet' },
+        { title: "Share Extension", value: "share" },
+        { title: "Action Extension", value: "action" },
+        { title: "App Clip", value: "clip" },
+        { title: "Messages App", value: "messages" },
+        { title: "iMessage Stickers", value: "imessage" },
+        { title: "Wallet Extension", value: "wallet" },
+        { title: "Siri Intent", value: "intent" },
+        {
+          title: "Widget (soft-deprecated — prefer expo-widgets for React/iOS)",
+          value: "widget",
+        },
       ],
     },
     {
-      type: 'text',
-      name: 'name',
-      message: 'Target name (e.g., my-widget):',
-      validate: (value) =>
-        value.length > 0 ? true : 'Target name is required',
+      type: (_prev, values) => (values.type === "widget" ? "confirm" : null),
+      name: "confirmNativeWidget",
+      message:
+        "Continue with a native WidgetKit scaffold? (React/iOS widgets → expo-widgets)",
+      initial: false,
     },
     {
-      type: 'multiselect',
-      name: 'platforms',
-      message: 'Select platforms:',
+      type: "text",
+      name: "name",
+      message: "Target name (e.g., my-share):",
+      validate: (value) =>
+        value.length > 0 ? true : "Target name is required",
+    },
+    {
+      type: "multiselect",
+      name: "platforms",
+      message: "Select platforms:",
       choices: [
-        { title: 'iOS', value: 'ios', selected: true },
-        { title: 'Android (coming soon)', value: 'android', disabled: true },
+        { title: "iOS", value: "ios", selected: true },
+        { title: "Android (coming soon)", value: "android", disabled: true },
       ],
     },
     {
       type: (_prev, values) =>
-        ['share', 'action', 'clip'].includes(values.type) ? 'confirm' : null,
-      name: 'useReactNative',
-      message: 'Use React Native for UI?',
-      initial: false,
+        ["share", "action", "clip"].includes(values.type) ? "confirm" : null,
+      name: "useReactNative",
+      message: "Use React Native for UI?",
+      initial: true,
     },
     {
-      type: (_prev, values) => (values.type === 'intent' ? 'confirm' : null),
-      name: 'includeIntentUI',
-      message: 'Include custom UI extension? (displays custom visuals in Siri)',
+      type: (_prev, values) => (values.type === "intent" ? "confirm" : null),
+      name: "includeIntentUI",
+      message: "Include custom UI extension? (displays custom visuals in Siri)",
       initial: true,
     },
   ]);
@@ -57,7 +75,17 @@ async function main() {
     return;
   }
 
-  const targetDir = path.join(process.cwd(), 'targets', response.name);
+  if (response.type === "widget") {
+    console.warn(`\n[expo-targets] ${WIDGET_HANDOFF}\n`);
+    if (response.confirmNativeWidget === false) {
+      console.log(
+        "Aborted. Install expo-widgets for React/iOS widgets, or re-run and confirm the native scaffold.",
+      );
+      return;
+    }
+  }
+
+  const targetDir = path.join(process.cwd(), "targets", response.name);
 
   if (fs.existsSync(targetDir)) {
     return;
@@ -72,34 +100,42 @@ async function main() {
     pascalName,
     response.platforms,
     response.useReactNative,
-    response.includeIntentUI
+    response.includeIntentUI,
   );
-  fs.writeFileSync(path.join(targetDir, 'expo-target.config.json'), config);
+  fs.writeFileSync(path.join(targetDir, "expo-target.config.json"), config);
 
-  if (response.platforms.includes('ios')) {
+  if (response.platforms.includes("ios")) {
     copyTemplate(
       response.type,
-      'ios',
+      "ios",
       targetDir,
       pascalName,
-      response.includeIntentUI
+      response.includeIntentUI,
     );
 
     if (response.useReactNative) {
-      const entryFile = path.join(targetDir, 'index.tsx');
+      const entryFile = path.join(targetDir, "index.tsx");
       fs.writeFileSync(
         entryFile,
-        getReactNativeTemplate(response.type, pascalName)
+        getReactNativeTemplate(response.type, pascalName),
       );
     }
   }
 
-  // Generate index.ts with pre-configured target instance
-  const indexTs = `import { createTarget } from 'expo-targets';
+  // Host-app helper instance (skip when RN entry already exports createTarget)
+  if (!response.useReactNative) {
+    const indexTs = `import { createTarget } from 'expo-targets';
 
 export const ${pascalToCamel(pascalName)} = createTarget('${pascalName}');
 `;
-  fs.writeFileSync(path.join(targetDir, 'index.ts'), indexTs);
+    fs.writeFileSync(path.join(targetDir, "index.ts"), indexTs);
+  }
+
+  if (response.type === "widget") {
+    console.warn(
+      "[expo-targets] Deprecated: native widget targets are soft-deprecated. Prefer expo-widgets for React/iOS widgets. See docs/widgets.md",
+    );
+  }
 }
 
 // biome-ignore lint/complexity/useMaxParams: pre-existing complexity; tracked for refactor
@@ -109,33 +145,33 @@ function generateConfig(
   pascalName: string,
   platforms: string[],
   useReactNative?: boolean,
-  includeIntentUi?: boolean
+  includeIntentUi?: boolean,
 ): string {
   const config: any = {
     type,
     name: pascalName,
     displayName: kebabName
-      .split('-')
+      .split("-")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' '),
+      .join(" "),
     platforms,
   };
 
-  if (platforms.includes('ios') && useReactNative) {
+  if (platforms.includes("ios") && useReactNative) {
     config.entry = `./targets/${kebabName}/index.tsx`;
-    config.excludedPackages = ['expo-updates', 'expo-dev-client'];
+    config.excludedPackages = ["expo-updates", "expo-dev-client"];
   }
 
-  if (type === 'intent' && platforms.includes('ios')) {
+  if (type === "intent" && platforms.includes("ios")) {
     config.ios = {
       intents: {
-        intentsSupported: ['INStartWorkoutIntent'],
+        intentsSupported: ["INStartWorkoutIntent"],
         ...(includeIntentUi && { ui: true }),
       },
     };
   }
 
-  if (type === 'wallet' && platforms.includes('ios')) {
+  if (type === "wallet" && platforms.includes("ios")) {
     config.ios = {
       wallet: {
         ui: true,
@@ -153,7 +189,7 @@ function copyTemplate(
   platform: string,
   targetDir: string,
   pascalName: string,
-  includeIntentUi?: boolean
+  includeIntentUi?: boolean,
 ) {
   const platformDir = path.join(targetDir, platform);
   fs.mkdirSync(platformDir, { recursive: true });
@@ -442,7 +478,7 @@ class PassProvider: PKIssuerProvisioningExtensionHandler {
         return config
     }
 }`,
-    'wallet-ui': `import UIKit
+    "wallet-ui": `import UIKit
 import PassKit
 
 class AuthorizationViewController: UIViewController, PKIssuerProvisioningExtensionAuthorizationProviding {
@@ -525,7 +561,7 @@ class IntentHandler: INExtension {
 //         completion(response)
 //     }
 // }`,
-    'intent-ui': `import IntentsUI
+    "intent-ui": `import IntentsUI
 
 class IntentViewController: UIViewController, INUIHostedViewControlling {
 
@@ -549,53 +585,53 @@ class IntentViewController: UIViewController, INUIHostedViewControlling {
 
   const templateFn = templates[type] || templates.widget;
   const template =
-    typeof templateFn === 'function' ? templateFn(pascalName) : templateFn;
-  let filename = 'Main.swift';
-  if (type === 'widget') {
-    filename = 'Widget.swift';
-  } else if (type === 'messages') {
-    filename = 'MessagesViewController.swift';
-  } else if (type === 'wallet') {
-    filename = 'PassProvider.swift';
-  } else if (type === 'intent') {
-    filename = 'IntentHandler.swift';
+    typeof templateFn === "function" ? templateFn(pascalName) : templateFn;
+  let filename = "Main.swift";
+  if (type === "widget") {
+    filename = "Widget.swift";
+  } else if (type === "messages") {
+    filename = "MessagesViewController.swift";
+  } else if (type === "wallet") {
+    filename = "PassProvider.swift";
+  } else if (type === "intent") {
+    filename = "IntentHandler.swift";
   }
 
   fs.writeFileSync(path.join(platformDir, filename), template);
 
   // For wallet type, also create AuthorizationViewController.swift (combined wallet with UI)
-  if (type === 'wallet') {
-    const walletUiTemplate = templates['wallet-ui'];
+  if (type === "wallet") {
+    const walletUiTemplate = templates["wallet-ui"];
     fs.writeFileSync(
-      path.join(platformDir, 'AuthorizationViewController.swift'),
-      walletUiTemplate as string
+      path.join(platformDir, "AuthorizationViewController.swift"),
+      walletUiTemplate as string,
     );
   }
 
   // For intent type with UI, also create IntentViewController.swift
-  if (type === 'intent' && includeIntentUi) {
-    const intentUiTemplate = templates['intent-ui'];
+  if (type === "intent" && includeIntentUi) {
+    const intentUiTemplate = templates["intent-ui"];
     fs.writeFileSync(
-      path.join(platformDir, 'IntentViewController.swift'),
-      intentUiTemplate as string
+      path.join(platformDir, "IntentViewController.swift"),
+      intentUiTemplate as string,
     );
   }
 
-  if (type === 'imessage') {
-    const stickersDir = path.join(platformDir, 'Stickers.xcstickers');
+  if (type === "imessage") {
+    const stickersDir = path.join(platformDir, "Stickers.xcstickers");
     fs.mkdirSync(stickersDir, { recursive: true });
     fs.writeFileSync(
-      path.join(stickersDir, 'Contents.json'),
+      path.join(stickersDir, "Contents.json"),
       JSON.stringify(
         {
           info: {
             version: 1,
-            author: 'xcode',
+            author: "xcode",
           },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
   }
 }
@@ -639,9 +675,9 @@ AppRegistry.registerComponent('${pascalName}', () => ${pascalName});
 
 function kebabToPascal(kebab: string): string {
   return kebab
-    .split('-')
+    .split("-")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('');
+    .join("");
 }
 
 function pascalToCamel(pascal: string): string {

--- a/packages/expo-targets/README.md
+++ b/packages/expo-targets/README.md
@@ -1,8 +1,14 @@
 # expo-targets
 
-Add iOS widgets, App Clips, iMessage stickers, and other native extensions to your Expo app with a simple, type-safe API.
+**Source of truth for** the published package overview (monorepo canonical story lives in the root README).
 
-> **Part of the expo-targets monorepo**. See the [main README](../../README.md) for complete documentation.
+<!-- doc-meta: owner=eng | last-reviewed=2026-07-30 -->
+
+Expo config plugin and runtime for Apple app extensions Expo does not ship — share, action, App Clips, messages, stickers, wallet, and more. React Native UIs are supported for share/action/clip/messages.
+
+> **Part of the expo-targets monorepo**. Full docs: [root README](../../README.md).
+>
+> **Widgets:** Prefer official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) for React/iOS widgets and Live Activities. See [widgets handoff](../../docs/widgets.md).
 
 ## Quick Start
 
@@ -10,67 +16,45 @@ Add iOS widgets, App Clips, iMessage stickers, and other native extensions to yo
 bun add expo-targets
 ```
 
-```typescript
-// targets/hello-widget/index.ts
-import { defineTarget } from "expo-targets";
+```bash
+npx create-expo-target
+# Share Extension → my-share → Use React Native: Yes
+```
 
-export const HelloWidget = defineTarget({
-  name: "hello-widget",
-  appGroup: "group.com.yourapp",
-  type: "widget",
-  platforms: {
-    ios: {
-      deploymentTarget: "14.0",
-      colors: {
-        $accent: "#007AFF",
-      },
-    },
-  },
-});
-
-export type HelloWidgetData = {
-  message: string;
-};
+```js
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTargetsMetro } = require("expo-targets/metro");
+module.exports = withTargetsMetro(getDefaultConfig(__dirname));
 ```
 
 ```typescript
-// App.tsx
-import { HelloWidget } from "./targets/hello-widget";
+// targets/my-share/index.tsx
+import { createTarget } from "expo-targets";
+import ShareExtension from "./ShareExtension";
 
-HelloWidget.set("message", "Hello Widget!");
-HelloWidget.refresh();
+export const myShare = createTarget<"share">("MyShare", ShareExtension);
 ```
 
 ## Package Structure
 
-This package contains four components:
-
 ### 1. TypeScript API (`src/`)
-
-Runtime API for data sharing and widget control.
 
 ```typescript
 import {
-  defineTarget,
+  createTarget,
   refreshAllTargets,
   close,
   openHostApp,
+  getSharedData,
 } from "expo-targets";
 ```
 
-**Exports:**
-
-- `defineTarget(options)`: Create type-safe target instance
-- `TargetStorage`: Legacy storage class
-- `AppGroupStorage`: Low-level storage class
-- `refreshAllTargets()`: Refresh all widgets/controls
-- `close()`: Close extension (share/action)
-- `openHostApp(path)`: Open main app from extension
-- `clearSharedData()`: Clear shared data
+- `createTarget(name, component?)` — target instance; pass a component for RN extensions
+- `close` / `openHostApp` / `getSharedData` — share/action (and related) lifecycle
+- Storage helpers via the target instance (`setData`, `getData`, `refresh`)
 
 ### 2. Config Plugin (`plugin/`)
-
-Expo config plugin for automatic Xcode project setup.
 
 ```json
 {
@@ -80,167 +64,30 @@ Expo config plugin for automatic Xcode project setup.
 }
 ```
 
-**Features:**
+### 3. Metro helper (`metro/`)
 
-- Scans `targets/*/index.ts` for `defineTarget()` calls
-- Parses configuration using Babel AST
-- Creates native Xcode targets
-- Links Swift files from `targets/*/ios/`
-- Generates color and image assets
-- Syncs entitlements from main app
-- Configures frameworks and build settings
-
-### 3. Metro Wrapper (`metro/`)
-
-Metro bundler wrapper for React Native extensions.
-
-```typescript
-import { withTargetsMetro } from "expo-targets/metro";
-```
-
-**Usage:**
-
-```javascript
-// metro.config.js
-const { getDefaultConfig } = require("expo/metro-config");
+```js
 const { withTargetsMetro } = require("expo-targets/metro");
-
 module.exports = withTargetsMetro(getDefaultConfig(__dirname));
 ```
 
-**Required for:**
+### 4. Native modules (`ios/`, `android/`)
 
-- Share extensions with React Native
-- Action extensions with React Native
-- App Clips with React Native
-
-### 4. Native Module (`ios/`)
-
-Swift module for data storage and widget lifecycle.
-
-**Capabilities:**
-
-- App Group storage via `UserDefaults`
-- Widget refresh (`WidgetCenter` API)
-- Control Center refresh (iOS 18+)
-- Extension lifecycle management
-- Deep linking to main app
-
-## Exports
-
-### Main Package
-
-```typescript
-// Core API
-import {
-  defineTarget,
-  TargetStorage,
-  AppGroupStorage,
-  refreshAllTargets,
-  close,
-  openHostApp,
-  clearSharedData,
-} from "expo-targets";
-
-// Types
-import type {
-  Target,
-  DefineTargetOptions,
-  TargetConfig,
-  IOSTargetConfig,
-  AndroidTargetConfig,
-  ExtensionType,
-  Color,
-} from "expo-targets";
-```
-
-### Metro Subpath
-
-```typescript
-import { withTargetsMetro } from "expo-targets/metro";
-```
-
-## Development
-
-### Build
-
-```bash
-bun run build        # Build all components
-bun run build:main   # Build TypeScript API
-bun run build:plugin # Build config plugin
-bun run build:metro  # Build Metro wrapper
-```
-
-### Clean
-
-```bash
-bun run clean        # Remove all build artifacts
-```
-
-### Lint
-
-```bash
-bun run lint         # Lint with Biome
-bun run format       # Format with Biome
-bun run check        # Lint + format check
-```
+App Group storage, WidgetCenter reload (legacy widgets), extension host bridges.
 
 ## Documentation
 
-- **[Getting Started](../../docs/getting-started.md)**: Step-by-step tutorial
-- **[API Reference](../../docs/api-reference.md)**: Complete API documentation
-- **[Config Reference](../../docs/config-reference.md)**: Configuration options
-- **[TypeScript Guide](../../docs/typescript-config-guide.md)**: Advanced patterns
-- **[Main README](../../README.md)**: Project overview
-
-## Examples
-
-- **[widget-basic](../../apps/widget-basic/)**: Complete working widget with data sharing
-
-## Features
-
-- 🎯 **Type-Safe API**: Full TypeScript support with IDE autocomplete
-- 📦 **Simple Configuration**: Single `index.ts` file per target
-- 🔄 **Data Sharing**: Built-in App Group storage
-- ⚛️ **React Native**: Optional RN rendering in compatible extensions
-- 🎨 **Asset Generation**: Automatic colors and images
-- 🔧 **Xcode Integration**: Full project manipulation
-- 📱 **iOS Production Ready**: Widgets, clips, iMessage tested
-
-## Platform Support
-
-- **iOS**: ✅ Production ready (iOS 14+)
-- **Android**: 📋 Coming soon (architecture prepared)
-
-## Requirements
-
-- Expo SDK 50+
-- iOS 14+ (for widgets)
-- macOS with Xcode 14+
-- TypeScript recommended
-
-## Version
-
-Current version: **0.1.0**
-
-See [CHANGELOG.md](../../CHANGELOG.md) for version history.
+- [Getting started](../../docs/getting-started.md)
+- [React Native extensions](../../docs/react-native-extensions.md)
+- [Widgets handoff](../../docs/widgets.md)
+- [Deprecations](../../docs/deprecations.md)
+- [Configuration](../../docs/configuration.md)
+- [API](../../docs/api.md)
 
 ## License
 
-[MIT](../../LICENSE)
-
-## Contributing
-
-See [Contributing Guide](../../CONTRIBUTING.md) (coming soon)
-
-## Support
-
-- **Issues**: [GitHub Issues](https://github.com/your-org/expo-targets/issues)
-- **Documentation**: [docs/](../../docs/)
-- **Examples**: [apps/](../../apps/)
+MIT
 
 ## Credits
 
-Part of expo-targets by [Your Organization]
-
-Inspired by [@bacons/apple-targets](https://github.com/EvanBacon/expo-apple-targets), [expo-widgets](https://github.com/bittingz/expo-widgets), and others.
+Inspired by [@bacons/apple-targets](https://github.com/EvanBacon/expo-apple-targets) and [expo-share-extension](https://github.com/MaxAst/expo-share-extension). Official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) is the recommended path for React/iOS widgets; community [bittingz/expo-widgets](https://github.com/bittingz/expo-widgets) was historical inspiration only.

--- a/packages/expo-targets/metro/src/index.ts
+++ b/packages/expo-targets/metro/src/index.ts
@@ -1,1 +1,6 @@
-export { withTargetsMetro } from './withTargetsMetro';
+export {
+  scanTargetsDirectory,
+  withTargetsMetro,
+  type ScanResult,
+  type TargetConfig,
+} from "./withTargetsMetro";

--- a/packages/expo-targets/metro/src/withTargetsMetro.ts
+++ b/packages/expo-targets/metro/src/withTargetsMetro.ts
@@ -1,19 +1,29 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import process from 'node:process';
-import type { MetroConfig } from 'metro-config';
+import * as fs from "node:fs";
+import * as path from "node:path";
+import process from "node:process";
+import type { MetroConfig } from "metro-config";
 
-interface TargetConfig {
+export interface TargetConfig {
   name: string;
   entry?: string;
 }
 
-function scanTargetsDirectory(projectRoot: string): Map<string, string> {
-  const targetsDir = path.join(projectRoot, 'targets');
+export interface ScanResult {
+  entryMap: Map<string, string>;
+  warnings: string[];
+}
+
+/**
+ * Scan each target's expo-target.config.json for RN entry fields.
+ * Exported for tests and tooling.
+ */
+export function scanTargetsDirectory(projectRoot: string): ScanResult {
+  const targetsDir = path.join(projectRoot, "targets");
   const entryMap = new Map<string, string>();
+  const warnings: string[] = [];
 
   if (!fs.existsSync(targetsDir)) {
-    return entryMap;
+    return { entryMap, warnings };
   }
 
   for (const dir of fs.readdirSync(targetsDir, { withFileTypes: true })) {
@@ -24,7 +34,7 @@ function scanTargetsDirectory(projectRoot: string): Map<string, string> {
     const configPath = path.join(
       targetsDir,
       dir.name,
-      'expo-target.config.json'
+      "expo-target.config.json",
     );
     if (!fs.existsSync(configPath)) {
       continue;
@@ -32,43 +42,90 @@ function scanTargetsDirectory(projectRoot: string): Map<string, string> {
 
     try {
       const config: TargetConfig = JSON.parse(
-        fs.readFileSync(configPath, 'utf-8')
+        fs.readFileSync(configPath, "utf-8"),
       );
-      if (config.entry) {
-        const entryPath = path.resolve(projectRoot, config.entry);
-        const bundleRoot = config.entry
-          .replace(/^\.\//, '')
-          .replace(/\.(tsx?|jsx?)$/, '');
-        entryMap.set(bundleRoot, entryPath);
+      if (!config.entry) {
+        continue;
       }
-    } catch {
-      // Skip invalid configs
+
+      if (!config.name) {
+        warnings.push(
+          "[expo-targets/metro] targets/" +
+            dir.name +
+            ': config has "entry" but missing "name"',
+        );
+      }
+
+      const entryPath = path.resolve(projectRoot, config.entry);
+      if (!fs.existsSync(entryPath)) {
+        warnings.push(
+          "[expo-targets/metro] targets/" +
+            dir.name +
+            ': entry "' +
+            config.entry +
+            '" does not exist (resolved: ' +
+            entryPath +
+            ")",
+        );
+        continue;
+      }
+
+      const bundleRoot = config.entry
+        .replace(/^\.\//, "")
+        .replace(/\.(tsx?|jsx?)$/, "");
+      entryMap.set(bundleRoot, entryPath);
+    } catch (error) {
+      warnings.push(
+        "[expo-targets/metro] targets/" +
+          dir.name +
+          ": invalid expo-target.config.json (" +
+          (error instanceof Error ? error.message : String(error)) +
+          ")",
+      );
     }
   }
 
-  return entryMap;
+  return { entryMap, warnings };
 }
 
 export function withTargetsMetro(
   metroConfig: MetroConfig,
-  options?: { projectRoot?: string }
+  options?: { projectRoot?: string; silent?: boolean },
 ): MetroConfig {
   const projectRoot = options?.projectRoot || process.cwd();
-  const entryMap = scanTargetsDirectory(projectRoot);
+  const { entryMap, warnings } = scanTargetsDirectory(projectRoot);
 
-  if (entryMap.size > 0) {
+  if (!options?.silent) {
+    for (const warning of warnings) {
+      console.warn(warning);
+    }
+    if (entryMap.size > 0) {
+      const roots = [...new Set(entryMap.values())];
+      console.log(
+        "[expo-targets/metro] Resolved " +
+          roots.length +
+          " RN extension entr" +
+          (roots.length === 1 ? "y" : "ies"),
+      );
+    }
   }
+
+  const previousResolveRequest = metroConfig.resolver?.resolveRequest;
 
   return {
     ...metroConfig,
     resolver: {
       ...metroConfig.resolver,
       resolveRequest: (context, moduleName, platform) => {
-        const normalized = moduleName.replace(/^\.\//, '');
+        const normalized = moduleName.replace(/^\.\//, "");
         const entryPath = entryMap.get(normalized);
 
         if (entryPath) {
-          return { type: 'sourceFile', filePath: entryPath };
+          return { type: "sourceFile", filePath: entryPath };
+        }
+
+        if (previousResolveRequest) {
+          return previousResolveRequest(context, moduleName, platform);
         }
 
         return context.resolveRequest(context, moduleName, platform);

--- a/packages/expo-targets/src/Target.ts
+++ b/packages/expo-targets/src/Target.ts
@@ -1,29 +1,29 @@
-import process from 'node:process';
-import Constants from 'expo-constants';
-import { AppRegistry } from 'react-native';
+import process from "node:process";
+import Constants from "expo-constants";
+import { AppRegistry } from "react-native";
 import type {
   ExtensionType,
   ReactNativeCompatibleType,
   TargetConfig,
-} from '../plugin/src/config';
-import { Extension, type SharedData } from './modules/extension/index';
+} from "../plugin/src/config";
+import { Extension, type SharedData } from "./modules/extension/index";
 import {
   type ConversationInfo,
   type MessageLayout,
   Messages,
   type PresentationStyle,
-} from './modules/messages/index';
+} from "./modules/messages/index";
 import {
   bootstrapSafariExtension,
   closePopup,
   copyToClipboard,
   isSafariExtension,
   openTab,
-} from './modules/safari/index';
+} from "./modules/safari/index";
 import {
   AppGroupStorage,
   getTargetsConfigFromBundle,
-} from './modules/storage/index';
+} from "./modules/storage/index";
 
 export interface BaseTarget {
   name: string;
@@ -43,9 +43,11 @@ export interface ExtensionTarget extends BaseTarget {
   getSharedData: () => SharedData | null;
 }
 
-export interface MessagesExtensionTarget
-  extends Omit<ExtensionTarget, 'close'> {
-  type: 'messages';
+export interface MessagesExtensionTarget extends Omit<
+  ExtensionTarget,
+  "close"
+> {
+  type: "messages";
   getPresentationStyle: () => PresentationStyle | null;
   requestPresentationStyle: (style: PresentationStyle) => void;
   sendMessage: (layout: MessageLayout) => void;
@@ -53,8 +55,8 @@ export interface MessagesExtensionTarget
   createSession: () => string | null;
   getConversationInfo: () => ConversationInfo | null;
   addEventListener: (
-    eventName: 'onPresentationStyleChange',
-    listener: (style: PresentationStyle) => void
+    eventName: "onPresentationStyleChange",
+    listener: (style: PresentationStyle) => void,
   ) => { remove: () => void };
 }
 
@@ -65,7 +67,7 @@ export interface NonExtensionTarget extends BaseTarget {
 }
 
 export interface SafariExtensionTarget extends BaseTarget {
-  type: 'safari';
+  type: "safari";
   closePopup: () => void;
   openTab: (url: string) => Promise<void>;
   copyToClipboard: (text: string) => Promise<boolean>;
@@ -104,7 +106,7 @@ function getTargetConfig(targetName: string): TargetConfig | null {
 
 function getTargetAppGroup(
   targetName: string,
-  config?: TargetConfig
+  config?: TargetConfig,
 ): string | null {
   const targetConfig = config || getTargetConfig(targetName);
   if (!targetConfig) {
@@ -115,16 +117,16 @@ function getTargetAppGroup(
 }
 
 const EXTENSION_TYPES: Set<ReactNativeCompatibleType> = new Set([
-  'share',
-  'action',
-  'clip',
-  'messages',
+  "share",
+  "action",
+  "clip",
+  "messages",
 ]);
 
-const WEB_EXTENSION_TYPES: Set<ExtensionType> = new Set(['safari']);
+const WEB_EXTENSION_TYPES: Set<ExtensionType> = new Set(["safari"]);
 
 function isExtensionType(
-  type: ExtensionType
+  type: ExtensionType,
 ): type is ReactNativeCompatibleType {
   return EXTENSION_TYPES.has(type as ReactNativeCompatibleType);
 }
@@ -133,36 +135,50 @@ function isWebExtensionType(type: ExtensionType): boolean {
   return WEB_EXTENSION_TYPES.has(type);
 }
 
+const warnedWidgetTargets = new Set<string>();
+
+function warnIfWidgetDeprecated(type: ExtensionType, targetName: string) {
+  if (type !== "widget" || warnedWidgetTargets.has(targetName)) {
+    return;
+  }
+  warnedWidgetTargets.add(targetName);
+  console.warn(
+    `[expo-targets] Target "${targetName}" uses type "widget", which is soft-deprecated. ` +
+      "For new React/iOS widgets and Live Activities, prefer expo-widgets (SDK 56+). " +
+      "See https://docs.expo.dev/versions/latest/sdk/widgets/ and docs/widgets.md",
+  );
+}
+
 // Function overloads for better type inference
-export function createTarget<_T extends 'messages'>(
+export function createTarget<_T extends "messages">(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): MessagesExtensionTarget;
-export function createTarget<_T extends 'safari'>(
+export function createTarget<_T extends "safari">(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): SafariExtensionTarget;
 export function createTarget<
-  _T extends Exclude<ReactNativeCompatibleType, 'messages'>,
+  _T extends Exclude<ReactNativeCompatibleType, "messages">,
 >(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): ExtensionTarget;
 export function createTarget<
   _T extends Exclude<ExtensionType, ReactNativeCompatibleType>,
 >(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): NonExtensionTarget;
 export function createTarget(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): Target;
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: pre-existing complexity; tracked for refactor
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: pre-existing complexity; tracked for refactor
 export function createTarget<_T extends ExtensionType = ExtensionType>(
   targetName: string,
-  componentFunc?: React.ComponentType<any>
+  componentFunc?: React.ComponentType<any>,
 ): Target {
   // Safari web extension: runs in browser context, use web rendering
   if (isSafariExtension() && componentFunc) {
@@ -172,16 +188,18 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
   const config = getTargetConfig(targetName);
   if (!config) {
     throw new Error(
-      `Target "${targetName}" not found. Ensure it's defined in app.json under "extra.targets"`
+      `Target "${targetName}" not found. Ensure it's defined in app.json under "extra.targets"`,
     );
   }
+
+  warnIfWidgetDeprecated(config.type, targetName);
 
   // Safari extension with entry but running in native context (config lookup)
   // This shouldn't normally happen but handle gracefully
   if (
     isWebExtensionType(config.type) &&
     componentFunc &&
-    'entry' in config &&
+    "entry" in config &&
     config.entry
   ) {
     // Safari extensions with entry should bootstrap for web
@@ -192,7 +210,7 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
   const appGroup = getTargetAppGroup(targetName, config);
   if (!appGroup) {
     throw new Error(
-      `App Group not configured for target "${targetName}". Add "appGroup" to your target config.`
+      `App Group not configured for target "${targetName}". Add "appGroup" to your target config.`,
     );
   }
 
@@ -220,11 +238,11 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
   if (isExtensionType(config.type)) {
     const extension = new Extension();
 
-    if (config.type === 'messages') {
+    if (config.type === "messages") {
       const messages = new Messages();
       const messagesTarget: MessagesExtensionTarget = {
         ...baseTarget,
-        type: 'messages',
+        type: "messages",
         openHostApp: (path?: string) => extension.openHostApp(path),
         getSharedData: () => extension.getSharedData(),
         getPresentationStyle: () => messages.getPresentationStyle(),
@@ -236,8 +254,8 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
         createSession: () => messages.createSession(),
         getConversationInfo: () => messages.getConversationInfo(),
         addEventListener: (
-          eventName: 'onPresentationStyleChange',
-          listener: (style: PresentationStyle) => void
+          eventName: "onPresentationStyleChange",
+          listener: (style: PresentationStyle) => void,
         ) => messages.addEventListener(eventName, listener),
       };
       target = messagesTarget as any;
@@ -262,17 +280,25 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
   }
 
   // Register component with target injected as prop
-  if (componentFunc && 'entry' in config && config.entry) {
+  if (componentFunc) {
+    if (!("entry" in config) || !config.entry) {
+      throw new Error(
+        `[expo-targets] createTarget("${targetName}", Component) requires an "entry" field in ` +
+          "expo-target.config pointing at the RN entry file (relative to project root). " +
+          "See docs/react-native-extensions.md",
+      );
+    }
+
     const WrappedComponent = (props: any) => {
-      const React = require('react');
+      const React = require("react");
       return React.createElement(componentFunc, { ...props, target });
     };
 
     let qualifiedComponent = WrappedComponent;
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== "production") {
       try {
-        const { withDevTools } = require('expo/src/launch/withDevTools');
+        const { withDevTools } = require("expo/src/launch/withDevTools");
         qualifiedComponent = withDevTools(WrappedComponent);
       } catch {}
     }
@@ -289,7 +315,7 @@ export function createTarget<_T extends ExtensionType = ExtensionType>(
  */
 function createSafariTarget(
   targetName: string,
-  componentFunc: React.ComponentType<any>
+  componentFunc: React.ComponentType<any>,
 ): SafariExtensionTarget {
   // Bootstrap the React component for web rendering
   bootstrapSafariExtension(targetName, componentFunc);
@@ -316,10 +342,10 @@ function createSafariTarget(
 
   const safariTarget: SafariExtensionTarget = {
     name: targetName,
-    type: 'safari',
-    appGroup: '', // Not applicable for Safari extensions
+    type: "safari",
+    appGroup: "", // Not applicable for Safari extensions
     storage: webStorage as any, // Web storage adapter
-    config: { type: 'safari', name: targetName, platforms: ['ios'] },
+    config: { type: "safari", name: targetName, platforms: ["ios"] },
     setData: webStorage.setData as any,
     getData: webStorage.getData,
     refresh: webStorage.refresh,
@@ -336,7 +362,7 @@ function createSafariTarget(
  */
 function createSafariTargetFromConfig(
   targetName: string,
-  config: TargetConfig
+  config: TargetConfig,
 ): SafariExtensionTarget {
   const webStorage = {
     setData: async (data: Record<string, any>) => {
@@ -353,8 +379,8 @@ function createSafariTargetFromConfig(
 
   return {
     name: targetName,
-    type: 'safari',
-    appGroup: config.appGroup || '',
+    type: "safari",
+    appGroup: config.appGroup || "",
     storage: webStorage as any,
     config,
     setData: webStorage.setData as any,

--- a/packages/expo-targets/src/index.ts
+++ b/packages/expo-targets/src/index.ts
@@ -8,21 +8,22 @@ export type {
   IOSTargetConfig,
   ReactNativeCompatibleType,
   TargetConfig,
-} from '../plugin/src/config';
-export type { SharedData } from './modules/extension/index';
+} from "../plugin/src/config";
+export type { SharedData } from "./modules/extension/index";
 // Extension module
 export {
   close,
   Extension,
+  getExtensionNativeModule,
   getSharedData,
   openHostApp,
-} from './modules/extension/index';
+} from "./modules/extension/index";
 export type {
   ConversationInfo,
   MessageLayout,
   PresentationStyle,
   SelectedMessage,
-} from './modules/messages/index';
+} from "./modules/messages/index";
 // Messages module
 export {
   addEventListener as addMessagesEventListener,
@@ -32,8 +33,8 @@ export {
   requestPresentationStyle,
   sendMessage,
   sendUpdate,
-} from './modules/messages/index';
-export type { BrowserTab } from './modules/safari/index';
+} from "./modules/messages/index";
+export type { BrowserTab } from "./modules/safari/index";
 // Safari module
 export {
   closePopup,
@@ -47,13 +48,13 @@ export {
   useMessageListener,
   useSendToContentScript,
   useSendToNative,
-} from './modules/safari/index';
+} from "./modules/safari/index";
 // Storage module
 export {
   AppGroupStorage,
   clearSharedData,
   refreshAllTargets,
-} from './modules/storage/index';
+} from "./modules/storage/index";
 export type {
   BaseTarget,
   ExtensionTarget,
@@ -61,5 +62,5 @@ export type {
   NonExtensionTarget,
   SafariExtensionTarget,
   Target,
-} from './Target';
-export { createTarget } from './Target';
+} from "./Target";
+export { createTarget } from "./Target";

--- a/packages/expo-targets/src/modules/extension/index.ts
+++ b/packages/expo-targets/src/modules/extension/index.ts
@@ -1,7 +1,5 @@
-import { requireNativeModule } from 'expo-modules-core';
-import { Platform } from 'react-native';
-
-const ExpoTargetsExtensionModule = requireNativeModule('ExpoTargetsExtension');
+import { requireNativeModule } from "expo-modules-core";
+import { Platform } from "react-native";
 
 export interface SharedData {
   text?: string;
@@ -12,40 +10,90 @@ export interface SharedData {
   preprocessedData?: any;
 }
 
-export class Extension {
-  close() {
-    if (Platform.OS === 'ios') {
-      ExpoTargetsExtensionModule.closeExtension();
-    }
-  }
+type ExtensionNativeModule = {
+  closeExtension: () => void;
+  openHostApp: (path: string) => void;
+  getSharedData: () => SharedData | null;
+};
 
-  openHostApp(path = '') {
-    if (Platform.OS === 'ios') {
-      ExpoTargetsExtensionModule.openHostApp(path);
-    }
-  }
+let cachedModule: ExtensionNativeModule | null | undefined;
 
-  getSharedData(): SharedData | null {
-    if (Platform.OS === 'ios') {
-      return ExpoTargetsExtensionModule.getSharedData();
-    }
+/**
+ * Resolve the ExpoTargetsExtension native module.
+ * Returns null when unavailable (wrong platform, missing native build, or host app).
+ */
+export function getExtensionNativeModule(): ExtensionNativeModule | null {
+  if (cachedModule !== undefined) {
+    return cachedModule;
+  }
+  if (Platform.OS !== "ios") {
+    cachedModule = null;
     return null;
+  }
+  try {
+    cachedModule = requireNativeModule(
+      "ExpoTargetsExtension",
+    ) as ExtensionNativeModule;
+  } catch {
+    cachedModule = null;
+  }
+  return cachedModule;
+}
+
+function requireExtensionModule(action: string): ExtensionNativeModule {
+  const mod = getExtensionNativeModule();
+  if (mod) {
+    return mod;
+  }
+  if (Platform.OS !== "ios") {
+    throw new Error(
+      `[expo-targets] ${action} is only available in iOS app extensions. ` +
+        `Current platform: ${Platform.OS}.`,
+    );
+  }
+  throw new Error(
+    `[expo-targets] ${action} failed: native module "ExpoTargetsExtension" is unavailable. ` +
+      "Run this inside a share/action/clip/messages extension after `npx expo prebuild` " +
+      "(or `expo-targets sync` on bare RN), and ensure the extension target embeds expo-targets.",
+  );
+}
+
+/**
+ * Cross-type RN extension lifecycle helpers (share, action, clip, messages).
+ *
+ * Contract:
+ * - Call from the extension JS bundle (not Expo Go).
+ * - `createTarget(name, Component)` registers the component via AppRegistry; `name` must match config.
+ * - `getSharedData` / `close` / `openHostApp` require the ExpoTargetsExtension native module.
+ * - Messages adds APIs on top of this contract (see Messages module).
+ */
+export class Extension {
+  /** Dismiss the extension UI (share/action). */
+  close() {
+    requireExtensionModule("close()").closeExtension();
+  }
+
+  /** Open the host app, optionally with a path/URL fragment. */
+  openHostApp(path = "") {
+    requireExtensionModule("openHostApp()").openHostApp(path);
+  }
+
+  /** Read content shared into the extension (text, URLs, images, …). */
+  getSharedData(): SharedData | null {
+    return requireExtensionModule("getSharedData()").getSharedData();
   }
 }
 
 export const close = () => {
-  const ext = new Extension();
-  ext.close();
+  new Extension().close();
 };
 
-export const openHostApp = (path = '') => {
-  const ext = new Extension();
-  ext.openHostApp(path);
+export const openHostApp = (path = "") => {
+  new Extension().openHostApp(path);
 };
 
 export const getSharedData = (): SharedData | null => {
-  const ext = new Extension();
-  return ext.getSharedData();
+  return new Extension().getSharedData();
 };
 
 export type { SharedData as ExtensionSharedData };

--- a/tests/e2e/metro/withTargetsMetro.test.ts
+++ b/tests/e2e/metro/withTargetsMetro.test.ts
@@ -1,0 +1,133 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  scanTargetsDirectory,
+  withTargetsMetro,
+} from "../../../packages/expo-targets/metro/src/withTargetsMetro";
+
+function makeTempProject(
+  entries: {
+    dir: string;
+    config: Record<string, unknown>;
+    entryFile?: string;
+  }[],
+): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "expo-targets-metro-"));
+  for (const item of entries) {
+    const targetDir = path.join(root, "targets", item.dir);
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetDir, "expo-target.config.json"),
+      JSON.stringify(item.config, null, 2),
+    );
+    if (item.entryFile) {
+      const entryPath = path.join(root, item.entryFile);
+      fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+      fs.writeFileSync(
+        entryPath,
+        "export default function App() { return null }",
+      );
+    }
+  }
+  return root;
+}
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("scanTargetsDirectory", () => {
+  test("maps valid entry paths to absolute files", () => {
+    const root = makeTempProject([
+      {
+        dir: "share-content",
+        config: {
+          type: "share",
+          name: "ShareContent",
+          entry: "./targets/share-content/index.tsx",
+        },
+        entryFile: "targets/share-content/index.tsx",
+      },
+    ]);
+    tempRoots.push(root);
+
+    const { entryMap, warnings } = scanTargetsDirectory(root);
+    expect(warnings).toEqual([]);
+    expect(entryMap.get("targets/share-content/index")).toBe(
+      path.join(root, "targets/share-content/index.tsx"),
+    );
+  });
+
+  test("warns when entry file is missing", () => {
+    const root = makeTempProject([
+      {
+        dir: "broken",
+        config: {
+          type: "share",
+          name: "Broken",
+          entry: "./targets/broken/missing.tsx",
+        },
+      },
+    ]);
+    tempRoots.push(root);
+
+    const { entryMap, warnings } = scanTargetsDirectory(root);
+    expect(entryMap.size).toBe(0);
+    expect(warnings.some((w) => w.includes("does not exist"))).toBe(true);
+  });
+
+  test("skips targets without entry", () => {
+    const root = makeTempProject([
+      {
+        dir: "stickers",
+        config: { type: "stickers", name: "Stickers" },
+      },
+    ]);
+    tempRoots.push(root);
+
+    const { entryMap, warnings } = scanTargetsDirectory(root);
+    expect(entryMap.size).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("withTargetsMetro", () => {
+  test("resolveRequest returns mapped entry files", () => {
+    const root = makeTempProject([
+      {
+        dir: "share-content",
+        config: {
+          type: "share",
+          name: "ShareContent",
+          entry: "./targets/share-content/index.tsx",
+        },
+        entryFile: "targets/share-content/index.tsx",
+      },
+    ]);
+    tempRoots.push(root);
+
+    const config = withTargetsMetro({ resolver: {} } as any, {
+      projectRoot: root,
+      silent: true,
+    });
+
+    const result = config.resolver!.resolveRequest!(
+      {
+        resolveRequest: () => ({ type: "sourceFile", filePath: "/fallback" }),
+      } as any,
+      "targets/share-content/index",
+      "ios",
+    );
+
+    expect(result).toEqual({
+      type: "sourceFile",
+      filePath: path.join(root, "targets/share-content/index.tsx"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Lead with RN share/action and other non-widget Apple targets; soft-deprecate native iOS widgets toward official `expo-widgets`, with docs handoff and CLI/runtime warnings
- Adopt Skeleton docs SSOT (`AGENTS.md`, registry) and rewrite getting-started / README around the new posture
- Harden RN extension backbone: sharper lifecycle errors, `withTargetsMetro` entry validation, and Metro unit tests

## Test plan
- [ ] `bun run audit:self` passes
- [ ] `bun test tests/e2e/metro/withTargetsMetro.test.ts` passes
- [ ] `bun run typecheck` and `bun run --filter './packages/*' build` succeed
- [ ] `npx create-expo-target` shows Share/Action first; Widget prompts `expo-widgets` handoff
- [ ] Skim README / `docs/widgets.md` / `docs/getting-started.md` for correct lead story