### PR TITLE
Set up Cursor Cloud dev environment (Bun) + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`expo-targets` is a **Bun-based monorepo** (no server/database) that publishes an Expo config plugin + CLIs for adding native Apple/Android app-extension targets. Node `>=22` and Bun are required (Bun is installed via `https://bun.sh/install`; it lives at `~/.bun/bin`, added to `PATH` in `~/.bashrc`). Standard scripts live in the root `package.json` and CI is `.github/workflows/test.yml`.
+
+### Services / layout
+There are no long-running services. Work happens in three layers: the publishable packages (`packages/expo-targets`, `packages/create-expo-target`, `packages/expo-targets-cli`), the example apps (`apps/*`), and the Bun test suite (`tests/e2e`, its own `bun.lock`).
+
+### Install caveat (important)
+`packages/expo-targets` has a `prepare` script that runs its build (`tsc`). A plain `bun install` therefore triggers that build. The update script uses `bun install --frozen-lockfile --ignore-scripts` specifically to skip that step so installs stay reliable — do not remove `--ignore-scripts` unless the build below is fixed. `tests/e2e` deps are installed separately (it is not part of the Bun workspaces).
+
+### Known pre-existing breakage on `main` (not an environment problem)
+CI is currently red on `main`. Root cause: `packages/expo-targets/src` references DOM globals (`window`/`document`/`navigator`, e.g. in `src/modules/safari/index.ts` and `src/Target.ts`) while `tsconfig.json` sets `lib: ["ES2020"]` (no `DOM`). Consequences, all stemming from this one issue:
+- `bun run typecheck` and `bun run build` fail on the `expo-targets` package. The other two packages (`create-expo-target`, `@expo-targets/cli`) build fine.
+- The `tests/e2e` workflow/managed/bare tests fail because they `npm install` the local `expo-targets` (re-triggering the failing `prepare`).
+Do not treat these as setup/dependency failures; they require a code/config fix by the maintainer.
+
+### What works on Linux
+- Lint: `bun run lint` (`biome lint .`) passes. Note the stricter CI variant `bunx biome ci . --error-on-warnings` reports a few pre-existing formatting diffs.
+- Tests: `bun test --cwd tests/e2e` — the config/target-type/api/metro/prebuild tests pass and do not need any build output. (One pre-existing `wallet: Bundle identifier suffix defined` assertion fails independently of setup.)
+- Scaffolding: the `create-expo-target` CLI (interactive via `prompts`) generates target files (`expo-target.config.json`, `index.ts`, Swift/Kotlin templates).
+
+### What requires macOS (cannot run on the Linux cloud VM)
+Building/running the example apps (`expo run:ios`) and the `tests/e2e` `compilation` + `runtime` suites need macOS + Xcode + CocoaPods + the iOS Simulator. These are out of reach on Linux.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Bun-based `expo-targets` monorepo on the Linux Cloud VM and documents how to work in it.

- Installs Bun (via `bun.sh`) alongside the pre-existing Node `>=22`.
- Configures the VM update script to install workspace deps reliably: `bun install --frozen-lockfile --ignore-scripts` (root) plus the same for `tests/e2e`. `--ignore-scripts` is required because `packages/expo-targets` has a `prepare` build that currently fails (see below), which would otherwise make `bun install` exit non-zero.
- Adds `AGENTS.md` with durable, non-obvious guidance for future agents.

No application code was modified.

## What works on Linux
- Lint: `bun run lint` (`biome lint .`) — passes.
- Build: `create-expo-target` and `@expo-targets/cli` packages build.
- Tests: `bun test --cwd tests/e2e` — the config/target-type/api/metro/prebuild tests pass (no build output needed).
- Hello-world: the `create-expo-target` CLI scaffolds a widget target end-to-end (README Quick Start step 3).

## Pre-existing breakage (not an environment issue)
CI is already red on `main`. `packages/expo-targets/src` references DOM globals (`window`/`document`/`navigator`) while `tsconfig.json` uses `lib: ["ES2020"]` (no `DOM`). This makes `bun run typecheck` / `bun run build` fail for the `expo-targets` package and cascades into the `tests/e2e` workflow/managed/bare tests (which `npm install` the local package and re-trigger the failing `prepare`). This needs a maintainer code/config fix and is out of scope for environment setup.

## macOS-only
Building/running the example apps (`expo run:ios`) and the `tests/e2e` `compilation`/`runtime` suites require macOS + Xcode + CocoaPods + iOS Simulator, which are unavailable on the Linux VM.

## Evidence
Lint / build / test:

[lint build test demo](https://cursor.com/agents/bc-8ccba12c-1c91-45c1-ac5a-45133e885cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_demo_lint_build_test.txt)

Hello-world scaffold:

[hello world scaffold](https://cursor.com/agents/bc-8ccba12c-1c91-45c1-ac5a-45133e885cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_scaffold.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ccba12c-1c91-45c1-ac5a-45133e885cad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ccba12c-1c91-45c1-ac5a-45133e885cad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

