### PR TITLE
feat(devicewright): iOS Simulator screen recording + frame viewing

### DIFF
--- a/packages/devicewright/README.md
+++ b/packages/devicewright/README.md
@@ -21,22 +21,44 @@ bun run --filter @expo-targets/devicewright doctor
 ## TypeScript
 
 ```ts
-import { devices } from '@expo-targets/devicewright';
+import { devices } from "@expo-targets/devicewright";
 
-const device = await devices.launch({ platform: 'ios', device: 'iPhone 16' });
-await device.launchApp('com.apple.Preferences');
-await device.getByText('General').tap();
-await device.screenshot({ path: 'settings.png' });
+const device = await devices.launch({ platform: "ios", device: "iPhone 16" });
+await device.launchApp("com.apple.Preferences");
+await device.getByText("General").tap();
+await device.screenshot({ path: "settings.png" });
 await device.close();
 ```
+
+### Screen recording (iOS Simulator)
+
+```ts
+await device.startRecording({ path: "flow.mp4" }); // optional maxSeconds
+// …interact…
+const videoPath = await device.stopRecording();
+const viewed = await device.viewRecording({ fps: 10, maxFrames: 60 });
+// viewed.frames[].t — seconds from start; thinned=true when long clip
+// zoom a 200ms slice at ~100ms spacing:
+const push = await device.viewRecording({
+  startSeconds: 12.0,
+  endSeconds: 12.2,
+  fps: 10,
+  maxFrames: 60,
+});
+await device.close(); // prefer stop_recording before close_device
+```
+
+**ffmpeg:** optional soft dependency. `record_video` / `stop_recording` use simctl only. `ui_view_recording` needs `ffmpeg` + `ffprobe` on PATH (`brew install ffmpeg`). `doctor` **warns** if missing — it does not fail the preflight. Frame JPEGs are deleted after MCP returns images; `.mp4` files stay in `os.tmpdir()` as `devicewright-*` (24h GC on close) unless you pass `output_path` / `path`.
+
+MCP: `record_video` → interact → `stop_recording` → `ui_view_recording` (`fps`, `max_frames`, optional `start_seconds` / `end_seconds`). Prefer `stop_recording` before `close_device` (force-close may SIGKILL and truncate). Android recording deferred. Manual Simulator demos are video/frames only — no gesture log.
 
 Cross-OS happy path (same script shape):
 
 ```ts
-const android = await devices.launch({ platform: 'android' });
-await android.launchApp('com.android.settings');
-await android.getByText('Settings').tap(); // or assert visible
-await android.screenshot({ path: 'android-settings.png' });
+const android = await devices.launch({ platform: "android" });
+await android.launchApp("com.android.settings");
+await android.getByText("Settings").tap(); // or assert visible
+await android.screenshot({ path: "android-settings.png" });
 await android.close();
 ```
 
@@ -66,7 +88,7 @@ Point Cursor at the workspace MCP (replaces `ios-simulator-mcp` after hardening)
 
 **Rollback:** restore `npx -y ios-simulator-mcp` (+ `IOS_SIMULATOR_MCP_IDB_PATH`).
 
-Tool names stay compatible with `ios-simulator-mcp` (`ui_tap`, `ui_describe_all`, `screenshot`, …) plus `doctor`, `list_booted_sims`, `close_device`, and optional `platform: android`.
+Tool names stay compatible with `ios-simulator-mcp` (`ui_tap`, `ui_describe_all`, `screenshot`, …) plus `doctor`, `list_booted_sims`, `close_device`, `record_video`, `stop_recording`, `ui_view_recording`, and optional `platform: android`.
 
 Local multi-sim smoke (two booted sims, not CI):
 
@@ -82,7 +104,7 @@ bun packages/devicewright/src/examples/parallel-sessions-smoke.ts
 
 ## Host claims (week-7 bar)
 
-Must keep: Share, Messages, Photos, SpringBoard, Settings, Safari.  
+Must keep: Share, Messages, Photos, SpringBoard, Settings, Safari.
 Cut first if behind: Wallet → App Clip → widgets → Stickers; Android hello-path cut if red.
 
 ```bash

--- a/packages/devicewright/src/android/driver.ts
+++ b/packages/devicewright/src/android/driver.ts
@@ -1,23 +1,25 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
-import { matchesAccessibilityCriteria } from '../a11yMatch';
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { matchesAccessibilityCriteria } from "../a11yMatch";
 import {
   assertSafeBundleId,
   assertSafeDeviceId,
   assertSafePath,
-} from '../allowlist';
-import { runSync, runSyncOrThrow } from '../exec';
+} from "../allowlist";
+import { runSync, runSyncOrThrow } from "../exec";
 import type {
   AccessibilityNode,
   DeviceDriver,
   DeviceKind,
   FindCriteria,
+  RecordVideoOptions,
+  RecordingHandle,
   ScreenshotOptions,
   SwipeOptions,
   TapOptions,
-} from '../types';
+} from "../types";
 
 export function getAdbBin(adbPath?: string): string {
   if (adbPath) return adbPath;
@@ -25,53 +27,53 @@ export function getAdbBin(adbPath?: string): string {
     return process.env.DEVICEWRIGHT_ADB_PATH;
   }
   if (process.env.ANDROID_HOME) {
-    return path.join(process.env.ANDROID_HOME, 'platform-tools', 'adb');
+    return path.join(process.env.ANDROID_HOME, "platform-tools", "adb");
   }
-  return 'adb';
+  return "adb";
 }
 
 export function adbAvailable(adbPath?: string): boolean {
   const bin = getAdbBin(adbPath);
-  return runSync(bin, ['version']).status === 0;
+  return runSync(bin, ["version"]).status === 0;
 }
 
 export function listDevices(
-  adbPath?: string
+  adbPath?: string,
 ): Array<{ serial: string; state: string }> {
-  const out = runSyncOrThrow(getAdbBin(adbPath), ['devices']);
+  const out = runSyncOrThrow(getAdbBin(adbPath), ["devices"]);
   return out
-    .split('\n')
+    .split("\n")
     .slice(1)
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
       const [serial, state] = line.split(/\s+/);
-      return { serial, state: state || 'unknown' };
+      return { serial, state: state || "unknown" };
     })
-    .filter((d) => d.serial && d.serial !== 'List');
+    .filter((d) => d.serial && d.serial !== "List");
 }
 
 export function resolveAndroidSerial(
   device?: string,
   deviceId?: string,
-  adbPath?: string
+  adbPath?: string,
 ): string {
   if (deviceId) return assertSafeDeviceId(deviceId);
-  const devices = listDevices(adbPath).filter((d) => d.state === 'device');
+  const devices = listDevices(adbPath).filter((d) => d.state === "device");
   if (device) {
     const match = devices.find(
-      (d) => d.serial === device || d.serial.includes(device)
+      (d) => d.serial === device || d.serial.includes(device),
     );
     if (match) return match.serial;
     throw new Error(`android device not found: ${device}`);
   }
   if (devices[0]) return devices[0].serial;
-  throw new Error('no android device/emulator connected');
+  throw new Error("no android device/emulator connected");
 }
 
 function adbSerial(serial: string, args: string[], adbPath?: string): string {
   return runSyncOrThrow(getAdbBin(adbPath), [
-    '-s',
+    "-s",
     assertSafeDeviceId(serial),
     ...args,
   ]);
@@ -80,10 +82,10 @@ function adbSerial(serial: string, args: string[], adbPath?: string): string {
 export function installApk(
   serial: string,
   apkPath: string,
-  adbPath?: string
+  adbPath?: string,
 ): void {
   const apk = assertSafePath(apkPath, { mustExist: true });
-  adbSerial(serial, ['install', '-r', apk], adbPath);
+  adbSerial(serial, ["install", "-r", apk], adbPath);
 }
 
 export function launchActivity(
@@ -93,39 +95,39 @@ export function launchActivity(
     activity?: string;
     terminateRunning?: boolean;
     adbPath?: string;
-  } = {}
+  } = {},
 ): void {
   const pkg = assertSafeBundleId(packageName);
   const adbPath = options.adbPath;
   if (options.terminateRunning) {
     runSync(getAdbBin(adbPath), [
-      '-s',
+      "-s",
       serial,
-      'shell',
-      'am',
-      'force-stop',
+      "shell",
+      "am",
+      "force-stop",
       pkg,
     ]);
   }
   if (options.activity) {
     adbSerial(
       serial,
-      ['shell', 'am', 'start', '-n', `${pkg}/${options.activity}`],
-      adbPath
+      ["shell", "am", "start", "-n", `${pkg}/${options.activity}`],
+      adbPath,
     );
   } else {
     adbSerial(
       serial,
       [
-        'shell',
-        'monkey',
-        '-p',
+        "shell",
+        "monkey",
+        "-p",
         pkg,
-        '-c',
-        'android.intent.category.LAUNCHER',
-        '1',
+        "-c",
+        "android.intent.category.LAUNCHER",
+        "1",
       ],
-      adbPath
+      adbPath,
     );
   }
 }
@@ -133,12 +135,12 @@ export function launchActivity(
 export function screenshotAdb(
   serial: string,
   outputPath: string,
-  adbPath?: string
+  adbPath?: string,
 ): string {
-  const remote = '/sdcard/devicewright-shot.png';
-  adbSerial(serial, ['shell', 'screencap', '-p', remote], adbPath);
+  const remote = "/sdcard/devicewright-shot.png";
+  adbSerial(serial, ["shell", "screencap", "-p", remote], adbPath);
   const out = path.resolve(outputPath);
-  adbSerial(serial, ['pull', remote, out], adbPath);
+  adbSerial(serial, ["pull", remote, out], adbPath);
   return out;
 }
 
@@ -150,10 +152,10 @@ function parseUiAutomatorXml(xml: string): AccessibilityNode[] {
     const attrs = m[1];
     const get = (name: string): string => {
       const am = attrs.match(new RegExp(`${name}="([^"]*)"`));
-      return am ? am[1] : '';
+      return am ? am[1] : "";
     };
