### PR TITLE
fix(ios): sticker packs land in build Stickers.xcassets

### DIFF
--- a/packages/expo-targets/plugin/src/ios/plan/assets.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/assets.ts
@@ -15,12 +15,6 @@ import type {
 
 const IMESSAGE_APP_ICON = 'iMessage App Icon.stickersiconset';
 
-function resolveProjectPath(projectRoot: string, filePath: string): string {
-  return path.isAbsolute(filePath)
-    ? filePath
-    : path.join(projectRoot, filePath);
-}
-
 function planColorsets({
   props,
   projectRoot,
@@ -52,19 +46,20 @@ function planColorsets({
 
 function planStickerPacks({
   props,
-  identity,
   paths,
+  buildAssetsPath,
 }: {
   props: IOSTargetProps;
-  identity: TargetIdentity;
   paths: ProjectPaths;
+  buildAssetsPath: string;
 }): StickerPackPlan[] {
   return (props.stickerPacks || []).map((pack) => {
-    const stickerPackPath = Paths.getStickerPackPath({
-      platformProjectRoot: paths.platformProjectRoot,
-      targetName: identity.targetName,
-      stickerPackName: pack.name,
-    });
+    // Packs must live in the same Stickers.xcassets Xcode references
+    // (targets/.../ios/build/), not the legacy ios/<Target>/ catalog.
+    const stickerPackPath = path.join(
+      buildAssetsPath,
+      `${pack.name}.stickerpack`
+    );
     const assets = pack.assets.map((assetPath) => {
       const sourcePath = path.isAbsolute(assetPath)
         ? assetPath
@@ -85,22 +80,24 @@ function planStickerPacks({
 
 function planStickers({
   props,
-  identity,
   paths,
   buildAssetsPath,
 }: {
   props: IOSTargetProps;
-  identity: TargetIdentity;
   paths: ProjectPaths;
   buildAssetsPath: string;
 }): StickersPlan {
   return {
     assetsPath: buildAssetsPath,
     iconsetPath: path.join(buildAssetsPath, IMESSAGE_APP_ICON),
+    // Match stickerPacks: paths in expo-target.config.json are relative to the
+    // target directory (e.g. targets/stickers/assets/...), not the app root.
     sourceIconPath: props.targetIcon
-      ? resolveProjectPath(paths.projectRoot, props.targetIcon)
+      ? path.isAbsolute(props.targetIcon)
+        ? props.targetIcon
+        : path.join(paths.projectRoot, props.directory, props.targetIcon)
       : undefined,
-    packs: planStickerPacks({ props, identity, paths }),
+    packs: planStickerPacks({ props, paths, buildAssetsPath }),
   };
 }
 
@@ -135,7 +132,7 @@ export function planAssets({
     copyUserAssets: workspace.hasUserAssets,
     colorsets: planColorsets({ props, projectRoot: paths.projectRoot }),
     stickers: isStickers
-      ? planStickers({ props, identity, paths, buildAssetsPath })
+      ? planStickers({ props, paths, buildAssetsPath })
       : undefined,
   };
 }

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -375,7 +375,7 @@ describe("planAssets for sticker targets", () => {
       "iMessage App Icon.stickersiconset",
     );
     expect(plan.stickers?.sourceIconPath).toBe(
-      path.join(PROJECT_ROOT, "assets/icon.png"),
+      path.join(PROJECT_ROOT, "targets/my-share/assets/icon.png"),
     );
   });
 
@@ -387,6 +387,15 @@ describe("planAssets for sticker targets", () => {
         "targets/my-share/stickers/hello.png",
       ),
     });
+  });
+
+  test("writes sticker packs into the referenced build Stickers.xcassets", () => {
+    expect(plan.stickers?.packs[0].stickerPackPath).toBe(
+      path.join(
+        PROJECT_ROOT,
+        "targets/my-share/ios/build/Stickers.xcassets/Pack.stickerpack",
+      ),
+    );
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/utils/paths.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/paths.ts
@@ -118,28 +118,6 @@ export function getColorsetPath({
 }
 
 /**
- * Get path to a specific sticker pack in Xcode project.
- */
-export function getStickerPackPath({
-  platformProjectRoot,
-  targetName,
-  stickerPackName,
-}: {
-  platformProjectRoot: string;
-  targetName: string;
-  stickerPackName: string;
-}): string {
-  return path.join(
-    getAssetsXcassetsPath({
-      platformProjectRoot,
-      targetName,
-      isStickers: true,
-    }),
-    `${stickerPackName}.stickerpack`
-  );
-}
-
-/**
  * ============================================================================
  * NEW: Reference-in-Place Path Utilities
  * ============================================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Plugin writes sticker packs into the **build** `Stickers.xcassets` catalog (not a parallel path)
- Resolves `targetIcon` under the stickers target directory
- Removes `getStickerPackPath`; planner unit tests cover the catalog write

## Stack
```
#33 THIS — catalog path
  └─ #34 408×408 example foundation
       └─ #37 locked Bip pose pack
            └─ #35 docs
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab0528c0-eea8-458e-9dea-55914f92fce9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab0528c0-eea8-458e-9dea-55914f92fce9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