-    const bounds = get('bounds');
-    let frame: AccessibilityNode['frame'];
+    const bounds = get("bounds");
+    let frame: AccessibilityNode["frame"];
     const bm = bounds.match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
     if (bm) {
       const x1 = Number(bm[1]);
@@ -163,10 +165,10 @@ function parseUiAutomatorXml(xml: string): AccessibilityNode[] {
       frame = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
     }
     nodes.push({
-      type: get('class'),
-      label: get('text') || get('content-desc'),
-      identifier: get('resource-id'),
-      value: get('text'),
+      type: get("class"),
+      label: get("text") || get("content-desc"),
+      identifier: get("resource-id"),
+      value: get("text"),
       frame,
       raw: attrs,
     });
@@ -175,52 +177,52 @@ function parseUiAutomatorXml(xml: string): AccessibilityNode[] {
 }
 
 export function dumpUi(serial: string, adbPath?: string): AccessibilityNode[] {
-  const remote = '/sdcard/devicewright-ui.xml';
-  adbSerial(serial, ['shell', 'uiautomator', 'dump', remote], adbPath);
+  const remote = "/sdcard/devicewright-ui.xml";
+  adbSerial(serial, ["shell", "uiautomator", "dump", remote], adbPath);
   const local = path.join(os.tmpdir(), `devicewright-ui-${serial}.xml`);
-  adbSerial(serial, ['pull', remote, local], adbPath);
-  return parseUiAutomatorXml(fs.readFileSync(local, 'utf8'));
+  adbSerial(serial, ["pull", remote, local], adbPath);
+  return parseUiAutomatorXml(fs.readFileSync(local, "utf8"));
 }
 
 export function tapAdb(
   serial: string,
   options: TapOptions,
-  adbPath?: string
+  adbPath?: string,
 ): void {
   adbSerial(
     serial,
-    ['shell', 'input', 'tap', String(options.x), String(options.y)],
-    adbPath
+    ["shell", "input", "tap", String(options.x), String(options.y)],
+    adbPath,
   );
 }
 
 export function typeAdb(serial: string, text: string, adbPath?: string): void {
   if (/[;&|`$]/.test(text)) {
-    throw new Error('android type rejects shell metacharacters');
+    throw new Error("android type rejects shell metacharacters");
   }
-  const escaped = text.replace(/ /g, '%s');
-  adbSerial(serial, ['shell', 'input', 'text', escaped], adbPath);
+  const escaped = text.replace(/ /g, "%s");
+  adbSerial(serial, ["shell", "input", "text", escaped], adbPath);
 }
 
 export function swipeAdb(
   serial: string,
   options: SwipeOptions,
-  adbPath?: string
+  adbPath?: string,
 ): void {
   const durationMs = Math.round((options.duration ?? 0.3) * 1000);
   adbSerial(
     serial,
     [
-      'shell',
-      'input',
-      'swipe',
+      "shell",
+      "input",
+      "swipe",
       String(options.xStart),
       String(options.yStart),
       String(options.xEnd),
       String(options.yEnd),
       String(durationMs),
     ],
-    adbPath
+    adbPath,
   );
 }
 
@@ -231,14 +233,14 @@ export type AndroidDriverOptions = {
 };
 
 export class AndroidDriver implements DeviceDriver {
-  readonly platform = 'android' as const;
+  readonly platform = "android" as const;
   readonly deviceId: string;
   readonly kind: DeviceKind;
   private readonly adbPath?: string;
 
   constructor(options: AndroidDriverOptions) {
     this.deviceId = options.deviceId;
-    this.kind = options.kind ?? 'emulator';
+    this.kind = options.kind ?? "emulator";
     this.adbPath = options.adbPath;
   }
 
@@ -248,7 +250,7 @@ export class AndroidDriver implements DeviceDriver {
 
   async launchApp(
     bundleId: string,
-    options?: { terminateRunning?: boolean }
+    options?: { terminateRunning?: boolean },
   ): Promise<void> {
     launchActivity(this.deviceId, bundleId, {
       ...options,
@@ -261,6 +263,20 @@ export class AndroidDriver implements DeviceDriver {
       options?.path ??
       path.join(os.tmpdir(), `devicewright-android-${Date.now()}.png`);
     return screenshotAdb(this.deviceId, out, this.adbPath);
+  }
+
+  async startRecording(
+    _options?: RecordVideoOptions,
+  ): Promise<RecordingHandle> {
+    throw new Error(
+      "Android screen recording is not supported yet in Devicewright (deferred). Use platform: ios.",
+    );
+  }
+
+  async stopRecording(): Promise<string> {
+    throw new Error(
+      "Android screen recording is not supported yet in Devicewright (deferred). Use platform: ios.",
+    );
   }
 
   async accessibilityTree(): Promise<AccessibilityNode[]> {

--- a/packages/devicewright/src/doctor.ts
+++ b/packages/devicewright/src/doctor.ts
@@ -1,9 +1,9 @@
-import process from 'node:process';
-import { adbAvailable, getAdbBin, listDevices } from './android';
-import { runSync } from './exec';
-import { idbAvailable } from './ios/idb';
-import { listSimulators } from './ios/simctl';
-import type { DoctorCheck } from './types';
+import process from "node:process";
+import { adbAvailable, getAdbBin, listDevices } from "./android";
+import { runSync } from "./exec";
+import { idbAvailable } from "./ios/idb";
+import { listSimulators } from "./ios/simctl";
+import type { DoctorCheck } from "./types";
 
 export type DoctorReport = {
   ok: boolean;
@@ -11,37 +11,37 @@ export type DoctorReport = {
 };
 
 function checkXcode(): DoctorCheck {
-  const xcode = runSync('xcodebuild', ['-version']);
+  const xcode = runSync("xcodebuild", ["-version"]);
   return {
-    name: 'xcode',
+    name: "xcode",
     ok: xcode.status === 0,
     detail:
       xcode.status === 0
-        ? xcode.stdout.trim().split('\n')[0] || 'ok'
-        : xcode.stderr || 'xcodebuild not found (macOS only)',
+        ? xcode.stdout.trim().split("\n")[0] || "ok"
+        : xcode.stderr || "xcodebuild not found (macOS only)",
   };
 }
 
 function checkSimctl(): DoctorCheck {
-  const simctl = runSync('xcrun', ['simctl', 'help']);
+  const simctl = runSync("xcrun", ["simctl", "help"]);
   return {
-    name: 'simctl',
+    name: "simctl",
     ok: simctl.status === 0,
-    detail: simctl.status === 0 ? 'ok' : 'xcrun simctl unavailable',
+    detail: simctl.status === 0 ? "ok" : "xcrun simctl unavailable",
   };
 }
 
 function checkSimulators(): DoctorCheck {
   try {
     const sims = listSimulators();
-    const booted = sims.filter((s) => s.state === 'Booted');
+    const booted = sims.filter((s) => s.state === "Booted");
     return {
-      name: 'simulators',
+      name: "simulators",
       ok: true,
       detail: `${sims.length} sims, ${booted.length} booted`,
     };
   } catch (e) {
-    return { name: 'simulators', ok: false, detail: String(e) };
+    return { name: "simulators", ok: false, detail: String(e) };
   }
 }
 
@@ -51,22 +51,22 @@ function checkIdb(idbPath?: string): DoctorCheck {
     idbPath ||
     process.env.DEVICEWRIGHT_IDB_PATH ||
     process.env.IOS_SIMULATOR_MCP_IDB_PATH ||
-    'idb';
+    "idb";
   return {
-    name: 'idb',
+    name: "idb",
     ok: idbOk,
     detail: idbOk
       ? `found (${resolved})`
-      : 'idb not found — set DEVICEWRIGHT_IDB_PATH or IOS_SIMULATOR_MCP_IDB_PATH',
+      : "idb not found — set DEVICEWRIGHT_IDB_PATH or IOS_SIMULATOR_MCP_IDB_PATH",
   };
 }
 
 function checkAdb(
   adbPath: string | undefined,
-  requireAndroid: boolean
+  requireAndroid: boolean,
 ): DoctorCheck {
   const adbOk = adbAvailable(adbPath);
-  let detail = adbOk ? `found (${getAdbBin(adbPath)})` : 'adb not found';
+  let detail = adbOk ? `found (${getAdbBin(adbPath)})` : "adb not found";
   if (adbOk) {
     try {
       detail += `; ${listDevices(adbPath).length} device(s)`;
@@ -75,14 +75,32 @@ function checkAdb(
     }
   }
   return {
-    name: 'adb',
+    name: "adb",
     ok: requireAndroid ? adbOk : true,
     detail,
   };
 }
 
+function checkFfmpeg(): DoctorCheck {
+  const ffmpeg = runSync("ffmpeg", ["-version"]);
+  const ffprobe = runSync("ffprobe", ["-version"]);
+  const okTools = ffmpeg.status === 0 && ffprobe.status === 0;
+  return {
+    name: "ffmpeg",
+    // Warn-only: missing ffmpeg does not fail doctor.ok (record/stop work without it).
+    ok: true,
+    detail: okTools
+      ? "found (needed for ui_view_recording)"
+      : "WARN missing — record/stop work; ui_view_recording needs ffmpeg+ffprobe",
+  };
+}
+
 export function runDoctor(
-  options: { idbPath?: string; adbPath?: string; requireAndroid?: boolean } = {}
+  options: {
+    idbPath?: string;
+    adbPath?: string;
+    requireAndroid?: boolean;
+  } = {},
 ): DoctorReport {
   const checks: DoctorCheck[] = [
     checkXcode(),
@@ -90,14 +108,15 @@ export function runDoctor(
     checkSimulators(),
     checkIdb(options.idbPath),
     checkAdb(options.adbPath, options.requireAndroid === true),
+    checkFfmpeg(),
   ];
   return { ok: checks.every((c) => c.ok), checks };
 }
 
 export function formatDoctor(report: DoctorReport): string {
   const lines = report.checks.map(
-    (c) => `${c.ok ? 'PASS' : 'FAIL'}  ${c.name}: ${c.detail}`
+    (c) => `${c.ok ? "PASS" : "FAIL"}  ${c.name}: ${c.detail}`,
   );
-  lines.push(report.ok ? '\nDoctor OK' : '\nDoctor FAILED');
-  return lines.join('\n');
+  lines.push(report.ok ? "\nDoctor OK" : "\nDoctor FAILED");
+  return lines.join("\n");
 }

--- a/packages/devicewright/src/index.ts
+++ b/packages/devicewright/src/index.ts
@@ -1,4 +1,4 @@
-export * as android from './android';
+export * as android from "./android";
 export {
   applyCuts,
   type ClaimState,
@@ -7,14 +7,14 @@ export {
   type HostClaim,
   type HostId,
   mustKeepHosts,
-} from './claims';
-export { devices } from './devices';
-export { type DoctorReport, formatDoctor, runDoctor } from './doctor';
-export * as ios from './ios';
-export { simctl as iosSimctl } from './ios';
-export { Locator } from './locator';
-export { acquireDeviceLock, acquireSimLock, type LockHandle } from './lock';
-export { createDevicewrightMcpServer, startMcpStdio } from './mcp/server';
+} from "./claims";
+export { devices } from "./devices";
+export { type DoctorReport, formatDoctor, runDoctor } from "./doctor";
+export * as ios from "./ios";
+export { simctl as iosSimctl } from "./ios";
+export { Locator } from "./locator";
+export { acquireDeviceLock, acquireSimLock, type LockHandle } from "./lock";
+export { createDevicewrightMcpServer, startMcpStdio } from "./mcp/server";
 export {
   type CloudDeviceAdapter,
   getCloudAdapter,
@@ -25,18 +25,28 @@ export {
   physicalLaunchOptions,
   registerCloudAdapter,
   runOnDevices,
-} from './scale';
-export { DeviceSession } from './session';
+} from "./scale";
+export { DeviceSession } from "./session";
 export type {
   AccessibilityNode,
   DeviceDriver,
   DeviceKind,
   DoctorCheck,
+  ExtractedFrame,
   FindCriteria,
   LaunchOptions,
   Platform,
+  RecordingHandle,
+  RecordVideoOptions,
   ScreenshotOptions,
   SwipeOptions,
   TapOptions,
   TraceStep,
-} from './types';
+  ViewRecordingOptions,
+  ViewRecordingResult,
+} from "./types";
+export {
+  computeFrameTimestamps,
+  extractFrames,
+  gcDevicewrightTemp,
+} from "./media";

--- a/packages/devicewright/src/ios/driver.ts
+++ b/packages/devicewright/src/ios/driver.ts
@@ -1,19 +1,22 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import type { ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { assertSafeBundleId, assertSafePath } from '../allowlist';
+import { assertSafeBundleId, assertSafePath } from "../allowlist";
 import type {
   AccessibilityNode,
   DeviceDriver,
   DeviceKind,
   FindCriteria,
+  RecordVideoOptions,
+  RecordingHandle,
   ScreenshotOptions,
   SwipeOptions,
   TapOptions,
-} from '../types';
-import * as idb from './idb';
-import * as simctl from './simctl';
+} from "../types";
+import * as idb from "./idb";
+import * as simctl from "./simctl";
 
 export type IosDriverOptions = {
   deviceId: string;
@@ -21,20 +24,30 @@ export type IosDriverOptions = {
   idbPath?: string;
 };
 
+type ActiveRecording = {
+  child: ChildProcess;
+  path: string;
+  startedAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  finalized: boolean;
+};
+
 export class IosDriver implements DeviceDriver {
-  readonly platform = 'ios' as const;
+  readonly platform = "ios" as const;
   readonly deviceId: string;
   readonly kind: DeviceKind;
   private readonly idbPath?: string;
+  private recording: ActiveRecording | null = null;
+  private lastFinalizedPath: string | null = null;
 
   constructor(options: IosDriverOptions) {
     this.deviceId = options.deviceId;
-    this.kind = options.kind ?? 'simulator';
+    this.kind = options.kind ?? "simulator";
     this.idbPath = options.idbPath;
   }
 
   async boot(): Promise<void> {
-    if (this.kind === 'simulator') {
+    if (this.kind === "simulator") {
       simctl.bootSimulator(this.deviceId);
     }
     // physical: assume already paired / trusted
@@ -42,25 +55,25 @@ export class IosDriver implements DeviceDriver {
 
   async install(appPath: string): Promise<void> {
     const app = assertSafePath(appPath, { mustExist: true });
-    if (this.kind === 'simulator') {
+    if (this.kind === "simulator") {
       simctl.installApp(this.deviceId, app);
       return;
     }
     throw new Error(
-      'physical install via Devicewright uses usbmux/ideviceinstaller — wire in Phase 4 deepen'
+      "physical install via Devicewright uses usbmux/ideviceinstaller — wire in Phase 4 deepen",
     );
   }
 
   async launchApp(
     bundleId: string,
-    options?: { terminateRunning?: boolean }
+    options?: { terminateRunning?: boolean },
   ): Promise<void> {
     const id = assertSafeBundleId(bundleId);
-    if (this.kind === 'simulator') {
+    if (this.kind === "simulator") {
       simctl.launchApp(this.deviceId, id, options);
       return;
     }
-    throw new Error('physical launchApp deepen in Phase 4');
+    throw new Error("physical launchApp deepen in Phase 4");
   }
 
   async terminateApp(bundleId: string): Promise<void> {
@@ -71,10 +84,91 @@ export class IosDriver implements DeviceDriver {
     const out =
       options?.path ??
       path.join(os.tmpdir(), `devicewright-${this.deviceId}-${Date.now()}.png`);
-    if (this.kind === 'simulator') {
+    if (this.kind === "simulator") {
       return simctl.screenshotSim(this.deviceId, out);
     }
-    throw new Error('physical screenshot deepen in Phase 4');
+    throw new Error("physical screenshot deepen in Phase 4");
+  }
+
+  async startRecording(
+    options: RecordVideoOptions = {},
+  ): Promise<RecordingHandle> {
+    if (this.kind !== "simulator") {
+      throw new Error("physical recordVideo deepen in Phase 4");
+    }
+    if (this.recording && !this.recording.finalized) {
+      throw new Error(
+        `recording already in progress on ${this.deviceId}: ${this.recording.path}`,
+      );
+    }
+    this.lastFinalizedPath = null;
+    const out =
+      options.path ??
+      path.join(os.tmpdir(), `devicewright-${this.deviceId}-${Date.now()}.mp4`);
+    const startedAt = Date.now();
+    const { child, path: filePath } = simctl.recordVideoStart(
+      this.deviceId,
+      out,
+      { codec: options.codec, force: true },
+    );
+
+    const active: ActiveRecording = {
+      child,
+      path: filePath,
+      startedAt,
+      timer: null,
+      finalized: false,
+    };
+    this.recording = active;
+
+    if (options.maxSeconds !== undefined) {
+      if (!Number.isFinite(options.maxSeconds) || options.maxSeconds <= 0) {
+        await this.finalizeRecording("error");
+        throw new Error(`invalid maxSeconds: ${options.maxSeconds}`);
+      }
+      active.timer = setTimeout(() => {
+        void this.finalizeRecording("timer");
+      }, options.maxSeconds * 1000);
+      active.timer.unref?.();
+    }
+
+    return { path: filePath, startedAt };
+  }
+
+  async stopRecording(): Promise<string> {
+    if (!this.recording || this.recording.finalized) {
+      if (this.lastFinalizedPath) return this.lastFinalizedPath;
+      throw new Error("no active recording to stop");
+    }
+    return this.finalizeRecording("stop");
+  }
+
+  private async finalizeRecording(
+    reason: "stop" | "timer" | "close" | "error",
+  ): Promise<string> {
+    const active = this.recording;
+    if (!active) {
+      if (this.lastFinalizedPath) return this.lastFinalizedPath;
+      throw new Error("no active recording to stop");
+    }
+    if (active.finalized) {
+      return active.path;
+    }
+    active.finalized = true;
+    if (active.timer) {
+      clearTimeout(active.timer);
+      active.timer = null;
+    }
+    try {
+      await simctl.stopRecording(active.child);
+      if (reason !== "error") {
+        simctl.assertRecordingFile(active.path);
+      }
+      this.lastFinalizedPath = active.path;
+      return active.path;
+    } finally {
+      this.recording = null;
+    }
   }
 
   async accessibilityTree(): Promise<AccessibilityNode[]> {
@@ -108,11 +202,21 @@ export class IosDriver implements DeviceDriver {
 
   async viewCompressed(): Promise<Buffer> {
     const p = await this.screenshot();
-    const file = typeof p === 'string' ? p : null;
+    const file = typeof p === "string" ? p : null;
     if (!file) return p as Buffer;
     return fs.readFileSync(file);
   }
+
+  async close(): Promise<void> {
+    if (this.recording && !this.recording.finalized) {
+      try {
+        await this.finalizeRecording("close");
+      } catch {
+        // best-effort
+      }
+    }
+  }
 }
 
-export * as idb from './idb';
-export * as simctl from './simctl';
+export * as idb from "./idb";
+export * as simctl from "./simctl";

--- a/packages/devicewright/src/ios/idb.ts
+++ b/packages/devicewright/src/ios/idb.ts
@@ -1,14 +1,14 @@
-import type { ChildProcess } from 'node:child_process';
-import process from 'node:process';
-import { matchesAccessibilityCriteria } from '../a11yMatch';
-import { assertSafeDeviceId } from '../allowlist';
-import { runAsync, runSync, runSyncOrThrow } from '../exec';
+import type { ChildProcess } from "node:child_process";
+import process from "node:process";
+import { matchesAccessibilityCriteria } from "../a11yMatch";
+import { assertSafeDeviceId } from "../allowlist";
+import { runAsync, runSync, runSyncOrThrow } from "../exec";
 import type {
   AccessibilityNode,
   FindCriteria,
   SwipeOptions,
   TapOptions,
-} from '../types';
+} from "../types";
 
 export type IdbRunOptions = {
   idbPath?: string;
@@ -21,10 +21,22 @@ export type IdbRunOptions = {
 /** Optional MCP registry hook — killable children for force-close. */
 let childTracker: ((udid: string, child: ChildProcess) => void) | null = null;
 
-export function setIdbChildTracker(
-  tracker: ((udid: string, child: ChildProcess) => void) | null
+/** Register a device-scoped child (IDB, simctl recordVideo, …) for force-close. */
+export function setDeviceChildTracker(
+  tracker: ((udid: string, child: ChildProcess) => void) | null,
 ): void {
   childTracker = tracker;
+}
+
+/** @deprecated Prefer setDeviceChildTracker */
+export function setIdbChildTracker(
+  tracker: ((udid: string, child: ChildProcess) => void) | null,
+): void {
+  setDeviceChildTracker(tracker);
+}
+
+export function notifyDeviceChild(udid: string, child: ChildProcess): void {
+  childTracker?.(udid, child);
 }
 
 function resolveIdb(idbPath?: string): string {
@@ -32,7 +44,7 @@ function resolveIdb(idbPath?: string): string {
     idbPath ||
     process.env.DEVICEWRIGHT_IDB_PATH ||
     process.env.IOS_SIMULATOR_MCP_IDB_PATH ||
-    'idb'
+    "idb"
   );
 }
 
@@ -42,25 +54,25 @@ function intCoord(n: number): string {
 
 function idbSync(
   args: string[],
-  options: { idbPath?: string; udid?: string } = {}
+  options: { idbPath?: string; udid?: string } = {},
 ): string {
   const bin = resolveIdb(options.idbPath);
   const full = [...args];
   if (options.udid) {
-    full.push('--udid', assertSafeDeviceId(options.udid));
+    full.push("--udid", assertSafeDeviceId(options.udid));
   }
   return runSyncOrThrow(bin, full);
 }
 
 async function idbAsync(
   args: string[],
-  options: IdbRunOptions = {}
+  options: IdbRunOptions = {},
 ): Promise<string> {
   const bin = resolveIdb(options.idbPath);
   const full = [...args];
   const udid = options.udid ? assertSafeDeviceId(options.udid) : undefined;
   if (udid) {
-    full.push('--udid', udid);
+    full.push("--udid", udid);
   }
   const result = await runAsync(bin, full, {
     signal: options.signal,
@@ -72,9 +84,9 @@ async function idbAsync(
   });
   if (result.status !== 0) {
     throw new Error(
-      `${bin} ${full.join(' ')} failed (${result.status}): ${
-        result.stderr || result.stdout || 'unknown'
-      }`
+      `${bin} ${full.join(" ")} failed (${result.status}): ${
+        result.stderr || result.stdout || "unknown"
+      }`,
     );
   }
   return result.stdout;
@@ -82,9 +94,9 @@ async function idbAsync(
 
 export function idbAvailable(idbPath?: string): boolean {
   const bin = resolveIdb(idbPath);
-  const which = runSync('which', [bin]);
+  const which = runSync("which", [bin]);
   if (which.status === 0) return true;
-  const help = runSync(bin, ['--help']);
+  const help = runSync(bin, ["--help"]);
   return help.status === 0 || help.stdout.length > 0 || help.stderr.length > 0;
 }
 
@@ -94,30 +106,30 @@ function parseDescribeAll(raw: string): AccessibilityNode[] {
     if (Array.isArray(parsed)) {
       return parsed.map(normalizeNode);
     }
-    if (parsed && typeof parsed === 'object') {
+    if (parsed && typeof parsed === "object") {
       return [normalizeNode(parsed)];
     }
   } catch {
     // idb sometimes returns non-JSON — wrap as raw
   }
-  return [{ type: 'Raw', value: raw.slice(0, 2000), raw }];
+  return [{ type: "Raw", value: raw.slice(0, 2000), raw }];
 }
 
 function pickString(
   o: Record<string, unknown>,
-  keys: string[]
+  keys: string[],
 ): string | undefined {
   for (const key of keys) {
     const v = o[key];
-    if (typeof v === 'string' || typeof v === 'number') {
+    if (typeof v === "string" || typeof v === "number") {
       return String(v);
     }
   }
 }
 
 function normalizeFrame(
-  frameRaw: Record<string, number> | undefined
-): AccessibilityNode['frame'] {
+  frameRaw: Record<string, number> | undefined,
+): AccessibilityNode["frame"] {
   if (!frameRaw) return;
   return {
     x: Number(frameRaw.x ?? frameRaw.X ?? 0),
@@ -128,7 +140,7 @@ function normalizeFrame(
 }
 
 function normalizeNode(input: unknown): AccessibilityNode {
-  if (!input || typeof input !== 'object') {
+  if (!input || typeof input !== "object") {
     return { raw: input };
   }
   const o = input as Record<string, unknown>;
@@ -137,10 +149,10 @@ function normalizeNode(input: unknown): AccessibilityNode {
     | undefined;
   const childrenRaw = (o.children ?? o.AXChildren) as unknown[] | undefined;
   return {
-    type: pickString(o, ['type', 'role', 'AXRole']) ?? '',
-    label: pickString(o, ['label', 'AXLabel', 'name']) ?? '',
-    value: pickString(o, ['value', 'AXValue']),
-    identifier: pickString(o, ['identifier', 'AXUniqueId']),
+    type: pickString(o, ["type", "role", "AXRole"]) ?? "",
+    label: pickString(o, ["label", "AXLabel", "name"]) ?? "",
+    value: pickString(o, ["value", "AXValue"]),
+    identifier: pickString(o, ["identifier", "AXUniqueId"]),
     frame: normalizeFrame(frameRaw),
     children: Array.isArray(childrenRaw)
       ? childrenRaw.map(normalizeNode)
@@ -151,9 +163,9 @@ function normalizeNode(input: unknown): AccessibilityNode {
 
 export async function describeAll(
   udid: string,
-  options: IdbRunOptions = {}
+  options: IdbRunOptions = {},
 ): Promise<AccessibilityNode[]> {
-  const raw = await idbAsync(['ui', 'describe-all'], { ...options, udid });
+  const raw = await idbAsync(["ui", "describe-all"], { ...options, udid });
   return parseDescribeAll(raw);
 }
 
@@ -167,14 +179,14 @@ export async function describePoint(options: {
   timeoutMs?: number;
 }): Promise<AccessibilityNode | null> {
   const raw = await idbAsync(
-    ['ui', 'describe-point', intCoord(options.x), intCoord(options.y)],
+    ["ui", "describe-point", intCoord(options.x), intCoord(options.y)],
     {
       idbPath: options.idbPath,
       udid: options.udid,
       signal: options.signal,
       onSpawn: options.onSpawn,
       timeoutMs: options.timeoutMs,
-    }
+    },
   );
   const nodes = parseDescribeAll(raw);
   return nodes[0] ?? null;
@@ -182,11 +194,11 @@ export async function describePoint(options: {
 
 export async function tap(
   udid: string,
-  options: TapOptions & IdbRunOptions
+  options: TapOptions & IdbRunOptions,
 ): Promise<void> {
-  const args = ['ui', 'tap', intCoord(options.x), intCoord(options.y)];
+  const args = ["ui", "tap", intCoord(options.x), intCoord(options.y)];
   if (options.duration !== undefined) {
-    args.push('--duration', String(options.duration));
+    args.push("--duration", String(options.duration));
   }
   await idbAsync(args, { ...options, udid });
 }
@@ -194,31 +206,31 @@ export async function tap(
 export async function typeText(
   udid: string,
   text: string,
-  options: IdbRunOptions = {}
+  options: IdbRunOptions = {},
 ): Promise<void> {
   if (!/^[\x20-\x7E]*$/.test(text)) {
-    throw new Error('ui type supports ASCII printable characters only');
+    throw new Error("ui type supports ASCII printable characters only");
   }
-  await idbAsync(['ui', 'text', text], { ...options, udid });
+  await idbAsync(["ui", "text", text], { ...options, udid });
 }
 
 export async function swipe(
   udid: string,
-  options: SwipeOptions & IdbRunOptions
+  options: SwipeOptions & IdbRunOptions,
 ): Promise<void> {
   const args = [
-    'ui',
-    'swipe',
+    "ui",
+    "swipe",
     intCoord(options.xStart),
     intCoord(options.yStart),
     intCoord(options.xEnd),
     intCoord(options.yEnd),
   ];
   if (options.duration !== undefined) {
-    args.push('--duration', String(options.duration));
+    args.push("--duration", String(options.duration));
   }
   if (options.delta !== undefined) {
-    args.push('--delta', String(options.delta));
+    args.push("--delta", String(options.delta));
   }
   await idbAsync(args, { ...options, udid });
 }
@@ -236,18 +248,18 @@ function flatten(nodes: AccessibilityNode[]): AccessibilityNode[] {
 export async function findElements(
   udid: string,
   criteria: FindCriteria,
-  options: IdbRunOptions = {}
+  options: IdbRunOptions = {},
 ): Promise<AccessibilityNode[]> {
   return flatten(await describeAll(udid, options)).filter((node) =>
-    matchesAccessibilityCriteria(node, criteria)
+    matchesAccessibilityCriteria(node, criteria),
   );
 }
 
 /** Sync helpers kept for non-UI / doctor paths that need immediate argv. */
 export function describeAllSync(
   udid: string,
-  options: { idbPath?: string } = {}
+  options: { idbPath?: string } = {},
 ): AccessibilityNode[] {
-  const raw = idbSync(['ui', 'describe-all'], { ...options, udid });
+  const raw = idbSync(["ui", "describe-all"], { ...options, udid });
   return parseDescribeAll(raw);
 }

--- a/packages/devicewright/src/ios/index.ts
+++ b/packages/devicewright/src/ios/index.ts
@@ -1,3 +1,8 @@
-export { IosDriver, type IosDriverOptions } from './driver';
-export * as idb from './idb';
-export * as simctl from './simctl';
+export { IosDriver, type IosDriverOptions } from "./driver";
+export * as idb from "./idb";
+export {
+  setDeviceChildTracker,
+  setIdbChildTracker,
+  notifyDeviceChild,
+} from "./idb";
+export * as simctl from "./simctl";

--- a/packages/devicewright/src/ios/simctl.ts
+++ b/packages/devicewright/src/ios/simctl.ts
@@ -1,10 +1,14 @@
-import process from 'node:process';
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import process from "node:process";
 import {
   assertSafeDeviceId,
   assertSafeOutputPath,
   assertSafePath,
-} from '../allowlist';
-import { runSync, runSyncOrThrow } from '../exec';
+} from "../allowlist";
+import { runSync, runSyncOrThrow } from "../exec";
+import { notifyDeviceChild } from "./idb";
 
 export type SimDevice = {
   udid: string;
@@ -15,11 +19,11 @@ export type SimDevice = {
 };
 
 function simctl(args: string[]): string {
-  return runSyncOrThrow('xcrun', ['simctl', ...args]);
+  return runSyncOrThrow("xcrun", ["simctl", ...args]);
 }
 
 export function listSimulators(): SimDevice[] {
-  const raw = simctl(['list', 'devices', '-j']);
+  const raw = simctl(["list", "devices", "-j"]);
   const json = JSON.parse(raw) as {
     devices?: Record<
       string,
@@ -51,16 +55,16 @@ export function resolveSimulatorId(device?: string, deviceId?: string): string {
     return assertSafeDeviceId(deviceId);
   }
   if (!device) {
-    const booted = listSimulators().find((d) => d.state === 'Booted');
+    const booted = listSimulators().find((d) => d.state === "Booted");
     if (booted) return booted.udid;
-    throw new Error('no device specified and no booted simulator');
+    throw new Error("no device specified and no booted simulator");
   }
   const safe = device.trim();
   const all = listSimulators();
   const byUdid = all.find((d) => d.udid === safe);
   if (byUdid) return byUdid.udid;
   const byName = all.filter((d) => d.name === safe || d.name.includes(safe));
-  const booted = byName.find((d) => d.state === 'Booted');
+  const booted = byName.find((d) => d.state === "Booted");
   if (booted) return booted.udid;
   if (byName[0]) return byName[0].udid;
   throw new Error(`simulator not found: ${device}`);
@@ -71,76 +75,152 @@ export function assertSimulatorExists(udid: string): void {
   const found = listSimulators().some((d) => d.udid === id);
   if (!found) {
     throw new Error(
-      `simulator UDID ${id} not found. Boot/create it or pass a valid deviceId.`
+      `simulator UDID ${id} not found. Boot/create it or pass a valid deviceId.`,
     );
   }
 }
 
 export function bootSimulator(udid: string): void {
   const id = assertSafeDeviceId(udid);
-  runSync('xcrun', ['simctl', 'boot', id]);
-  const status = runSync('xcrun', ['simctl', 'bootstatus', id, '-b'], {
+  runSync("xcrun", ["simctl", "boot", id]);
+  const status = runSync("xcrun", ["simctl", "bootstatus", id, "-b"], {
     timeout: 120_000,
   });
   if (status.status !== 0) {
     throw new Error(
-      `simulator ${id} failed to become ready: ${status.stderr || status.stdout}`
+      `simulator ${id} failed to become ready: ${status.stderr || status.stdout}`,
     );
   }
 }
 
 export function openSimulatorApp(): void {
-  runSync('open', ['-a', 'Simulator']);
+  runSync("open", ["-a", "Simulator"]);
 }
 
 export function screenshotSim(udid: string, outputPath: string): string {
   const id = assertSafeDeviceId(udid);
   const out = assertSafeOutputPath(outputPath);
-  simctl(['io', id, 'screenshot', out]);
+  simctl(["io", id, "screenshot", out]);
   return out;
 }
 
 export function installApp(udid: string, appPath: string): void {
   const id = assertSafeDeviceId(udid);
   const app = assertSafePath(appPath, { mustExist: true });
-  simctl(['install', id, app]);
+  simctl(["install", id, app]);
 }
 
 export function launchApp(
   udid: string,
   bundleId: string,
-  options: { terminateRunning?: boolean; env?: Record<string, string> } = {}
+  options: { terminateRunning?: boolean; env?: Record<string, string> } = {},
 ): void {
   const id = assertSafeDeviceId(udid);
   if (options.terminateRunning) {
-    runSync('xcrun', ['simctl', 'terminate', id, bundleId]);
+    runSync("xcrun", ["simctl", "terminate", id, bundleId]);
   }
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const [k, v] of Object.entries(options.env ?? {})) {
     env[`SIMCTL_CHILD_${k}`] = v;
   }
-  runSyncOrThrow('xcrun', ['simctl', 'launch', id, bundleId], { env });
+  runSyncOrThrow("xcrun", ["simctl", "launch", id, bundleId], { env });
 }
 
 export function terminateApp(udid: string, bundleId: string): void {
-  runSync('xcrun', ['simctl', 'terminate', assertSafeDeviceId(udid), bundleId]);
+  runSync("xcrun", ["simctl", "terminate", assertSafeDeviceId(udid), bundleId]);
 }
 
+export type RecordVideoStartOptions = {
+  codec?: "h264" | "hevc";
+  force?: boolean;
+  onSpawn?: (child: ChildProcess) => void;
+};
+
+export type RecordVideoProcess = {
+  child: ChildProcess;
+  path: string;
+};
+
+/**
+ * Start simulator screen recording (long-lived child). Does not await exit.
+ * Stop with stopRecording(child).
+ */
 export function recordVideoStart(
   udid: string,
   outputPath: string,
-  options: { codec?: 'h264' | 'hevc'; force?: boolean } = {}
-): void {
+  options: RecordVideoStartOptions = {},
+): RecordVideoProcess {
   const id = assertSafeDeviceId(udid);
   const out = assertSafeOutputPath(outputPath);
-  const args = ['io', id, 'recordVideo'];
+  const args = ["simctl", "io", id, "recordVideo"];
   if (options.codec) args.push(`--codec=${options.codec}`);
-  if (options.force) args.push('--force');
+  if (options.force !== false) args.push("--force");
   args.push(out);
-  // Fire-and-forget recording is managed externally; sync start check only.
-  runSync('xcrun', ['simctl', ...args]);
+
+  const child = spawn("xcrun", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+  });
+  notifyDeviceChild(id, child);
+  options.onSpawn?.(child);
+  return { child, path: out };
 }
 
-export function stopRecording(): void {
-  runSync('killall', ['simctl']);
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+function waitForClose(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<"closed" | "timeout"> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve("closed");
+      return;
+    }
+    let settled = false;
+    const done = (result: "closed" | "timeout") => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.removeListener("close", onClose);
+      resolve(result);
+    };
+    const onClose = () => done("closed");
+    const timer = setTimeout(() => done("timeout"), timeoutMs);
+    child.once("close", onClose);
+  });
+}
+
+/**
+ * Graceful stop: SIGINT, await close; escalate to SIGKILL after timeoutMs.
+ */
+export async function stopRecording(
+  child: ChildProcess,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      child.kill("SIGINT");
+    } catch {
+      // ignore
+    }
+  }
+  const first = await waitForClose(child, timeoutMs);
+  if (first === "timeout") {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // ignore
+    }
+    await waitForClose(child, timeoutMs);
+  }
+}
+
+export function assertRecordingFile(outputPath: string): string {
+  const out = assertSafeOutputPath(outputPath);
+  if (!fs.existsSync(out)) {
+    throw new Error(`recording file missing after stop: ${out}`);
+  }
+  return out;
 }

--- a/packages/devicewright/src/locator.test.ts
+++ b/packages/devicewright/src/locator.test.ts
@@ -1,29 +1,35 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from "bun:test";
 
-import { Locator } from './locator';
+import { Locator } from "./locator";
 import type {
   AccessibilityNode,
   DeviceDriver,
   FindCriteria,
   TapOptions,
-} from './types';
+} from "./types";
 
 function fakeDriver(nodes: AccessibilityNode[]): DeviceDriver {
   return {
-    platform: 'ios',
-    deviceId: 'fake',
-    kind: 'simulator',
+    platform: "ios",
+    deviceId: "fake",
+    kind: "simulator",
     async install() {},
     async launchApp() {},
     async screenshot() {
-      return Buffer.from('');
+      return Buffer.from("");
+    },
+    async startRecording() {
+      return { path: "/tmp/fake.mp4", startedAt: Date.now() };
+    },
+    async stopRecording() {
+      return "/tmp/fake.mp4";
     },
     async accessibilityTree() {
       return nodes;
     },
     async findElements(criteria: FindCriteria) {
       return nodes.filter((n) =>
-        criteria.search.some((s) => (n.label ?? '').includes(s))
+        criteria.search.some((s) => (n.label ?? "").includes(s)),
       );
     },
     async tap(_options: TapOptions) {},
@@ -32,29 +38,29 @@ function fakeDriver(nodes: AccessibilityNode[]): DeviceDriver {
   };
 }
 
-describe('Locator', () => {
-  test('taps center of matching frame', async () => {
+describe("Locator", () => {
+  test("taps center of matching frame", async () => {
     const taps: TapOptions[] = [];
     const driver = fakeDriver([
       {
-        type: 'Button',
-        label: 'Share',
+        type: "Button",
+        label: "Share",
         frame: { x: 10, y: 20, width: 100, height: 40 },
       },
     ]);
     driver.tap = async (o) => {
       taps.push(o);
     };
-    const loc = new Locator(driver, { search: ['Share'] }, { timeoutMs: 500 });
+    const loc = new Locator(driver, { search: ["Share"] }, { timeoutMs: 500 });
     await loc.tap();
     expect(taps[0]).toEqual({ x: 60, y: 40 });
   });
 
-  test('times out when missing', async () => {
+  test("times out when missing", async () => {
     const loc = new Locator(
       fakeDriver([]),
-      { search: ['Nope'] },
-      { timeoutMs: 200, intervalMs: 50 }
+      { search: ["Nope"] },
+      { timeoutMs: 200, intervalMs: 50 },
     );
     await expect(loc.tap()).rejects.toThrow(/locator timeout/);
   });

--- a/packages/devicewright/src/mcp/sessions.ts
+++ b/packages/devicewright/src/mcp/sessions.ts
@@ -3,16 +3,17 @@
  * Soft-omit lives here only (do not import from CLI / shared resolveSimulatorId).
  */
 
-import type { ChildProcess } from 'node:child_process';
+import type { ChildProcess } from "node:child_process";
 
-import { assertSafeDeviceId } from '../allowlist';
-import { devices } from '../devices';
-import { setIdbChildTracker } from '../ios/idb';
-import { listSimulators, type SimDevice } from '../ios/simctl';
-import type { DeviceSession } from '../session';
+import { assertSafeDeviceId } from "../allowlist";
+import { devices } from "../devices";
+import { setDeviceChildTracker } from "../ios/idb";
+import { listSimulators, type SimDevice } from "../ios/simctl";
+import { gcDevicewrightTemp } from "../media/gc";
+import type { DeviceSession } from "../session";
 
-export const DEVICE_CLOSE_FORCED = 'DEVICE_CLOSE_FORCED';
-export const DEVICE_SESSION_ABORTED = 'DEVICE_SESSION_ABORTED';
+export const DEVICE_CLOSE_FORCED = "DEVICE_CLOSE_FORCED";
+export const DEVICE_SESSION_ABORTED = "DEVICE_SESSION_ABORTED";
 
 export type CloseDeviceResult =
   | { ok: true; forced: false; udid: string }
@@ -33,7 +34,7 @@ export type BootedSimRow = {
 
 function abortedError(udid: string): Error {
   const err = new Error(
-    `${DEVICE_SESSION_ABORTED}: device session ${udid} was aborted (closing or force-closed)`
+    `${DEVICE_SESSION_ABORTED}: device session ${udid} was aborted (closing or force-closed)`,
   );
   err.name = DEVICE_SESSION_ABORTED;
   return err;
@@ -42,18 +43,18 @@ function abortedError(udid: string): Error {
 /** MCP-only soft-omit: 0 → error; 1 → that udid; many → error with list. */
 export function resolveMcpSimulatorIdFromBooted(
   deviceId: string | undefined,
-  booted: Array<{ udid: string; name: string }>
+  booted: Array<{ udid: string; name: string }>,
 ): string {
   if (deviceId) return assertSafeDeviceId(deviceId);
   if (booted.length === 0) {
     throw new Error(
-      'no booted simulator; boot one or pass udid. Use list_booted_sims.'
+      "no booted simulator; boot one or pass udid. Use list_booted_sims.",
     );
   }
   if (booted.length === 1) return booted[0]!.udid;
-  const list = booted.map((d) => `${d.name} (${d.udid})`).join(', ');
+  const list = booted.map((d) => `${d.name} (${d.udid})`).join(", ");
   throw new Error(
-    `multiple booted simulators; pass udid. Booted: ${list}. Use list_booted_sims.`
+    `multiple booted simulators; pass udid. Booted: ${list}. Use list_booted_sims.`,
   );
 }
 
@@ -68,7 +69,7 @@ export function discoverBootedSimId(): string {
 }
 
 export function listBootedSimulators(): SimDevice[] {
-  return listSimulators().filter((d) => d.state === 'Booted');
+  return listSimulators().filter((d) => d.state === "Booted");
 }
 
 export type SessionRegistryDeps = {
@@ -97,7 +98,7 @@ export class SessionRegistry {
   constructor(deps: SessionRegistryDeps = {}) {
     this.deps = deps;
     if (!deps.skipIdbTracker) {
-      setIdbChildTracker((udid, child) => this.trackChild(udid, child));
+      setDeviceChildTracker((udid, child) => this.trackChild(udid, child));
     }
   }
 
@@ -138,7 +139,7 @@ export class SessionRegistry {
         const session = this.deps.launchIos
           ? await this.deps.launchIos(id)
           : await devices.launch({
-              platform: 'ios',
+              platform: "ios",
               deviceId: id,
               lock: true,
               boot: true,
@@ -160,7 +161,7 @@ export class SessionRegistry {
    */
   async runExclusive<T>(
     deviceId: string,
-    fn: (session: DeviceSession) => Promise<T>
+    fn: (session: DeviceSession) => Promise<T>,
   ): Promise<T> {
     const id = assertSafeDeviceId(deviceId);
     if (this.closing.has(id)) {
@@ -175,7 +176,7 @@ export class SessionRegistry {
     const prev = this.queues.get(id) ?? Promise.resolve();
     this.queues.set(
       id,
-      prev.then(() => gate).catch(() => gate)
+      prev.then(() => gate).catch(() => gate),
     );
 
     await prev.catch(() => undefined);
@@ -219,7 +220,7 @@ export class SessionRegistry {
 
   async closeDevice(
     deviceId: string,
-    drainMs = 30_000
+    drainMs = 30_000,
   ): Promise<CloseDeviceResult> {
     const udid = assertSafeDeviceId(deviceId);
     this.closing.add(udid);
@@ -246,6 +247,7 @@ export class SessionRegistry {
     }
 
     this.closing.delete(udid);
+    gcDevicewrightTemp();
 
     if (forced) {
       return {
@@ -284,9 +286,10 @@ export class SessionRegistry {
         } catch {
           // ignore
         }
-      })
+      }),
     );
     this.closing.clear();
+    gcDevicewrightTemp();
   }
 
   private poisonExclusive(udid: string): void {
@@ -310,8 +313,8 @@ export class SessionRegistry {
     }
     set.add(child);
     const cleanup = () => set!.delete(child);
-    child.once('close', cleanup);
-    child.once('error', cleanup);
+    child.once("close", cleanup);
+    child.once("error", cleanup);
   }
 
   private killChildren(udid: string): void {
@@ -319,7 +322,7 @@ export class SessionRegistry {
     if (!set) return;
     for (const child of set) {
       try {
-        child.kill('SIGKILL');
+        child.kill("SIGKILL");
       } catch {
         // ignore
       }
@@ -358,20 +361,20 @@ export class SessionRegistry {
 
   private async waitIdleOrTimeout(
     udid: string,
-    drainMs: number
+    drainMs: number,
   ): Promise<boolean> {
     const winner = await Promise.race([
-      this.waitUntilIdle(udid).then(() => 'idle' as const),
-      new Promise<'timeout'>((resolve) => {
-        setTimeout(() => resolve('timeout'), drainMs);
+      this.waitUntilIdle(udid).then(() => "idle" as const),
+      new Promise<"timeout">((resolve) => {
+        setTimeout(() => resolve("timeout"), drainMs);
       }),
     ]);
-    return winner === 'timeout' && (this.busyCount.get(udid) ?? 0) > 0;
+    return winner === "timeout" && (this.busyCount.get(udid) ?? 0) > 0;
   }
 }
 
 export function createSessionRegistry(
-  deps: SessionRegistryDeps = {}
+  deps: SessionRegistryDeps = {},
 ): SessionRegistry {
   return new SessionRegistry(deps);
 }

--- a/packages/devicewright/src/mcp/tools.ts
+++ b/packages/devicewright/src/mcp/tools.ts
@@ -2,26 +2,30 @@
  * MCP tool registration — kept separate so createDevicewrightMcpServer stays small.
  */
 
-import fs from 'node:fs';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
+import fs from "node:fs";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 import {
   assertSafeBundleId,
+  assertSafeDeviceId,
   assertSafeOutputPath,
   assertSafePath,
-} from '../allowlist';
-import { devices } from '../devices';
-import { formatDoctor, runDoctor } from '../doctor';
-import { openSimulatorApp } from '../ios/simctl';
-import type { DeviceSession } from '../session';
+} from "../allowlist";
+import { devices } from "../devices";
+import { formatDoctor, runDoctor } from "../doctor";
+import { openSimulatorApp } from "../ios/simctl";
+import { deleteFrameFiles } from "../media/frames";
+import type { DeviceSession } from "../session";
 import {
   discoverBootedSimId,
+  listBootedSimulators,
+  resolveMcpSimulatorId,
   type SessionRegistry,
-} from './sessions';
+} from "./sessions";
 
 function textResult(text: string) {
-  return { content: [{ type: 'text' as const, text }] };
+  return { content: [{ type: "text" as const, text }] };
 }
 
 function jsonResult(value: unknown) {
@@ -29,23 +33,23 @@ function jsonResult(value: unknown) {
 }
 
 function optDuration(
-  duration: string | number | undefined
+  duration: string | number | undefined,
 ): number | undefined {
   if (duration === undefined) return;
-  return typeof duration === 'number' ? duration : Number(duration);
+  return typeof duration === "number" ? duration : Number(duration);
 }
 
 async function withDevice(
   registry: SessionRegistry,
-  platform: 'ios' | 'android' | undefined,
+  platform: "ios" | "android" | undefined,
   udid: string | undefined,
   // MCP tool handlers return heterogeneous content shapes (text/image).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fn: (s: DeviceSession) => Promise<any>
+  fn: (s: DeviceSession) => Promise<any>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
-  if (platform === 'android') {
-    const s = await devices.launch({ platform: 'android', deviceId: udid });
+  if (platform === "android") {
+    const s = await devices.launch({ platform: "android", deviceId: udid });
     try {
       return await fn(s);
     } finally {
@@ -56,61 +60,86 @@ async function withDevice(
   return registry.runExclusive(session.deviceId, fn);
 }
 
+/**
+ * Soft-omit for stop/view: require udid when >1 held OR multi-booted.
+ */
+function resolveRecordingSessionUdid(
+  registry: SessionRegistry,
+  udid?: string,
+): string {
+  if (udid) return assertSafeDeviceId(udid);
+  const held = registry.heldIds();
+  if (held.length > 1) {
+    throw new Error(
+      `multiple held sessions; pass udid. Held: ${held.join(", ")}. Use list_booted_sims.`,
+    );
+  }
+  if (held.length === 1) {
+    const booted = listBootedSimulators();
+    if (booted.length > 1) {
+      // Prefer the held session when multi-booted but only one held.
+      return held[0]!;
+    }
+    return held[0]!;
+  }
+  return resolveMcpSimulatorId();
+}
+
 export function registerDevicewrightTools(
   server: McpServer,
-  registry: SessionRegistry
+  registry: SessionRegistry,
 ): void {
   server.registerTool(
-    'doctor',
+    "doctor",
     {
-      description: 'Preflight: Xcode, simctl, idb, simulators, adb.',
+      description: "Preflight: Xcode, simctl, idb, simulators, adb.",
       inputSchema: { requireAndroid: z.boolean().optional() },
     },
     async ({ requireAndroid }) =>
-      textResult(formatDoctor(runDoctor({ requireAndroid })))
+      textResult(formatDoctor(runDoctor({ requireAndroid }))),
   );
 
   server.registerTool(
-    'get_booted_sim_id',
+    "get_booted_sim_id",
     {
       description:
-        'Discovery-only: return the booted simulator UDID when exactly one is booted. Does not attach, lock, or mutate the session registry. If multiple are booted, use list_booted_sims and pass udid to other tools.',
+        "Discovery-only: return the booted simulator UDID when exactly one is booted. Does not attach, lock, or mutate the session registry. If multiple are booted, use list_booted_sims and pass udid to other tools.",
       inputSchema: {},
     },
-    async () => jsonResult({ udid: discoverBootedSimId() })
+    async () => jsonResult({ udid: discoverBootedSimId() }),
   );
 
   server.registerTool(
-    'list_booted_sims',
+    "list_booted_sims",
     {
       description:
-        'List booted iOS simulators and whether this MCP process currently holds a session (map membership, not liveness).',
+        "List booted iOS simulators and whether this MCP process currently holds a session (map membership, not liveness).",
       inputSchema: {},
     },
-    async () => jsonResult({ sims: registry.listBootedWithHeld() })
+    async () => jsonResult({ sims: registry.listBootedWithHeld() }),
   );
 
   server.registerTool(
-    'close_device',
+    "close_device",
     {
       description:
-        'Close the MCP session for a UDID: drain in-flight work (default 30s) then unlock. Force-close returns DEVICE_CLOSE_FORCED if drain times out.',
+        "Close the MCP session for a UDID: drain in-flight work (default 30s) then unlock. Force-close returns DEVICE_CLOSE_FORCED if drain times out.",
       inputSchema: {
         udid: z.string(),
         drain_ms: z.number().optional(),
       },
     },
     async ({ udid, drain_ms }) =>
-      jsonResult(await registry.closeDevice(udid, drain_ms ?? 30_000))
+      jsonResult(await registry.closeDevice(udid, drain_ms ?? 30_000)),
   );
 
   server.registerTool(
-    'open_simulator',
-    { description: 'Opens the iOS Simulator application', inputSchema: {} },
+    "open_simulator",
+    { description: "Opens the iOS Simulator application", inputSchema: {} },
     async () => {
       openSimulatorApp();
-      return textResult('opened Simulator');
-    }
+      return textResult("opened Simulator");
+    },
   );
 
   registerUiTools(server, registry);
@@ -119,60 +148,60 @@ export function registerDevicewrightTools(
 
 function registerUiTools(server: McpServer, registry: SessionRegistry): void {
   server.registerTool(
-    'ui_describe_all',
+    "ui_describe_all",
     {
-      description: 'Describes accessibility information for the entire screen',
+      description: "Describes accessibility information for the entire screen",
       inputSchema: {
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ udid, platform }) =>
       withDevice(registry, platform, udid, async (s) =>
-        jsonResult(await s.accessibilityTree())
-      )
+        jsonResult(await s.accessibilityTree()),
+      ),
   );
 
   server.registerTool(
-    'ui_tap',
+    "ui_tap",
     {
-      description: 'Tap on the screen',
+      description: "Tap on the screen",
       inputSchema: {
         x: z.number(),
         y: z.number(),
         duration: z.union([z.string(), z.number()]).optional(),
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ x, y, duration, udid, platform }) =>
       withDevice(registry, platform, udid, async (s) => {
         await s.tap({ x, y, duration: optDuration(duration) });
         return textResult(`tapped (${x}, ${y})`);
-      })
+      }),
   );
 
   server.registerTool(
-    'ui_type',
+    "ui_type",
     {
-      description: 'Input text into the device',
+      description: "Input text into the device",
       inputSchema: {
         text: z.string(),
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ text, udid, platform }) =>
       withDevice(registry, platform, udid, async (s) => {
         await s.type(text);
-        return textResult('typed');
-      })
+        return textResult("typed");
+      }),
   );
 
   server.registerTool(
-    'ui_swipe',
+    "ui_swipe",
     {
-      description: 'Swipe on the screen',
+      description: "Swipe on the screen",
       inputSchema: {
         x_start: z.number(),
         y_start: z.number(),
@@ -181,7 +210,7 @@ function registerUiTools(server: McpServer, registry: SessionRegistry): void {
         duration: z.union([z.string(), z.number()]).optional(),
         delta: z.number().optional(),
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async (args) =>
@@ -194,14 +223,14 @@ function registerUiTools(server: McpServer, registry: SessionRegistry): void {
           duration: optDuration(args.duration),
           delta: args.delta,
         });
-        return textResult('swiped');
-      })
+        return textResult("swiped");
+      }),
   );
 
   server.registerTool(
-    'ui_describe_point',
+    "ui_describe_point",
     {
-      description: 'Returns the accessibility element at coordinates',
+      description: "Returns the accessibility element at coordinates",
       inputSchema: {
         x: z.number(),
         y: z.number(),
@@ -209,22 +238,22 @@ function registerUiTools(server: McpServer, registry: SessionRegistry): void {
       },
     },
     async ({ x, y, udid }) =>
-      withDevice(registry, 'ios', udid, async (s) =>
-        jsonResult(await s.describePoint(x, y))
-      )
+      withDevice(registry, "ios", udid, async (s) =>
+        jsonResult(await s.describePoint(x, y)),
+      ),
   );
 
   server.registerTool(
-    'ui_find_element',
+    "ui_find_element",
     {
-      description: 'Search the accessibility tree for matching elements',
+      description: "Search the accessibility tree for matching elements",
       inputSchema: {
         search: z.array(z.string()),
         type: z.string().optional(),
-        matchMode: z.enum(['substring', 'exact']).optional(),
+        matchMode: z.enum(["substring", "exact"]).optional(),
         caseSensitive: z.boolean().optional(),
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async (args) =>
@@ -235,46 +264,46 @@ function registerUiTools(server: McpServer, registry: SessionRegistry): void {
             type: args.type,
             matchMode: args.matchMode,
             caseSensitive: args.caseSensitive,
-          })
-        )
-      )
+          }),
+        ),
+      ),
   );
 
   server.registerTool(
-    'ui_view',
+    "ui_view",
     {
-      description: 'Get a screenshot of the current device view (base64 png)',
+      description: "Get a screenshot of the current device view (base64 png)",
       inputSchema: {
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ udid, platform }) =>
       withDevice(registry, platform, udid, async (s) => {
         const shot = await s.screenshot();
         const buf =
-          typeof shot === 'string' ? fs.readFileSync(shot) : Buffer.from(shot);
+          typeof shot === "string" ? fs.readFileSync(shot) : Buffer.from(shot);
         return {
           content: [
             {
-              type: 'image' as const,
-              data: buf.toString('base64'),
-              mimeType: 'image/png',
+              type: "image" as const,
+              data: buf.toString("base64"),
+              mimeType: "image/png",
             },
           ],
         };
-      })
+      }),
   );
 
   server.registerTool(
-    'screenshot',
+    "screenshot",
     {
-      description: 'Takes a screenshot and saves it to output_path',
+      description: "Takes a screenshot and saves it to output_path",
       inputSchema: {
         output_path: z.string(),
         udid: z.string().optional(),
-        type: z.enum(['png', 'jpeg']).optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        type: z.enum(["png", "jpeg"]).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ output_path, udid, type, platform }) =>
@@ -282,19 +311,19 @@ function registerUiTools(server: McpServer, registry: SessionRegistry): void {
         const out = assertSafeOutputPath(output_path);
         const saved = await s.screenshot({ path: out, type });
         return textResult(`saved ${saved}`);
-      })
+      }),
   );
 }
 
 function registerAppTools(server: McpServer, registry: SessionRegistry): void {
   server.registerTool(
-    'install_app',
+    "install_app",
     {
-      description: 'Installs an app bundle (.app / .ipa / .apk)',
+      description: "Installs an app bundle (.app / .ipa / .apk)",
       inputSchema: {
         app_path: z.string(),
         udid: z.string().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ app_path, udid, platform }) =>
@@ -302,18 +331,18 @@ function registerAppTools(server: McpServer, registry: SessionRegistry): void {
         const app = assertSafePath(app_path, { mustExist: true });
         await s.install(app);
         return textResult(`installed ${app}`);
-      })
+      }),
   );
 
   server.registerTool(
-    'launch_app',
+    "launch_app",
     {
-      description: 'Launches an app by bundle identifier / package name',
+      description: "Launches an app by bundle identifier / package name",
       inputSchema: {
         bundle_id: z.string(),
         udid: z.string().optional(),
         terminate_running: z.boolean().optional(),
-        platform: z.enum(['ios', 'android']).optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
     async ({ bundle_id, udid, terminate_running, platform }) =>
@@ -321,28 +350,127 @@ function registerAppTools(server: McpServer, registry: SessionRegistry): void {
         const id = assertSafeBundleId(bundle_id);
         await s.launchApp(id, { terminateRunning: terminate_running });
         return textResult(`launched ${id}`);
-      })
+      }),
   );
 
   server.registerTool(
-    'record_video',
+    "record_video",
     {
-      description: 'Records simulator video via simctl (iOS simulator only).',
+      description:
+        "Start iOS Simulator screen recording (simctl). Optional max_seconds auto-stops. Android not supported yet.",
       inputSchema: {
         output_path: z.string().optional(),
         udid: z.string().optional(),
+        max_seconds: z.number().optional(),
+        platform: z.enum(["ios", "android"]).optional(),
       },
     },
-    async () =>
-      textResult(
-        'record_video: use xcrun simctl io <udid> recordVideo via Devicewright test runner traces for now'
-      )
+    async ({ output_path, udid, max_seconds, platform }) => {
+      if (platform === "android") {
+        return textResult(
+          "record_video: Android screen recording is not supported yet in Devicewright (deferred). Use platform: ios.",
+        );
+      }
+      return withDevice(registry, "ios", udid, async (s) => {
+        const handle = await s.startRecording({
+          path: output_path ? assertSafeOutputPath(output_path) : undefined,
+          maxSeconds: max_seconds,
+        });
+        return textResult(`recording → ${handle.path}`);
+      });
+    },
   );
 
   server.registerTool(
-    'stop_recording',
-    { description: 'Stops simulator video recording', inputSchema: {} },
-    async () =>
-      textResult('stop_recording: no-op unless a recorder was started')
+    "stop_recording",
+    {
+      description:
+        "Stop iOS Simulator screen recording (SIGINT). Pass udid when multiple sims are held or booted.",
+      inputSchema: {
+        udid: z.string().optional(),
+        platform: z.enum(["ios", "android"]).optional(),
+      },
+    },
+    async ({ udid, platform }) => {
+      if (platform === "android") {
+        return textResult(
+          "stop_recording: Android screen recording is not supported yet in Devicewright (deferred).",
+        );
+      }
+      const id = resolveRecordingSessionUdid(registry, udid);
+      return withDevice(registry, "ios", id, async (s) => {
+        const saved = await s.stopRecording();
+        return textResult(`saved ${saved}`);
+      });
+    },
+  );
+
+  server.registerTool(
+    "ui_view_recording",
+    {
+      description:
+        "Sample frames from a recording (default: last stopped on this session) as MCP images for animation inspection. Requires ffmpeg+ffprobe (doctor warns if missing; record/stop still work). Optional start_seconds/end_seconds zoom into a window (e.g. 200ms: fps 5–10 over a short range).",
+      inputSchema: {
+        path: z.string().optional(),
+        fps: z.number().optional(),
+        max_frames: z.number().optional(),
+        start_seconds: z.number().optional(),
+        end_seconds: z.number().optional(),
+        udid: z.string().optional(),
+        platform: z.enum(["ios", "android"]).optional(),
+      },
+    },
+    async ({
+      path: videoPath,
+      fps,
+      max_frames,
+      start_seconds,
+      end_seconds,
+      udid,
+      platform,
+    }) => {
+      if (platform === "android") {
+        return textResult(
+          "ui_view_recording: Android screen recording is not supported yet in Devicewright (deferred).",
+        );
+      }
+      const id = resolveRecordingSessionUdid(registry, udid);
+      return withDevice(registry, "ios", id, async (s) => {
+        const viewed = await s.viewRecording({
+          path: videoPath ? assertSafeOutputPath(videoPath) : undefined,
+          fps,
+          maxFrames: max_frames,
+          startSeconds: start_seconds,
+          endSeconds: end_seconds,
+        });
+        const summary = [
+          `path=${viewed.path}`,
+          `duration=${viewed.duration.toFixed(3)}s`,
+          `window=[${viewed.startSeconds.toFixed(3)}, ${viewed.endSeconds.toFixed(3)}]`,
+          `frameCount=${viewed.frameCount}`,
+          `fps=${viewed.fps}`,
+          `maxFrames=${viewed.maxFrames}`,
+          `thinned=${viewed.thinned}`,
+          `t=[${viewed.frames.map((f) => f.t.toFixed(3)).join(", ")}]`,
+        ].join(" ");
+        const content: Array<
+          | { type: "text"; text: string }
+          | { type: "image"; data: string; mimeType: string }
+        > = [{ type: "text", text: summary }];
+        try {
+          for (const frame of viewed.frames) {
+            const buf = fs.readFileSync(frame.path);
+            content.push({
+              type: "image",
+              data: buf.toString("base64"),
+              mimeType: "image/jpeg",
+            });
+          }
+        } finally {
+          deleteFrameFiles(viewed.outDir);
+        }
+        return { content };
+      });
+    },
   );
 }

--- a/packages/devicewright/src/media/frames.test.ts
+++ b/packages/devicewright/src/media/frames.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  clampFps,
+  clampMaxFrames,
+  clampSeekTime,
+  computeFrameTimestamps,
+  resolveViewWindow,
+} from "./frames";
+import { gcDevicewrightTemp } from "./gc";
+
+describe("computeFrameTimestamps", () => {
+  test("dense short clip samples at fps", () => {
+    const { times, thinned } = computeFrameTimestamps(2, 10, 60);
+    expect(thinned).toBe(false);
+    expect(times[0]).toBe(0);
+    expect(times.at(-1)).toBeCloseTo(2, 5);
+    expect(times.length).toBe(21); // 0..2 inclusive at 0.1s
+  });
+
+  test("long clip thins evenly to maxFrames", () => {
+    const { times, thinned } = computeFrameTimestamps(60, 10, 60);
+    expect(thinned).toBe(true);
+    expect(times.length).toBe(60);
+    expect(times[0]).toBe(0);
+    expect(times.at(-1)).toBeCloseTo(60, 5);
+  });
+
+  test("single maxFrame", () => {
+    const { times, thinned } = computeFrameTimestamps(10, 10, 1);
+    expect(thinned).toBe(true);
+    expect(times).toEqual([0]);
+  });
+
+  test("zero duration", () => {
+    expect(computeFrameTimestamps(0, 10, 60)).toEqual({
+      times: [0],
+      thinned: false,
+    });
+  });
+
+  test("200ms window at fps 5 stays dense", () => {
+    const { times, thinned } = computeFrameTimestamps(0.2, 5, 60);
+    expect(thinned).toBe(false);
+    expect(times).toEqual([0, 0.2]);
+  });
+});
+
+describe("resolveViewWindow", () => {
+  test("defaults to full duration", () => {
+    expect(resolveViewWindow(18.4)).toEqual({ start: 0, end: 18.4 });
+  });
+
+  test("clamps end to duration", () => {
+    expect(resolveViewWindow(10, 8, 99)).toEqual({ start: 8, end: 10 });
+  });
+
+  test("rejects empty or past-end windows", () => {
+    expect(() => resolveViewWindow(10, 5, 5)).toThrow(/empty view window/);
+    expect(() => resolveViewWindow(10, 12, 14)).toThrow(/past duration/);
+  });
+});
+
+describe("clamp helpers", () => {
+  test("rejects invalid fps/maxFrames", () => {
+    expect(() => clampFps(0)).toThrow(/invalid fps/);
+    expect(() => clampMaxFrames(0)).toThrow(/invalid maxFrames/);
+  });
+
+  test("clampSeekTime stays off EOF", () => {
+    expect(clampSeekTime(18.435, 18.435)).toBeCloseTo(18.385, 5);
+    expect(clampSeekTime(0, 18.435)).toBe(0);
+    expect(clampSeekTime(9, 18.435)).toBe(9);
+  });
+});
+
+describe("gcDevicewrightTemp", () => {
+  test("removes old devicewright-* entries", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dw-gc-test-"));
+    const oldFile = path.join(dir, "devicewright-old.mp4");
+    const freshFile = path.join(dir, "devicewright-fresh.mp4");
+    const other = path.join(dir, "other.txt");
+    fs.writeFileSync(oldFile, "x");
+    fs.writeFileSync(freshFile, "y");
+    fs.writeFileSync(other, "z");
+    const oldTime = Date.now() - 48 * 60 * 60 * 1000;
+    fs.utimesSync(oldFile, new Date(oldTime), new Date(oldTime));
+
+    const result = gcDevicewrightTemp({
+      tmpDir: dir,
+      olderThanMs: 24 * 60 * 60 * 1000,
+    });
+    expect(result.removed).toContain(oldFile);
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(freshFile)).toBe(true);
+    expect(fs.existsSync(other)).toBe(true);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/devicewright/src/media/frames.ts
+++ b/packages/devicewright/src/media/frames.ts
@@ -1,0 +1,249 @@
+/**
+ * ffmpeg/ffprobe frame extraction for ui_view_recording.
+ * Structured argv only — never shell interpolation.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { assertSafeOutputPath, assertSafePath } from "../allowlist";
+import { runSync } from "../exec";
+import type { ExtractedFrame } from "../types";
+
+export const DEFAULT_VIEW_FPS = 10;
+export const DEFAULT_MAX_FRAMES = 60;
+const MIN_VIDEO_BYTES = 64;
+
+export type ExtractFramesOptions = {
+  fps?: number;
+  maxFrames?: number;
+  outDir?: string;
+  /** Inclusive window start (seconds from video start). Default 0. */
+  startSeconds?: number;
+  /** Window end (seconds from video start). Default: full duration. */
+  endSeconds?: number;
+};
+
+export type ExtractFramesResult = {
+  frames: ExtractedFrame[];
+  duration: number;
+  startSeconds: number;
+  endSeconds: number;
+  thinned: boolean;
+  fps: number;
+  maxFrames: number;
+  outDir: string;
+};
+
+export function clampFps(fps: number | undefined): number {
+  const n = fps ?? DEFAULT_VIEW_FPS;
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`invalid fps: ${fps}`);
+  }
+  return n;
+}
+
+export function clampMaxFrames(maxFrames: number | undefined): number {
+  const n = maxFrames ?? DEFAULT_MAX_FRAMES;
+  if (!Number.isFinite(n) || n < 1) {
+    throw new Error(`invalid maxFrames: ${maxFrames}`);
+  }
+  return Math.floor(n);
+}
+
+/**
+ * Resolve [start, end] within [0, duration]. end defaults to duration.
+ * Empty / inverted windows throw.
+ */
+export function resolveViewWindow(
+  duration: number,
+  startSeconds?: number,
+  endSeconds?: number,
+): { start: number; end: number } {
+  if (!(duration >= 0) || !Number.isFinite(duration)) {
+    throw new Error(`invalid duration: ${duration}`);
+  }
+  const start = startSeconds ?? 0;
+  const end = endSeconds ?? duration;
+  if (!Number.isFinite(start) || start < 0) {
+    throw new Error(`invalid startSeconds: ${startSeconds}`);
+  }
+  if (!Number.isFinite(end) || end < 0) {
+    throw new Error(`invalid endSeconds: ${endSeconds}`);
+  }
+  if (start > duration) {
+    throw new Error(
+      `startSeconds ${start} is past duration ${duration.toFixed(3)}s`,
+    );
+  }
+  const clampedEnd = Math.min(end, duration);
+  if (clampedEnd <= start) {
+    throw new Error(
+      `empty view window: startSeconds=${start} endSeconds=${end} duration=${duration}`,
+    );
+  }
+  return { start, end: clampedEnd };
+}
+
+/** Even-spacing timestamps over a span (relative 0..span). */
+export function computeFrameTimestamps(
+  span: number,
+  fps: number,
+  maxFrames: number,
+): { times: number[]; thinned: boolean } {
+  if (!(span > 0) || !Number.isFinite(span)) {
+    return { times: [0], thinned: false };
+  }
+  const denseBudget = maxFrames / fps;
+  if (span > denseBudget) {
+    const n = maxFrames;
+    if (n === 1) return { times: [0], thinned: true };
+    const times = Array.from({ length: n }, (_, i) => (i * span) / (n - 1));
+    return { times, thinned: true };
+  }
+  const times: number[] = [];
+  for (let i = 0; times.length < maxFrames; i++) {
+    const t = i / fps;
+    if (t > span + 1e-9) break;
+    times.push(t);
+  }
+  if (times.length === 0) times.push(0);
+  return { times, thinned: false };
+}
+
+export function assertReadableVideo(videoPath: string): void {
+  const resolved = assertSafePath(videoPath, { mustExist: true });
+  const st = fs.statSync(resolved);
+  if (!st.isFile() || st.size < MIN_VIDEO_BYTES) {
+    throw new Error(
+      `unreadable or empty recording: ${resolved} (size ${st.size})`,
+    );
+  }
+}
+
+export function probeDurationSeconds(videoPath: string): number {
+  const resolved = assertSafePath(videoPath, { mustExist: true });
+  const result = runSync("ffprobe", [
+    "-v",
+    "error",
+    "-show_entries",
+    "format=duration",
+    "-of",
+    "default=noprint_wrappers=1:nokey=1",
+    resolved,
+  ]);
+  if (result.status !== 0) {
+    throw new Error(
+      `ffprobe failed for ${resolved}: ${result.stderr || result.stdout || "unknown"}`,
+    );
+  }
+  const duration = Number.parseFloat(result.stdout.trim());
+  if (!Number.isFinite(duration) || duration < 0) {
+    throw new Error(`ffprobe returned invalid duration: ${result.stdout}`);
+  }
+  return duration;
+}
+
+/** Keep -ss off EOF so simctl HEVC still yields a frame. */
+export function clampSeekTime(t: number, duration: number): number {
+  if (!(duration > 0) || !Number.isFinite(duration)) return 0;
+  if (!Number.isFinite(t) || t <= 0) return 0;
+  const maxSeek = Math.max(0, duration - 0.05);
+  return Math.min(t, maxSeek);
+}
+
+function extractOneFrame(videoPath: string, t: number, outPath: string): void {
+  const result = runSync("ffmpeg", [
+    "-y",
+    "-ss",
+    String(t),
+    "-i",
+    videoPath,
+    "-frames:v",
+    "1",
+    "-q:v",
+    "2",
+    // ffmpeg 8 image2: single-file output needs -update 1
+    "-update",
+    "1",
+    outPath,
+  ]);
+  if (result.status !== 0 || !fs.existsSync(outPath)) {
+    throw new Error(
+      `ffmpeg frame extract failed at t=${t}: ${
+        result.stderr || result.stdout || "unknown"
+      }`,
+    );
+  }
+}
+
+export function extractFrames(
+  videoPath: string,
+  options: ExtractFramesOptions = {},
+): ExtractFramesResult {
+  assertReadableVideo(videoPath);
+  const resolved = assertSafePath(videoPath, { mustExist: true });
+  const fps = clampFps(options.fps);
+  const maxFrames = clampMaxFrames(options.maxFrames);
+  const duration = probeDurationSeconds(resolved);
+  const { start, end } = resolveViewWindow(
+    duration,
+    options.startSeconds,
+    options.endSeconds,
+  );
+  const span = end - start;
+  const { times: relative, thinned } = computeFrameTimestamps(
+    span,
+    fps,
+    maxFrames,
+  );
+  const times = relative.map((t) => start + t);
+
+  const outDir =
+    options.outDir ??
+    path.join(os.tmpdir(), `devicewright-frames-${Date.now()}`);
+  const safeOut = assertSafeOutputPath(outDir);
+  fs.mkdirSync(safeOut, { recursive: true });
+
+  const frames: ExtractedFrame[] = [];
+  for (let i = 0; i < times.length; i++) {
+    const t = times[i]!;
+    const seekT = clampSeekTime(t, duration);
+    const framePath = path.join(
+      safeOut,
+      `frame_${String(i).padStart(4, "0")}_t${t.toFixed(3)}.jpg`,
+    );
+    extractOneFrame(resolved, seekT, framePath);
+    frames.push({ path: framePath, t });
+  }
+
+  return {
+    frames,
+    duration,
+    startSeconds: start,
+    endSeconds: end,
+    thinned,
+    fps,
+    maxFrames,
+    outDir: safeOut,
+  };
+}
+
+export function deleteFrameFiles(outDir: string): void {
+  const resolved = assertSafePath(outDir, { mustExist: false });
+  if (!fs.existsSync(resolved)) return;
+  try {
+    fs.rmSync(resolved, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+export function ffmpegAvailable(): boolean {
+  return runSync("ffmpeg", ["-version"]).status === 0;
+}
+
+export function ffprobeAvailable(): boolean {
+  return runSync("ffprobe", ["-version"]).status === 0;
+}

--- a/packages/devicewright/src/media/gc.ts
+++ b/packages/devicewright/src/media/gc.ts
@@ -1,0 +1,49 @@
+/**
+ * Best-effort cleanup of devicewright-* artifacts under os.tmpdir().
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_OLDER_THAN_MS = 24 * 60 * 60 * 1000;
+
+export type GcOptions = {
+  olderThanMs?: number;
+  tmpDir?: string;
+};
+
+export type GcResult = {
+  removed: string[];
+  errors: string[];
+};
+
+export function gcDevicewrightTemp(options: GcOptions = {}): GcResult {
+  const olderThanMs = options.olderThanMs ?? DEFAULT_OLDER_THAN_MS;
+  const tmpDir = options.tmpDir ?? os.tmpdir();
+  const cutoff = Date.now() - olderThanMs;
+  const removed: string[] = [];
+  const errors: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(tmpDir);
+  } catch (e) {
+    return { removed, errors: [String(e)] };
+  }
+
+  for (const name of entries) {
+    if (!name.startsWith("devicewright-")) continue;
+    const full = path.join(tmpDir, name);
+    try {
+      const st = fs.statSync(full);
+      if (st.mtimeMs >= cutoff) continue;
+      fs.rmSync(full, { recursive: true, force: true });
+      removed.push(full);
+    } catch (e) {
+      errors.push(`${full}: ${String(e)}`);
+    }
+  }
+
+  return { removed, errors };
+}

--- a/packages/devicewright/src/media/index.ts
+++ b/packages/devicewright/src/media/index.ts
@@ -1,0 +1,18 @@
+export {
+  clampFps,
+  clampMaxFrames,
+  clampSeekTime,
+  resolveViewWindow,
+  computeFrameTimestamps,
+  assertReadableVideo,
+  probeDurationSeconds,
+  extractFrames,
+  deleteFrameFiles,
+  ffmpegAvailable,
+  ffprobeAvailable,
+  DEFAULT_VIEW_FPS,
+  DEFAULT_MAX_FRAMES,
+  type ExtractFramesOptions,
+  type ExtractFramesResult,
+} from "./frames";
+export { gcDevicewrightTemp, type GcOptions, type GcResult } from "./gc";

--- a/packages/devicewright/src/session.ts
+++ b/packages/devicewright/src/session.ts
@@ -1,16 +1,28 @@
-import { Locator, type LocatorOptions } from './locator';
-import type { LockHandle } from './lock';
+import os from "node:os";
+import path from "node:path";
+
+import { Locator, type LocatorOptions } from "./locator";
+import type { LockHandle } from "./lock";
+import {
+  DEFAULT_MAX_FRAMES,
+  DEFAULT_VIEW_FPS,
+  extractFrames,
+} from "./media/frames";
 import type {
   AccessibilityNode,
   DeviceDriver,
   DeviceKind,
   FindCriteria,
   Platform,
+  RecordVideoOptions,
+  RecordingHandle,
   ScreenshotOptions,
   SwipeOptions,
   TapOptions,
   TraceStep,
-} from './types';
+  ViewRecordingOptions,
+  ViewRecordingResult,
+} from "./types";
 
 export class DeviceSession {
   readonly platform: Platform;
@@ -20,11 +32,9 @@ export class DeviceSession {
   private readonly lock?: LockHandle;
   private readonly steps: TraceStep[] = [];
   private closed = false;
+  private lastRecordingPath: string | undefined;
 
-  constructor(options: {
-    driver: DeviceDriver;
-    lock?: LockHandle;
-  }) {
+  constructor(options: { driver: DeviceDriver; lock?: LockHandle }) {
     this.driver = options.driver;
     this.lock = options.lock;
     this.platform = options.driver.platform;
@@ -35,7 +45,7 @@ export class DeviceSession {
   private trace(
     action: string,
     detail?: Record<string, unknown>,
-    error?: string
+    error?: string,
   ) {
     this.steps.push({
       at: new Date().toISOString(),
@@ -49,43 +59,107 @@ export class DeviceSession {
     return [...this.steps];
   }
 
+  getLastRecordingPath(): string | undefined {
+    return this.lastRecordingPath;
+  }
+
   async install(appPath: string): Promise<void> {
     try {
       await this.driver.install(appPath);
-      this.trace('install', { appPath });
+      this.trace("install", { appPath });
     } catch (e) {
-      this.trace('install', { appPath }, String(e));
+      this.trace("install", { appPath }, String(e));
       throw e;
     }
   }
 
   async launchApp(
     bundleId: string,
-    options?: { terminateRunning?: boolean }
+    options?: { terminateRunning?: boolean },
   ): Promise<void> {
     try {
       await this.driver.launchApp(bundleId, options);
-      this.trace('launchApp', { bundleId, ...options });
+      this.trace("launchApp", { bundleId, ...options });
     } catch (e) {
-      this.trace('launchApp', { bundleId }, String(e));
+      this.trace("launchApp", { bundleId }, String(e));
       throw e;
     }
   }
 
   async terminateApp(bundleId: string): Promise<void> {
     if (!this.driver.terminateApp) {
-      throw new Error('terminateApp not supported on this driver');
+      throw new Error("terminateApp not supported on this driver");
     }
     await this.driver.terminateApp(bundleId);
-    this.trace('terminateApp', { bundleId });
+    this.trace("terminateApp", { bundleId });
   }
 
   async screenshot(options?: ScreenshotOptions): Promise<Buffer | string> {
     const result = await this.driver.screenshot(options);
-    this.trace('screenshot', {
-      path: typeof result === 'string' ? result : options?.path,
+    this.trace("screenshot", {
+      path: typeof result === "string" ? result : options?.path,
     });
     return result;
+  }
+
+  async startRecording(options?: RecordVideoOptions): Promise<RecordingHandle> {
+    const handle = await this.driver.startRecording(options);
+    this.trace("startRecording", {
+      path: handle.path,
+      maxSeconds: options?.maxSeconds,
+    });
+    return handle;
+  }
+
+  async stopRecording(): Promise<string> {
+    const saved = await this.driver.stopRecording();
+    this.lastRecordingPath = saved;
+    this.trace("stopRecording", { path: saved });
+    return saved;
+  }
+
+  async viewRecording(
+    options: ViewRecordingOptions = {},
+  ): Promise<ViewRecordingResult> {
+    const videoPath = options.path ?? this.lastRecordingPath;
+    if (!videoPath) {
+      throw new Error(
+        "no recording path: pass path or stop_recording first on this session",
+      );
+    }
+    const fps = options.fps ?? DEFAULT_VIEW_FPS;
+    const maxFrames = options.maxFrames ?? DEFAULT_MAX_FRAMES;
+    const outDir = path.join(
+      os.tmpdir(),
+      `devicewright-frames-${this.deviceId}-${Date.now()}`,
+    );
+    const extracted = extractFrames(videoPath, {
+      fps,
+      maxFrames,
+      outDir,
+      startSeconds: options.startSeconds,
+      endSeconds: options.endSeconds,
+    });
+    this.trace("viewRecording", {
+      path: videoPath,
+      frameCount: extracted.frames.length,
+      thinned: extracted.thinned,
+      duration: extracted.duration,
+      startSeconds: extracted.startSeconds,
+      endSeconds: extracted.endSeconds,
+    });
+    return {
+      path: videoPath,
+      duration: extracted.duration,
+      startSeconds: extracted.startSeconds,
+      endSeconds: extracted.endSeconds,
+      frameCount: extracted.frames.length,
+      fps: extracted.fps,
+      maxFrames: extracted.maxFrames,
+      thinned: extracted.thinned,
+      frames: extracted.frames,
+      outDir: extracted.outDir,
+    };
   }
 
   async accessibilityTree(): Promise<AccessibilityNode[]> {
@@ -94,7 +168,7 @@ export class DeviceSession {
 
   async describePoint(x: number, y: number): Promise<AccessibilityNode | null> {
     if (!this.driver.describePoint) {
-      throw new Error('describePoint not supported on this driver');
+      throw new Error("describePoint not supported on this driver");
     }
     return this.driver.describePoint(x, y);
   }
@@ -105,53 +179,53 @@ export class DeviceSession {
 
   async tap(options: TapOptions): Promise<void> {
     await this.driver.tap(options);
-    this.trace('tap', options as unknown as Record<string, unknown>);
+    this.trace("tap", options as unknown as Record<string, unknown>);
   }
 
   async type(text: string): Promise<void> {
     await this.driver.type(text);
-    this.trace('type', { length: text.length });
+    this.trace("type", { length: text.length });
   }
 
   async swipe(options: SwipeOptions): Promise<void> {
     await this.driver.swipe(options);
-    this.trace('swipe', options as unknown as Record<string, unknown>);
+    this.trace("swipe", options as unknown as Record<string, unknown>);
   }
 
   getByText(
     text: string,
-    options?: LocatorOptions & { exact?: boolean }
+    options?: LocatorOptions & { exact?: boolean },
   ): Locator {
     return new Locator(
       this.driver,
       {
         search: [text],
-        matchMode: options?.exact ? 'exact' : 'substring',
+        matchMode: options?.exact ? "exact" : "substring",
       },
-      options
+      options,
     );
   }
 
   getByRole(
     role: string,
-    options?: LocatorOptions & { name?: string }
+    options?: LocatorOptions & { name?: string },
   ): Locator {
     return new Locator(
       this.driver,
       {
         type: role,
-        search: options?.name ? [options.name] : [''],
-        matchMode: 'substring',
+        search: options?.name ? [options.name] : [""],
+        matchMode: "substring",
       },
-      options
+      options,
     );
   }
 
   getById(id: string, options?: LocatorOptions): Locator {
     return new Locator(
       this.driver,
-      { search: [id], matchMode: 'exact' },
-      options
+      { search: [id], matchMode: "exact" },
+      options,
     );
   }
 
@@ -166,7 +240,7 @@ export class DeviceSession {
       await this.driver.close?.();
     } finally {
       this.lock?.release();
-      this.trace('close');
+      this.trace("close");
     }
   }
 }

--- a/packages/devicewright/src/types.ts
+++ b/packages/devicewright/src/types.ts
@@ -1,6 +1,6 @@
-export type Platform = 'ios' | 'android';
+export type Platform = "ios" | "android";
 
-export type DeviceKind = 'simulator' | 'emulator' | 'physical' | 'cloud';
+export type DeviceKind = "simulator" | "emulator" | "physical" | "cloud";
 
 export type LaunchOptions = {
   platform: Platform;
@@ -21,7 +21,53 @@ export type LaunchOptions = {
 
 export type ScreenshotOptions = {
   path?: string;
-  type?: 'png' | 'jpeg';
+  type?: "png" | "jpeg";
+};
+
+export type RecordVideoOptions = {
+  path?: string;
+  codec?: "h264" | "hevc";
+  /** Optional auto-SIGINT; omit = unbounded. */
+  maxSeconds?: number;
+};
+
+export type ViewRecordingOptions = {
+  /** Default: last stopped recording on this session. */
+  path?: string;
+  /** Default 10. */
+  fps?: number;
+  /** Default 60. */
+  maxFrames?: number;
+  /** Inclusive window start (seconds from video start). Default 0. */
+  startSeconds?: number;
+  /** Exclusive-ish window end (seconds from video start). Default: full duration. */
+  endSeconds?: number;
+};
+
+export type RecordingHandle = {
+  path: string;
+  startedAt: number;
+};
+
+export type ExtractedFrame = {
+  path: string;
+  /** Seconds from video start. */
+  t: number;
+};
+
+export type ViewRecordingResult = {
+  path: string;
+  duration: number;
+  /** Resolved sample window (seconds from video start). */
+  startSeconds: number;
+  endSeconds: number;
+  frameCount: number;
+  fps: number;
+  maxFrames: number;
+  thinned: boolean;
+  frames: ExtractedFrame[];
+  /** Temp dir holding frame files — delete after MCP encode. */
+  outDir: string;
 };
 
 export type SwipeOptions = {
@@ -52,7 +98,7 @@ export type AccessibilityNode = {
 export type FindCriteria = {
   search: string[];
   type?: string;
-  matchMode?: 'substring' | 'exact';
+  matchMode?: "substring" | "exact";
   caseSensitive?: boolean;
 };
 
@@ -79,10 +125,12 @@ export interface DeviceDriver {
   install(appPath: string): Promise<void>;
   launchApp(
     bundleId: string,
-    options?: { terminateRunning?: boolean }
+    options?: { terminateRunning?: boolean },
   ): Promise<void>;
   terminateApp?(bundleId: string): Promise<void>;
   screenshot(options?: ScreenshotOptions): Promise<Buffer | string>;
+  startRecording(options?: RecordVideoOptions): Promise<RecordingHandle>;
+  stopRecording(): Promise<string>;
   accessibilityTree(): Promise<AccessibilityNode[]>;
   describePoint?(x: number, y: number): Promise<AccessibilityNode | null>;
   findElements(criteria: FindCriteria): Promise<AccessibilityNode[]>;


### PR DESCRIPTION
## Summary
- Add iOS Simulator `startRecording` / `stopRecording` (simctl) with optional `maxSeconds`, MCP tools `record_video` / `stop_recording` / `ui_view_recording`, and Android fail-loud stub for this PR.
- Sample frames via ffmpeg/ffprobe with even spacing, optional `start_seconds` / `end_seconds` windows for dense slices (e.g. 200ms), EOF seek clamp, and soft `doctor` warn when ffmpeg is missing.
- Temp `devicewright-*` GC (24h) on session close; frame JPEGs deleted after MCP image encode.

Stacked on #38 (`chris/agent/devicewright-f6fe`).

## Test plan
- [ ] `bun test` in `packages/devicewright` (esp. `src/media/frames.test.ts`)
- [ ] `doctor` warns (not fails) without ffmpeg; PASSes with ffmpeg
- [ ] MCP: `record_video` → interact → `stop_recording` → `ui_view_recording`
- [ ] MCP window: `start_seconds` / `end_seconds` + `fps: 10` yields dense `t` list, `thinned=false`
- [ ] Android `record_video` returns not-supported