### PR TITLE
chore(examples): Devicewright suite — ^0.1.4, ensure-install, journey harden

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ APPLE_TEAM_ID=
 # Used by root .npmrc: //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 # https://www.npmjs.com/settings/csark0812/tokens
 NODE_AUTH_TOKEN=
+
+# Absolute path to the `idb` CLI if it is not on PATH.
+# Companion: brew install idb-companion (facebook/fb). CLI: pip3 install --user fb-idb
+# DEVICEWRIGHT_IDB_PATH=/Users/YOU/Library/Python/3.9/bin/idb

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 bun.lockb
 
 # Build outputs

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
-        "@csark0812/devicewright": "^0.1.1",
+        "@csark0812/devicewright": "^0.1.2",
         "@csark0812/skeleton": "^1.5.5",
         "typescript": "~5.3.3",
       },
@@ -459,7 +459,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-o7I9dDEpVhOaiisqSJMLAmuvTqgGRsOxi0ZwKHZcPHPqNaDUp0Fc/FyJEIhLnMB4GXWFjUhWNQsZX7XirLFU4Q=="],
+    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-AEum8iNjqgu3RW2JDcq49tL2y1iCsSCDA0+FQH1pT/vPEEC4TC0pOlAD0mM1JPgflo5ZLKu+7VGkM+ABOlrOlA=="],
 
     "@csark0812/skeleton": ["@csark0812/skeleton@1.5.5", "", { "dependencies": { "ajv": "^8.17.1", "github-slugger": "^2.0.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "yaml": "^2.8.0" }, "bin": { "skeleton": "dist/cli.js" } }, "sha512-YNXotMr5fWLqM3LJi+3IrTgrXrfJtBXnpeKaQA21tZp/qp/1N5r5VAGRX0ap9m9pPmkrZrm2fBhMu2624qCu3g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
-        "@csark0812/devicewright": "^0.1.3",
+        "@csark0812/devicewright": "^0.1.4",
         "@csark0812/skeleton": "^1.5.5",
         "typescript": "~5.3.3",
       },
@@ -459,7 +459,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-+9jppcC83MP9nCRtlolbS1LBkhCiNfqY+EyLBZ1MWbIkzlZzoEUA5X1m+CQ9RByg/dneEVqMVNgGZJoTtjWSIw=="],
+    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-QjJ8A5xZQBC1hwMc+GhRzkp+caT8o00NRJodkicbJPvRtIBI4Q6SwYkscgsNq+ttkj1wc6EeCo+oXIFIK/yyTw=="],
 
     "@csark0812/skeleton": ["@csark0812/skeleton@1.5.5", "", { "dependencies": { "ajv": "^8.17.1", "github-slugger": "^2.0.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "yaml": "^2.8.0" }, "bin": { "skeleton": "dist/cli.js" } }, "sha512-YNXotMr5fWLqM3LJi+3IrTgrXrfJtBXnpeKaQA21tZp/qp/1N5r5VAGRX0ap9m9pPmkrZrm2fBhMu2624qCu3g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
-        "@csark0812/devicewright": "^0.1.2",
+        "@csark0812/devicewright": "^0.1.3",
         "@csark0812/skeleton": "^1.5.5",
         "typescript": "~5.3.3",
       },
@@ -459,7 +459,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-AEum8iNjqgu3RW2JDcq49tL2y1iCsSCDA0+FQH1pT/vPEEC4TC0pOlAD0mM1JPgflo5ZLKu+7VGkM+ABOlrOlA=="],
+    "@csark0812/devicewright": ["@csark0812/devicewright@0.1.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-+9jppcC83MP9nCRtlolbS1LBkhCiNfqY+EyLBZ1MWbIkzlZzoEUA5X1m+CQ9RByg/dneEVqMVNgGZJoTtjWSIw=="],
 
     "@csark0812/skeleton": ["@csark0812/skeleton@1.5.5", "", { "dependencies": { "ajv": "^8.17.1", "github-slugger": "^2.0.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "yaml": "^2.8.0" }, "bin": { "skeleton": "dist/cli.js" } }, "sha512-YNXotMr5fWLqM3LJi+3IrTgrXrfJtBXnpeKaQA21tZp/qp/1N5r5VAGRX0ap9m9pPmkrZrm2fBhMu2624qCu3g=="],
 

--- a/examples/.devicewright/README.md
+++ b/examples/.devicewright/README.md
@@ -4,11 +4,11 @@ Owns REQUIRED_V1 journeys for public `examples/*`. Devicewright (`@csark0812/dev
 
 ## Layout (Maestro parallel)
 
-| Maestro | Devicewright |
-|---------|----------------|
+| Maestro                              | Devicewright                              |
+| ------------------------------------ | ----------------------------------------- |
 | `examples/share/.maestro/smoke.yaml` | `examples/share/.devicewright/journey.ts` |
-| `examples/.maestro/subflows/` | `examples/.devicewright/` (shared) |
-| `examples:maestro:share` | `examples:devicewright:share` |
+| `examples/.maestro/subflows/`        | `examples/.devicewright/` (shared)        |
+| `examples:maestro:share`             | `examples:devicewright:share`             |
 
 ## Private dependency
 
@@ -29,6 +29,21 @@ bun install
 npx expo prebuild --platform ios
 npx expo run:ios --configuration Release
 ```
+
+### Opt-in ensure-install
+
+Pass `--ensure-install` so the matrix Release-builds any missing host before its journey (skips when already on the sim). First full run can take a long time (minutes × up to 8 apps).
+
+```bash
+bun examples/.devicewright/cli.ts matrix --ids=share --ensure-install --no-fail-fast
+bun run examples:devicewright:matrix:ensure   # live-through=3, all rows, --no-fail-fast
+```
+
+Without the flag, missing hosts stay an operator/infra fail (no builds).
+
+### iOS 26.5+ accessibility
+
+`@csark0812/devicewright@^0.1.3` sets `IgnoreAXServerEntitlements` in `doctor` / `devices.launch`. Empty `Application {0×0}` from idb usually means an older DW or a sim that needs a SpringBoard refresh — run dry-preflight / relaunch.
 
 ## dry-preflight + matrix
 

--- a/examples/.devicewright/catalog.ts
+++ b/examples/.devicewright/catalog.ts
@@ -13,6 +13,8 @@ export type TargetCatalogEntry = {
   payloadMarker: string;
   readyText?: string;
   completeButton: string;
+  /** Expand share-sheet action list before looking for the row. */
+  needsViewMore?: boolean;
   /** Host testIDs expected for C1 / A bars. */
   testIds: {
     screenRoot: string;
@@ -55,6 +57,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     payloadMarker: 'grayscale',
     readyText: 'Images: 1',
     completeButton: 'Process',
+    needsViewMore: true,
     testIds: { ...SHARE_TEST_IDS },
   },
   'native-share': {
@@ -79,6 +82,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     payloadMarker: 'Original',
     readyText: 'Original',
     completeButton: 'Process Image',
+    needsViewMore: true,
     testIds: { ...SHARE_TEST_IDS },
   },
   messages: {
@@ -87,7 +91,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     hostBundleId: 'com.expotargets.example.messages',
     hostDisplayName: 'ET Messages',
     extensionName: 'Example Messages',
-    extensionAliases: ['ET Messages', 'Messages'],
+    extensionAliases: ['ExampleMessagesTarget', 'ET Messages'],
     payloadMarker: 'Hello from expo-targets',
     completeButton: 'Send template',
     testIds: {
@@ -103,7 +107,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     hostBundleId: 'com.expotargets.example.stickers',
     hostDisplayName: 'ET Stickers',
     extensionName: 'Fun Stickers',
-    extensionAliases: ['Stickers', 'Fun Stickers'],
+    extensionAliases: ['FunStickersTarget', 'Fun Stickers'],
     /** Honest pack catalog marker (asset-only packs cannot App-Group on selection). */
     payloadMarker: 'pack: Fun Stickers (brutus, happy, excited)',
     completeButton: '',
@@ -157,9 +161,7 @@ export const BLOCKED_SHEET_LABELS = new Set([
   'Assign to Contact',
   'Add to Shared Album',
   'Edit Actions',
-  'More',
-  'View More',
-  'View Less',
+  // Note: View More / More are expanded intentionally via point-probe — not blocked there.
   'Apps',
   'Close',
   'Cancel',

--- a/examples/.devicewright/cli.ts
+++ b/examples/.devicewright/cli.ts
@@ -1,16 +1,19 @@
 #!/usr/bin/env bun
-import process from 'node:process';
-import { formatDryPreflight, runDryPreflight } from './dry-preflight';
-import { runTargetMatrix } from './matrix';
-import { REQUIRED_V1, type TargetPhase } from './required';
+import process from "node:process";
+import { formatDryPreflight, runDryPreflight } from "./dry-preflight";
+import { runTargetMatrix } from "./matrix";
+import { REQUIRED_V1, type TargetPhase } from "./required";
 
 function usage(): never {
   console.error(`examples/.devicewright/cli.ts <command>
 
 Commands:
   dry-preflight [--no-sim] [--android]
-  matrix [--ids=a,b] [--stubs-only] [--live-through=1|2|3] [--no-fail-fast]
+  matrix [--ids=a,b] [--stubs-only] [--live-through=1|2|3] [--no-fail-fast] [--ensure-install]
   list
+
+  --ensure-install  Release-build + install missing hosts before live journeys
+                    (slow on first run; minutes × apps). Skips when already installed.
 
 Env:
   DEVICEWRIGHT_IDB_PATH / IOS_SIMULATOR_MCP_IDB_PATH
@@ -21,27 +24,28 @@ Env:
 
 function cmdDry(rest: string[]): void {
   const report = runDryPreflight({
-    allowNoSim: rest.includes('--no-sim'),
-    requireAndroid: rest.includes('--android'),
+    allowNoSim: rest.includes("--no-sim"),
+    requireAndroid: rest.includes("--android"),
   });
   console.log(formatDryPreflight(report));
   process.exit(report.ok ? 0 : 1);
 }
 
 async function cmdMatrix(rest: string[]): Promise<void> {
-  const idsArg = rest.find((a) => a.startsWith('--ids='));
+  const idsArg = rest.find((a) => a.startsWith("--ids="));
   const ids = idsArg
-    ? idsArg.slice('--ids='.length).split(',').filter(Boolean)
+    ? idsArg.slice("--ids=".length).split(",").filter(Boolean)
     : undefined;
-  const liveArg = rest.find((a) => a.startsWith('--live-through='));
+  const liveArg = rest.find((a) => a.startsWith("--live-through="));
   const liveThroughPhase = liveArg
-    ? (Number(liveArg.slice('--live-through='.length)) as TargetPhase)
+    ? (Number(liveArg.slice("--live-through=".length)) as TargetPhase)
     : undefined;
   const result = await runTargetMatrix({
     ids,
-    stubsOnly: rest.includes('--stubs-only'),
+    stubsOnly: rest.includes("--stubs-only"),
     liveThroughPhase,
-    failFast: !rest.includes('--no-fail-fast'),
+    failFast: !rest.includes("--no-fail-fast"),
+    ensureInstall: rest.includes("--ensure-install"),
   });
   console.log(
     JSON.stringify(
@@ -52,21 +56,21 @@ async function cmdMatrix(rest: string[]): Promise<void> {
         results: result.results,
       },
       null,
-      2
-    )
+      2,
+    ),
   );
   const hardRed = result.results.some(
-    (r) => !r.ok && r.status !== 'stub' && r.status !== 'os-limit'
+    (r) => !r.ok && r.status !== "stub" && r.status !== "os-limit",
   );
   process.exit(hardRed ? 1 : 0);
 }
 
 async function main(): Promise<void> {
   const [cmd, ...rest] = process.argv.slice(2);
-  if (!cmd || cmd === 'help' || cmd === '--help') usage();
-  if (cmd === 'dry-preflight') return cmdDry(rest);
-  if (cmd === 'matrix') return cmdMatrix(rest);
-  if (cmd === 'list') {
+  if (!cmd || cmd === "help" || cmd === "--help") usage();
+  if (cmd === "dry-preflight") return cmdDry(rest);
+  if (cmd === "matrix") return cmdMatrix(rest);
+  if (cmd === "list") {
     console.log(JSON.stringify(REQUIRED_V1, null, 2));
     return;
   }

--- a/examples/.devicewright/dry-preflight.ts
+++ b/examples/.devicewright/dry-preflight.ts
@@ -1,13 +1,13 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from "node:fs";
+import path from "node:path";
 import {
   type DoctorReport,
   formatDoctor,
   runDoctor,
-} from '@csark0812/devicewright';
-import { simctl } from '@csark0812/devicewright/ios';
-import { REQUIRED_V1 } from './required';
-import { exampleExists, repoRoot } from './root';
+} from "@csark0812/devicewright";
+import { simctl } from "@csark0812/devicewright/ios";
+import { REQUIRED_V1 } from "./required";
+import { exampleExists, repoRoot } from "./root";
 
 export type DoctorCheck = { name: string; ok: boolean; detail: string };
 
@@ -24,58 +24,58 @@ function checkRequiredPaths(): DoctorCheck {
     if (!exampleExists(row.path)) missing.push(row.path);
   }
   return {
-    name: 'REQUIRED_V1_paths',
+    name: "REQUIRED_V1_paths",
     ok: missing.length === 0,
     detail:
       missing.length === 0
         ? `${REQUIRED_V1.length} paths present`
-        : `missing: ${missing.join(', ')}`,
+        : `missing: ${missing.join(", ")}`,
   };
 }
 
 function checkBootedSim(): DoctorCheck {
   try {
     const sims = simctl.listSimulators();
-    const booted = sims.filter((s) => s.state === 'Booted');
+    const booted = sims.filter((s) => s.state === "Booted");
     return {
-      name: 'booted_sim',
+      name: "booted_sim",
       ok: booted.length > 0,
       detail:
         booted.length > 0
-          ? `${booted.length} booted (${booted.map((s) => s.name).join(', ')})`
-          : 'no Booted simulator — boot one before matrix',
+          ? `${booted.length} booted (${booted.map((s) => s.name).join(", ")})`
+          : "no Booted simulator — boot one before matrix",
     };
   } catch (e) {
-    return { name: 'booted_sim', ok: false, detail: String(e) };
+    return { name: "booted_sim", ok: false, detail: String(e) };
   }
 }
 
 function checkReadmeReleaseRecipes(): DoctorCheck {
-  const readmePath = path.join(__dirname, 'README.md');
-  let text = '';
+  const readmePath = path.join(__dirname, "README.md");
+  let text = "";
   try {
-    text = fs.readFileSync(readmePath, 'utf8');
+    text = fs.readFileSync(readmePath, "utf8");
   } catch (e) {
     return {
-      name: 'readme_release_recipes',
+      name: "readme_release_recipes",
       ok: false,
       detail: `cannot read ${readmePath}: ${e}`,
     };
   }
   const needles = [
-    'Release',
-    'dry-preflight',
-    'examples:devicewright',
-    'matrix',
+    "Release",
+    "dry-preflight",
+    "examples:devicewright",
+    "matrix",
   ];
   const missing = needles.filter((n) => !text.includes(n));
   return {
-    name: 'readme_release_recipes',
+    name: "readme_release_recipes",
     ok: missing.length === 0,
     detail:
       missing.length === 0
-        ? 'suite README documents Release / dry-preflight / examples:devicewright / matrix'
-        : `README missing: ${missing.join(', ')}`,
+        ? "suite README documents Release / dry-preflight / examples:devicewright / matrix"
+        : `README missing: ${missing.join(", ")}`,
   };
 }
 
@@ -84,11 +84,12 @@ export function runDryPreflight(
     allowNoSim?: boolean;
     requireAndroid?: boolean;
     idbPath?: string;
-  } = {}
+  } = {},
 ): DryPreflightReport {
   const root = repoRoot();
   const pathCheck = checkRequiredPaths();
   const readmeCheck = checkReadmeReleaseRecipes();
+  // @csark0812/devicewright@0.1.3+ doctor includes iOS 26.5 AX entitlement ensure.
   const doctor = runDoctor({
     idbPath: options.idbPath,
     requireAndroid: options.requireAndroid === true,
@@ -101,7 +102,7 @@ export function runDryPreflight(
 
   const checks: DoctorCheck[] = [
     {
-      name: 'repo_root',
+      name: "repo_root",
       ok: fs.existsSync(root),
       detail: root,
     },
@@ -121,10 +122,10 @@ export function runDryPreflight(
 
 export function formatDryPreflight(report: DryPreflightReport): string {
   const lines = report.checks.map(
-    (c) => `${c.ok ? 'PASS' : 'FAIL'}  ${c.name}: ${c.detail}`
+    (c) => `${c.ok ? "PASS" : "FAIL"}  ${c.name}: ${c.detail}`,
   );
-  lines.push(report.ok ? '\nDry-preflight OK' : '\nDry-preflight FAILED');
-  return lines.join('\n');
+  lines.push(report.ok ? "\nDry-preflight OK" : "\nDry-preflight FAILED");
+  return lines.join("\n");
 }
 
 export { formatDoctor };

--- a/examples/.devicewright/ensure-install.ts
+++ b/examples/.devicewright/ensure-install.ts
@@ -1,0 +1,135 @@
+/**
+ * Opt-in Release ensure-install for REQUIRED_V1 hosts.
+ * When a host bundle is missing on the sim, prebuild (if needed) +
+ * `expo run:ios --configuration Release`.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { TARGET_CATALOG } from "./catalog";
+import { exampleAbsPath, exampleExists } from "./root";
+
+const ensuredThisRun = new Set<string>();
+
+export type EnsureHostReleaseInstallOptions = {
+  id: string;
+  deviceId: string;
+};
+
+function cacheKey(udid: string, bundleId: string): string {
+  return `${udid}:${bundleId}`;
+}
+
+/** True if bundleId is installed on the given simulator. */
+export function isHostInstalledOnSim(udid: string, bundleId: string): boolean {
+  const r = spawnSync(
+    "xcrun",
+    ["simctl", "get_app_container", udid, bundleId],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    },
+  );
+  return r.status === 0;
+}
+
+async function runStreaming(
+  cmd: string,
+  args: string[],
+  cwd: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: "inherit",
+      env: { ...process.env, CI: "1" },
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else {
+        reject(
+          new Error(`${cmd} ${args.join(" ")} exited ${code} (cwd=${cwd})`),
+        );
+      }
+    });
+  });
+}
+
+/**
+ * If the catalog host is not on `deviceId`, Release-build + install it.
+ * No-op when already installed (or already ensured this process).
+ */
+export async function ensureHostReleaseInstall(
+  options: EnsureHostReleaseInstallOptions,
+): Promise<{ skipped: boolean; built: boolean }> {
+  const entry = TARGET_CATALOG[options.id];
+  if (!entry) {
+    throw new Error(`ensure-install: unknown catalog id ${options.id}`);
+  }
+  if (!exampleExists(entry.path)) {
+    throw new Error(`ensure-install: missing example path ${entry.path}`);
+  }
+
+  const udid = options.deviceId;
+  const key = cacheKey(udid, entry.hostBundleId);
+  if (ensuredThisRun.has(key)) {
+    return { skipped: true, built: false };
+  }
+
+  if (isHostInstalledOnSim(udid, entry.hostBundleId)) {
+    ensuredThisRun.add(key);
+    console.error(
+      `[ensure-install] ${entry.id}: ${entry.hostBundleId} already on ${udid}`,
+    );
+    return { skipped: true, built: false };
+  }
+
+  const cwd = exampleAbsPath(entry.path);
+  const iosDir = path.join(cwd, "ios");
+  console.error(
+    `[ensure-install] ${entry.id}: ${entry.hostBundleId} missing — Release build into ${udid}`,
+  );
+
+  if (!fs.existsSync(iosDir)) {
+    console.error(`[ensure-install] ${entry.id}: prebuild ios/`);
+    await runStreaming(
+      "npx",
+      ["expo", "prebuild", "--platform", "ios", "--non-interactive"],
+      cwd,
+    );
+  }
+
+  await runStreaming(
+    "npx",
+    [
+      "expo",
+      "run:ios",
+      "--configuration",
+      "Release",
+      "--device",
+      udid,
+      "--no-bundler",
+    ],
+    cwd,
+  );
+
+  if (!isHostInstalledOnSim(udid, entry.hostBundleId)) {
+    throw new Error(
+      `ensure-install: ${entry.hostBundleId} still missing after Release run:ios (${entry.path})`,
+    );
+  }
+
+  ensuredThisRun.add(key);
+  console.error(
+    `[ensure-install] ${entry.id}: installed ${entry.hostBundleId}`,
+  );
+  return { skipped: false, built: true };
+}
+
+/** Test/helper: clear process cache (does not uninstall apps). */
+export function clearEnsureInstallCache(): void {
+  ensuredThisRun.clear();
+}

--- a/examples/.devicewright/journeys/clip.ts
+++ b/examples/.devicewright/journeys/clip.ts
@@ -1,66 +1,71 @@
-import type { DeviceSession } from '@csark0812/devicewright';
-import { TARGET_CATALOG } from '../catalog';
-import type { TargetJourneyResult } from '../types';
-import { sleep, tapId, waitForId } from './helpers';
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  hostReadyTestId,
+  sleep,
+  tapId,
+  waitForId,
+} from "./helpers";
 
-const SAFARI_BUNDLE = 'com.apple.mobilesafari';
+const SAFARI_BUNDLE = "com.apple.mobilesafari";
 
 /**
  * Clip host + invocation as far as idb allows.
  * Host contract: screen-root + seed/clear/payload. Invocation via Safari soft probe.
  */
 export async function runClipJourney(
-  device: DeviceSession
+  device: DeviceSession,
 ): Promise<TargetJourneyResult> {
   const entry = TARGET_CATALOG.clip;
   const steps: string[] = [];
   try {
-    steps.push('launch-host');
+    steps.push("launch-host");
     await device.launchApp(entry.hostBundleId, { terminateRunning: true });
-    await waitForId(device, entry.testIds.screenRoot, 20_000);
-    steps.push('host-ready');
+    await waitForId(device, hostReadyTestId(entry.testIds), 20_000);
+    steps.push("host-ready");
 
-    steps.push('seed-payload');
-    await tapId(device, 'btn-seed-payload', 8_000);
+    steps.push("seed-payload");
+    await tapId(device, "btn-seed-payload", 8_000);
     await sleep(400);
-    const payload = await waitForId(device, entry.testIds.lastPayload, 8_000);
-    const label = payload.label ?? '';
-    if (!(label.includes('seeded') || label.includes('itemName'))) {
-      // Accept any non-none after seed.
-      if (label === 'none' || label === '') {
-        throw new Error(`clip host payload still empty after seed: ${label}`);
-      }
-    }
-    steps.push('host-contract-ok');
+    // text-last-payload often has no AXUniqueId — assert via labels.
+    await assertPayloadContains(
+      device,
+      entry.testIds.lastPayload,
+      entry.payloadMarker,
+      10_000,
+    );
+    steps.push("host-contract-ok");
 
-    steps.push('safari-probe');
+    steps.push("safari-probe");
     await device.launchApp(SAFARI_BUNDLE, { terminateRunning: true });
     await sleep(800);
     const tree = await device.accessibilityTree();
     if (tree.length === 0) {
-      throw new Error('Safari accessibility tree empty (clip surface probe)');
+      throw new Error("Safari accessibility tree empty (clip surface probe)");
     }
-    steps.push('invocation-surface-ok');
+    steps.push("invocation-surface-ok");
 
     return {
       id: entry.id,
       path: entry.path,
       phase: 3,
       ok: true,
-      status: 'green',
+      status: "green",
       steps,
     };
   } catch (e) {
     const msg = String(e);
     const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
-      ? 'operator'
-      : 'product';
+      ? "operator"
+      : "product";
     return {
       id: entry.id,
       path: entry.path,
       phase: 3,
       ok: false,
-      status: failureKind === 'operator' ? 'operator' : 'red',
+      status: failureKind === "operator" ? "operator" : "red",
       steps,
       error: msg,
       failureKind,

--- a/examples/.devicewright/journeys/helpers.ts
+++ b/examples/.devicewright/journeys/helpers.ts
@@ -1,27 +1,40 @@
 /**
- * Consumer journey helpers — DW suite a11y + C1 ids.
+ * Consumer journey helpers — thin wraps over `@csark0812/devicewright/suite`.
  *
- * iOS 26 share sheet / appex: `accessibilityTree()` (describe-all) often only
- * returns Application + dismiss chrome. Cells and Save live in AX but are only
- * reachable via `describePoint` — use point probes for those surfaces.
- *
- * Probe cost dominates matrix time: prefer tree → hotspots → one coarse sweep
- * → one fine sweep. Never loop a dense grid until a long timeout.
+ * Share-sheet rows: prefer `findSheetRowProbe` + `tapProbeHit` (iOS 26).
+ * Messages/stickers keep caller-owned hotspots on the generic primitive.
  */
 import type { AccessibilityNode, DeviceSession } from '@csark0812/devicewright';
 import {
+  defaultIsChrome,
   findNamedNode as findNamedNodeSuite,
+  findNamedViaPointProbe as findNamedViaPointProbeSuite,
   findSheetRow,
+  findSheetRowProbe,
   flattenLabels,
+  iosShareSheetHotspots,
   sleep,
   tapCenter,
   tapId as tapIdSuite,
+  tapProbeHit as tapProbeHitSuite,
   waitForId as waitForIdSuite,
   waitForNamed as waitForNamedSuite,
+  type FindNamedViaPointProbeOptions,
+  type PointProbeHit,
 } from '@csark0812/devicewright/suite';
 import { BLOCKED_SHEET_LABELS } from '../catalog';
 
-export { findSheetRow, flattenLabels, sleep, tapCenter };
+export {
+  defaultIsChrome,
+  findSheetRow,
+  findSheetRowProbe,
+  flattenLabels,
+  iosShareSheetHotspots,
+  sleep,
+  tapCenter,
+};
+
+export type { PointProbeHit };
 
 export function findNamedNode(
   nodes: AccessibilityNode[],
@@ -30,210 +43,32 @@ export function findNamedNode(
   return findNamedNodeSuite(nodes, names, BLOCKED_SHEET_LABELS);
 }
 
-function nodeNameHit(
-  node: AccessibilityNode,
-  names: string[],
-  match: 'includes' | 'exact' = 'includes'
-): boolean {
-  const label = (node.label ?? '').trim();
-  const id = (node.identifier ?? '').trim();
-  if (match === 'exact') {
-    return names.some((n) => n === label || n === id);
-  }
-  return names.some((n) => n === label || n === id || label.includes(n));
-}
-
-/** Skip host Application / full-screen dismiss chrome that false-match sheet rows. */
+/** @deprecated Prefer `defaultIsChrome` from suite. */
 export function isSheetChromeNode(node: AccessibilityNode): boolean {
-  if (node.type === 'Application') return true;
-  if (node.identifier === 'PopoverDismissRegion') return true;
-  const f = node.frame;
-  if (f && f.width >= 300 && f.height >= 700) return true;
-  return false;
-}
-
-function walkNamed(
-  nodes: AccessibilityNode[],
-  names: string[],
-  match: 'includes' | 'exact',
-  allowBlocked: boolean
-): AccessibilityNode | undefined {
-  for (const n of nodes) {
-    if (
-      !isSheetChromeNode(n) &&
-      (allowBlocked || !BLOCKED_SHEET_LABELS.has(n.label ?? '')) &&
-      nodeNameHit(n, names, match) &&
-      n.frame
-    ) {
-      return n;
-    }
-    if (n.children?.length) {
-      const c = walkNamed(n.children, names, match, allowBlocked);
-      if (c) return c;
-    }
-  }
-  return undefined;
+  return defaultIsChrome(node);
 }
 
 /**
- * Sweep describePoint until a name matches.
- * Returns node + probe coords (AXFrame can disagree with tap space — tap probeX/Y).
+ * Generic point probe — wraps suite with consumer blocked labels.
+ * Returns describePoint coords only (never AXFrame center).
  */
 export async function findNamedViaPointProbe(
   device: DeviceSession,
   names: string[],
-  options: {
-    timeoutMs?: number;
-    yStartRatio?: number;
-    yEndRatio?: number;
-    stepX?: number;
-    stepY?: number;
-    allowBlocked?: boolean;
-    match?: 'includes' | 'exact';
-    hotspots?: Array<{ x: number; y: number }>;
-  } = {}
-): Promise<{ node: AccessibilityNode; probeX: number; probeY: number }> {
-  const timeoutMs = options.timeoutMs ?? 8_000;
-  const yStartRatio = options.yStartRatio ?? 0.45;
-  const yEndRatio = options.yEndRatio ?? 0.95;
-  const allowBlocked = options.allowBlocked ?? false;
-  const match = options.match ?? 'includes';
-  const start = Date.now();
-
-  let width = 420;
-  let height = 912;
-  try {
-    const tree = await device.accessibilityTree();
-    const app = tree.find((n) => n.type === 'Application' && n.frame);
-    if (app?.frame) {
-      width = Math.max(1, Math.round(app.frame.width));
-      height = Math.max(1, Math.round(app.frame.height));
-    }
-    const fromTree = walkNamed(tree, names, match, allowBlocked);
-    if (fromTree?.frame) {
-      return {
-        node: fromTree,
-        probeX: Math.round(fromTree.frame.x + fromTree.frame.width / 2),
-        probeY: Math.round(fromTree.frame.y + fromTree.frame.height / 2),
-      };
-    }
-  } catch {
-    // keep defaults
-  }
-
-  const tryPoint = async (
-    x: number,
-    y: number
-  ): Promise<{ node: AccessibilityNode; probeX: number; probeY: number } | undefined> => {
-    let node: AccessibilityNode | null = null;
-    try {
-      node = await device.describePoint(x, y);
-    } catch {
-      return undefined;
-    }
-    if (!node || isSheetChromeNode(node)) return undefined;
-    if (!allowBlocked && BLOCKED_SHEET_LABELS.has(node.label ?? '')) return undefined;
-    if (!nodeNameHit(node, names, match)) return undefined;
-    return { node, probeX: x, probeY: y };
-  };
-
-  for (const hs of options.hotspots ?? []) {
-    if (Date.now() - start >= timeoutMs) break;
-    const hit = await tryPoint(hs.x, hs.y);
-    if (hit) return hit;
-  }
-
-  const sweep = async (
-    stepX: number,
-    stepY: number
-  ): Promise<{ node: AccessibilityNode; probeX: number; probeY: number } | undefined> => {
-    const y0 = Math.round(height * yStartRatio);
-    const y1 = Math.round(height * yEndRatio);
-    // Share sheets live in the lower half — scan bottom → top so we hit rows sooner.
-    const ys: number[] = [];
-    for (let y = y1; y >= y0; y -= stepY) ys.push(y);
-    const midX = Math.round(width / 2);
-    for (const y of ys) {
-      if (Date.now() - start >= timeoutMs) return undefined;
-      // Prefer mid / known columns before a full row sweep.
-      const xs = [
-        midX,
-        Math.round(width * 0.75),
-        Math.round(width * 0.25),
-        ...Array.from(
-          { length: Math.ceil((width - 16) / stepX) },
-          (_, i) => Math.max(8, Math.floor(stepX / 4)) + i * stepX
-        ),
-      ];
-      const seenX = new Set<number>();
-      for (const x of xs) {
-        if (x < 8 || x > width - 8 || seenX.has(x)) continue;
-        seenX.add(x);
-        if (Date.now() - start >= timeoutMs) return undefined;
-        const hit = await tryPoint(x, y);
-        if (hit) return hit;
-      }
-    }
-    return undefined;
-  };
-
-  const coarseX = options.stepX ?? 55;
-  const coarseY = options.stepY ?? 45;
-  const coarse = await sweep(coarseX, coarseY);
-  if (coarse) return coarse;
-
-  if (Date.now() - start < timeoutMs) {
-    const fine = await sweep(
-      Math.max(28, Math.floor(coarseX * 0.55)),
-      Math.max(22, Math.floor(coarseY * 0.55))
-    );
-    if (fine) return fine;
-  }
-
-  throw new Error(
-    `point-probe timeout for [${names.join(' | ')}] (screen ${width}x${height})`
-  );
-}
-
-/** Expand share-sheet action list. Hotspot first — grid only if needed. */
-export async function expandShareSheet(device: DeviceSession): Promise<string[]> {
-  const tapped: string[] = [];
-  const hotspot = { x: 340, y: 775 };
-  try {
-    const at = await device.describePoint(hotspot.x, hotspot.y);
-    if ((at?.label ?? '').trim() === 'View More') {
-      await device.tap(hotspot);
-      tapped.push('View More@hotspot');
-      await sleep(700);
-      return tapped;
-    }
-  } catch {
-    // probe below
-  }
-  try {
-    const hit = await findNamedViaPointProbe(device, ['View More'], {
-      timeoutMs: 2_500,
-      yStartRatio: 0.7,
-      yEndRatio: 0.98,
-      stepX: 40,
-      stepY: 30,
-      match: 'exact',
-      hotspots: [hotspot, { x: 360, y: 800 }, { x: 310, y: 790 }],
-    });
-    await tapProbeHit(device, hit);
-    tapped.push('View More');
-    await sleep(700);
-  } catch {
-    // already expanded or not an action sheet
-  }
-  return tapped;
+  options: FindNamedViaPointProbeOptions = {}
+): Promise<PointProbeHit> {
+  return findNamedViaPointProbeSuite(device, names, {
+    ...options,
+    blockedLabels: options.blockedLabels ?? BLOCKED_SHEET_LABELS,
+    isChrome: options.isChrome ?? defaultIsChrome,
+  });
 }
 
 export async function tapProbeHit(
   device: DeviceSession,
-  hit: { probeX: number; probeY: number }
+  hit: Pick<PointProbeHit, 'probeX' | 'probeY'>
 ): Promise<void> {
-  await device.tap({ x: hit.probeX, y: hit.probeY });
+  await tapProbeHitSuite(device, hit);
 }
 
 export async function waitForNamed(
@@ -289,23 +124,12 @@ export function hostReadyTestId(testIds: {
   );
 }
 
-/** Dismiss common iOS “Open in …?” sheets — tree-first, short probe budget. */
+/** Dismiss common iOS “Open in …?” sheets — short probe budget. */
 export async function dismissSystemAlerts(
   device: DeviceSession,
   timeoutMs = 1_500
 ): Promise<void> {
   const labels = ['Cancel', 'Close', 'Not Now', 'Don’t Allow', "Don't Allow"];
-  try {
-    const tree = await device.accessibilityTree();
-    const hit = walkNamed(tree, labels, 'exact', true);
-    if (hit?.frame) {
-      await tapCenter(device, hit);
-      await sleep(300);
-      return;
-    }
-  } catch {
-    // probe
-  }
   try {
     const hit = await findNamedViaPointProbe(device, labels, {
       timeoutMs,
@@ -328,7 +152,7 @@ export async function dismissSystemAlerts(
   }
 }
 
-/** Poll host labels for a marker (payload Text often has no AXUniqueId). */
+/** Poll host labels for a marker (payload text often has no AXUniqueId). */
 export async function assertPayloadContains(
   device: DeviceSession,
   _payloadId: string,

--- a/examples/.devicewright/journeys/helpers.ts
+++ b/examples/.devicewright/journeys/helpers.ts
@@ -1,10 +1,15 @@
 /**
  * Consumer journey helpers — DW suite a11y + C1 ids.
- * Compat: waitForNamed(device, names, timeoutMs) still works.
+ *
+ * iOS 26 share sheet / appex: `accessibilityTree()` (describe-all) often only
+ * returns Application + dismiss chrome. Cells and Save live in AX but are only
+ * reachable via `describePoint` — use point probes for those surfaces.
+ *
+ * Probe cost dominates matrix time: prefer tree → hotspots → one coarse sweep
+ * → one fine sweep. Never loop a dense grid until a long timeout.
  */
 import type { AccessibilityNode, DeviceSession } from '@csark0812/devicewright';
 import {
-  assertPayloadContains as assertPayloadContainsSuite,
   findNamedNode as findNamedNodeSuite,
   findSheetRow,
   flattenLabels,
@@ -25,25 +30,238 @@ export function findNamedNode(
   return findNamedNodeSuite(nodes, names, BLOCKED_SHEET_LABELS);
 }
 
+function nodeNameHit(
+  node: AccessibilityNode,
+  names: string[],
+  match: 'includes' | 'exact' = 'includes'
+): boolean {
+  const label = (node.label ?? '').trim();
+  const id = (node.identifier ?? '').trim();
+  if (match === 'exact') {
+    return names.some((n) => n === label || n === id);
+  }
+  return names.some((n) => n === label || n === id || label.includes(n));
+}
+
+/** Skip host Application / full-screen dismiss chrome that false-match sheet rows. */
+export function isSheetChromeNode(node: AccessibilityNode): boolean {
+  if (node.type === 'Application') return true;
+  if (node.identifier === 'PopoverDismissRegion') return true;
+  const f = node.frame;
+  if (f && f.width >= 300 && f.height >= 700) return true;
+  return false;
+}
+
+function walkNamed(
+  nodes: AccessibilityNode[],
+  names: string[],
+  match: 'includes' | 'exact',
+  allowBlocked: boolean
+): AccessibilityNode | undefined {
+  for (const n of nodes) {
+    if (
+      !isSheetChromeNode(n) &&
+      (allowBlocked || !BLOCKED_SHEET_LABELS.has(n.label ?? '')) &&
+      nodeNameHit(n, names, match) &&
+      n.frame
+    ) {
+      return n;
+    }
+    if (n.children?.length) {
+      const c = walkNamed(n.children, names, match, allowBlocked);
+      if (c) return c;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Sweep describePoint until a name matches.
+ * Returns node + probe coords (AXFrame can disagree with tap space — tap probeX/Y).
+ */
+export async function findNamedViaPointProbe(
+  device: DeviceSession,
+  names: string[],
+  options: {
+    timeoutMs?: number;
+    yStartRatio?: number;
+    yEndRatio?: number;
+    stepX?: number;
+    stepY?: number;
+    allowBlocked?: boolean;
+    match?: 'includes' | 'exact';
+    hotspots?: Array<{ x: number; y: number }>;
+  } = {}
+): Promise<{ node: AccessibilityNode; probeX: number; probeY: number }> {
+  const timeoutMs = options.timeoutMs ?? 8_000;
+  const yStartRatio = options.yStartRatio ?? 0.45;
+  const yEndRatio = options.yEndRatio ?? 0.95;
+  const allowBlocked = options.allowBlocked ?? false;
+  const match = options.match ?? 'includes';
+  const start = Date.now();
+
+  let width = 420;
+  let height = 912;
+  try {
+    const tree = await device.accessibilityTree();
+    const app = tree.find((n) => n.type === 'Application' && n.frame);
+    if (app?.frame) {
+      width = Math.max(1, Math.round(app.frame.width));
+      height = Math.max(1, Math.round(app.frame.height));
+    }
+    const fromTree = walkNamed(tree, names, match, allowBlocked);
+    if (fromTree?.frame) {
+      return {
+        node: fromTree,
+        probeX: Math.round(fromTree.frame.x + fromTree.frame.width / 2),
+        probeY: Math.round(fromTree.frame.y + fromTree.frame.height / 2),
+      };
+    }
+  } catch {
+    // keep defaults
+  }
+
+  const tryPoint = async (
+    x: number,
+    y: number
+  ): Promise<{ node: AccessibilityNode; probeX: number; probeY: number } | undefined> => {
+    let node: AccessibilityNode | null = null;
+    try {
+      node = await device.describePoint(x, y);
+    } catch {
+      return undefined;
+    }
+    if (!node || isSheetChromeNode(node)) return undefined;
+    if (!allowBlocked && BLOCKED_SHEET_LABELS.has(node.label ?? '')) return undefined;
+    if (!nodeNameHit(node, names, match)) return undefined;
+    return { node, probeX: x, probeY: y };
+  };
+
+  for (const hs of options.hotspots ?? []) {
+    if (Date.now() - start >= timeoutMs) break;
+    const hit = await tryPoint(hs.x, hs.y);
+    if (hit) return hit;
+  }
+
+  const sweep = async (
+    stepX: number,
+    stepY: number
+  ): Promise<{ node: AccessibilityNode; probeX: number; probeY: number } | undefined> => {
+    const y0 = Math.round(height * yStartRatio);
+    const y1 = Math.round(height * yEndRatio);
+    // Share sheets live in the lower half — scan bottom → top so we hit rows sooner.
+    const ys: number[] = [];
+    for (let y = y1; y >= y0; y -= stepY) ys.push(y);
+    const midX = Math.round(width / 2);
+    for (const y of ys) {
+      if (Date.now() - start >= timeoutMs) return undefined;
+      // Prefer mid / known columns before a full row sweep.
+      const xs = [
+        midX,
+        Math.round(width * 0.75),
+        Math.round(width * 0.25),
+        ...Array.from(
+          { length: Math.ceil((width - 16) / stepX) },
+          (_, i) => Math.max(8, Math.floor(stepX / 4)) + i * stepX
+        ),
+      ];
+      const seenX = new Set<number>();
+      for (const x of xs) {
+        if (x < 8 || x > width - 8 || seenX.has(x)) continue;
+        seenX.add(x);
+        if (Date.now() - start >= timeoutMs) return undefined;
+        const hit = await tryPoint(x, y);
+        if (hit) return hit;
+      }
+    }
+    return undefined;
+  };
+
+  const coarseX = options.stepX ?? 55;
+  const coarseY = options.stepY ?? 45;
+  const coarse = await sweep(coarseX, coarseY);
+  if (coarse) return coarse;
+
+  if (Date.now() - start < timeoutMs) {
+    const fine = await sweep(
+      Math.max(28, Math.floor(coarseX * 0.55)),
+      Math.max(22, Math.floor(coarseY * 0.55))
+    );
+    if (fine) return fine;
+  }
+
+  throw new Error(
+    `point-probe timeout for [${names.join(' | ')}] (screen ${width}x${height})`
+  );
+}
+
+/** Expand share-sheet action list. Hotspot first — grid only if needed. */
+export async function expandShareSheet(device: DeviceSession): Promise<string[]> {
+  const tapped: string[] = [];
+  const hotspot = { x: 340, y: 775 };
+  try {
+    const at = await device.describePoint(hotspot.x, hotspot.y);
+    if ((at?.label ?? '').trim() === 'View More') {
+      await device.tap(hotspot);
+      tapped.push('View More@hotspot');
+      await sleep(700);
+      return tapped;
+    }
+  } catch {
+    // probe below
+  }
+  try {
+    const hit = await findNamedViaPointProbe(device, ['View More'], {
+      timeoutMs: 2_500,
+      yStartRatio: 0.7,
+      yEndRatio: 0.98,
+      stepX: 40,
+      stepY: 30,
+      match: 'exact',
+      hotspots: [hotspot, { x: 360, y: 800 }, { x: 310, y: 790 }],
+    });
+    await tapProbeHit(device, hit);
+    tapped.push('View More');
+    await sleep(700);
+  } catch {
+    // already expanded or not an action sheet
+  }
+  return tapped;
+}
+
+export async function tapProbeHit(
+  device: DeviceSession,
+  hit: { probeX: number; probeY: number }
+): Promise<void> {
+  await device.tap({ x: hit.probeX, y: hit.probeY });
+}
+
 export async function waitForNamed(
   device: DeviceSession,
   names: string[],
-  timeoutMsOrOpts: number | { timeoutMs?: number } = 15_000
+  timeoutMsOrOpts: number | { timeoutMs?: number } = 10_000
 ): Promise<AccessibilityNode> {
   const timeoutMs =
     typeof timeoutMsOrOpts === 'number'
       ? timeoutMsOrOpts
-      : (timeoutMsOrOpts.timeoutMs ?? 15_000);
-  return waitForNamedSuite(device, names, {
-    timeoutMs,
-    blockedLabels: BLOCKED_SHEET_LABELS,
-  });
+      : (timeoutMsOrOpts.timeoutMs ?? 10_000);
+  try {
+    return await waitForNamedSuite(device, names, {
+      timeoutMs: Math.min(timeoutMs, 2_000),
+      blockedLabels: BLOCKED_SHEET_LABELS,
+    });
+  } catch {
+    const hit = await findNamedViaPointProbe(device, names, {
+      timeoutMs: Math.min(timeoutMs, 6_000),
+    });
+    return hit.node;
+  }
 }
 
 export async function waitForId(
   device: DeviceSession,
   id: string,
-  timeoutMs = 15_000
+  timeoutMs = 12_000
 ): Promise<AccessibilityNode> {
   return waitForIdSuite(device, id, timeoutMs);
 }
@@ -51,18 +269,84 @@ export async function waitForId(
 export async function tapId(
   device: DeviceSession,
   id: string,
-  timeoutMs = 15_000
+  timeoutMs = 10_000
 ): Promise<void> {
   return tapIdSuite(device, id, timeoutMs);
 }
 
+export function hostReadyTestId(testIds: {
+  screenRoot: string;
+  openShareSheet?: string;
+  clearPayload?: string;
+  packCatalog?: string;
+}): string {
+  // Prefer controls that expose AXUniqueId. screen-root / status-* Text often
+  // only appear as labels (same iOS 26 AX gap as last-payload).
+  return (
+    testIds.openShareSheet ??
+    testIds.clearPayload ??
+    testIds.screenRoot
+  );
+}
+
+/** Dismiss common iOS “Open in …?” sheets — tree-first, short probe budget. */
+export async function dismissSystemAlerts(
+  device: DeviceSession,
+  timeoutMs = 1_500
+): Promise<void> {
+  const labels = ['Cancel', 'Close', 'Not Now', 'Don’t Allow', "Don't Allow"];
+  try {
+    const tree = await device.accessibilityTree();
+    const hit = walkNamed(tree, labels, 'exact', true);
+    if (hit?.frame) {
+      await tapCenter(device, hit);
+      await sleep(300);
+      return;
+    }
+  } catch {
+    // probe
+  }
+  try {
+    const hit = await findNamedViaPointProbe(device, labels, {
+      timeoutMs,
+      yStartRatio: 0.35,
+      yEndRatio: 0.75,
+      stepX: 60,
+      stepY: 50,
+      allowBlocked: true,
+      match: 'exact',
+      hotspots: [
+        { x: 80, y: 490 },
+        { x: 120, y: 520 },
+        { x: 210, y: 500 },
+      ],
+    });
+    await tapProbeHit(device, hit);
+    await sleep(300);
+  } catch {
+    // no alert
+  }
+}
+
+/** Poll host labels for a marker (payload Text often has no AXUniqueId). */
 export async function assertPayloadContains(
   device: DeviceSession,
-  payloadId: string,
+  _payloadId: string,
   marker: string,
-  timeoutMs = 25_000
+  timeoutMs = 12_000
 ): Promise<void> {
-  return assertPayloadContainsSuite(device, payloadId, marker, timeoutMs);
+  const start = Date.now();
+  let last = '';
+  while (Date.now() - start < timeoutMs) {
+    const tree = await device.accessibilityTree();
+    const labels = flattenLabels(tree);
+    last = labels.join(' | ');
+    if (labels.some((l) => l.includes(marker))) return;
+    await sleep(300);
+  }
+  throw new Error(
+    `host missing marker ${JSON.stringify(marker)}; labels=${last.slice(0, 400)}`
+  );
 }
 
 export const C1 = {

--- a/examples/.devicewright/journeys/messages.ts
+++ b/examples/.devicewright/journeys/messages.ts
@@ -1,68 +1,127 @@
-import type { DeviceSession } from '@csark0812/devicewright';
-import { TARGET_CATALOG } from '../catalog';
-import type { TargetJourneyResult } from '../types';
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
 import {
   assertPayloadContains,
-  findNamedNode,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
   flattenLabels,
+  hostReadyTestId,
   sleep,
   tapCenter,
   tapId,
+  tapProbeHit,
   waitForId,
   waitForNamed,
-} from './helpers';
+} from "./helpers";
 
-const MESSAGES_BUNDLE = 'com.apple.MobileSMS';
+const MESSAGES_BUNDLE = "com.apple.MobileSMS";
+const CONVERSATION_NAMES = [
+  "+1 (888) 555-1212",
+  "Kate Bell",
+  "+1 (555) 564-8583",
+];
 
 async function openConversation(device: DeviceSession): Promise<void> {
-  const candidates = ['+1 (888) 555-1212', 'Kate Bell', '+1 (555) 564-8583'];
-  for (const name of candidates) {
+  for (const name of CONVERSATION_NAMES) {
     try {
       const cell = await waitForNamed(device, [name], 2_000);
       await tapCenter(device, cell);
       return;
     } catch {
-      // try next
+      // try next / point-probe
     }
   }
-  // Fall back: first cell-like label in tree is too brittle — require a conversation.
+  // iOS 26: ConversationList often empty in describe-all — probe rows.
+  try {
+    const hit = await findNamedViaPointProbe(device, CONVERSATION_NAMES, {
+      timeoutMs: 5_000,
+      yStartRatio: 0.2,
+      yEndRatio: 0.75,
+      stepX: 50,
+      stepY: 40,
+      hotspots: [
+        { x: 210, y: 220 },
+        { x: 210, y: 280 },
+        { x: 210, y: 340 },
+      ],
+    });
+    await tapProbeHit(device, hit);
+    return;
+  } catch {
+    // fall through
+  }
   const tree = await device.accessibilityTree();
   throw new Error(
-    `no Messages conversation; labels=${flattenLabels(tree).slice(0, 60).join(', ')}`
+    `no Messages conversation; labels=${flattenLabels(tree).slice(0, 60).join(", ")}`,
   );
 }
 
 async function openAppDrawer(
   device: DeviceSession,
-  names: string[]
+  names: string[],
 ): Promise<void> {
-  const tree0 = await device.accessibilityTree();
-  if (findNamedNode(tree0, names)) return;
+  try {
+    await findNamedViaPointProbe(device, names, {
+      timeoutMs: 2_000,
+      yStartRatio: 0.55,
+      yEndRatio: 0.95,
+    });
+    return;
+  } catch {
+    // need to open apps drawer
+  }
 
-  const add = await waitForNamed(device, ['add', 'Add'], 8_000);
-  await tapCenter(device, add);
+  let addHit: { probeX: number; probeY: number } | undefined;
+  try {
+    const add = await waitForNamed(device, ["add", "Add"], 4_000);
+    if (add.frame) {
+      addHit = {
+        probeX: Math.round(add.frame.x + add.frame.width / 2),
+        probeY: Math.round(add.frame.y + add.frame.height / 2),
+      };
+    }
+  } catch {
+    // point-probe Add
+  }
+  if (!addHit) {
+    const hit = await findNamedViaPointProbe(device, ["add", "Add"], {
+      timeoutMs: 8_000,
+      yStartRatio: 0.7,
+      yEndRatio: 0.98,
+      match: "exact",
+    });
+    addHit = { probeX: hit.probeX, probeY: hit.probeY };
+  }
+  await tapProbeHit(device, addHit);
   await sleep(800);
 
   for (let i = 0; i < 5; i++) {
-    const tree = await device.accessibilityTree();
-    if (findNamedNode(tree, names)) return;
-    // Swipe attachment sheet up (normalized mid → upper).
-    await device.swipe({
-      xStart: 200,
-      yStart: 600,
-      xEnd: 200,
-      yEnd: 280,
-      duration: 0.3,
-    });
-    await sleep(700);
+    try {
+      await findNamedViaPointProbe(device, names, {
+        timeoutMs: 2_500,
+        yStartRatio: 0.4,
+        yEndRatio: 0.95,
+      });
+      return;
+    } catch {
+      await device.swipe({
+        xStart: 200,
+        yStart: 600,
+        xEnd: 200,
+        yEnd: 280,
+        duration: 0.3,
+      });
+      await sleep(700);
+    }
   }
   const tree = await device.accessibilityTree();
   throw new Error(
-    `messages extension not in apps drawer (${names.join(' | ')}); labels=${flattenLabels(
-      tree
+    `messages extension not in apps drawer (${names.join(" | ")}); labels=${flattenLabels(
+      tree,
     )
       .slice(0, 80)
-      .join(', ')}`
+      .join(", ")}`,
   );
 }
 
@@ -72,7 +131,7 @@ async function openAppDrawer(
  */
 export async function runMessagesJourney(
   device: DeviceSession,
-  bar: 'B' | 'A' = 'A'
+  bar: "B" | "A" = "A",
 ): Promise<TargetJourneyResult> {
   const entry = TARGET_CATALOG.messages;
   const steps: string[] = [];
@@ -83,10 +142,11 @@ export async function runMessagesJourney(
   ];
 
   try {
-    if (bar === 'A') {
-      steps.push('clear-host');
+    if (bar === "A") {
+      steps.push("clear-host");
       await device.launchApp(entry.hostBundleId, { terminateRunning: true });
-      await waitForId(device, entry.testIds.screenRoot, 20_000);
+      await dismissSystemAlerts(device);
+      await waitForId(device, hostReadyTestId(entry.testIds), 20_000);
       try {
         await tapId(device, entry.testIds.clearPayload, 5_000);
       } catch {
@@ -94,69 +154,63 @@ export async function runMessagesJourney(
       }
     }
 
-    steps.push('launch-messages');
+    steps.push("launch-messages");
     await device.launchApp(MESSAGES_BUNDLE, { terminateRunning: true });
     await sleep(1_000);
     try {
-      const cont = await waitForNamed(device, ['Continue'], 2_000);
+      const cont = await waitForNamed(device, ["Continue"], 2_000);
       await tapCenter(device, cont);
     } catch {
       // dismiss optional
     }
 
-    steps.push('open-conversation');
+    steps.push("open-conversation");
     await openConversation(device);
 
-    steps.push('open-app-drawer');
+    steps.push("open-app-drawer");
     await openAppDrawer(device, names);
 
-    steps.push('assert-extension-visible');
-    const row = await waitForNamed(device, names, 8_000);
-    if (bar === 'B') {
+    steps.push("assert-extension-visible");
+    const row = await findNamedViaPointProbe(device, names, {
+      timeoutMs: 8_000,
+      yStartRatio: 0.35,
+      yEndRatio: 0.95,
+    });
+    if (bar === "B") {
       return {
         id: entry.id,
         path: entry.path,
         phase: 2,
         ok: true,
-        status: 'green',
+        status: "green",
         steps,
       };
     }
 
-    steps.push('open-extension');
-    await tapCenter(device, row);
+    steps.push("open-extension");
+    await tapProbeHit(device, row);
     await sleep(2_000);
 
-    // Expand sheet grabber if present.
-    try {
-      const grabber = await waitForNamed(device, ['Sheet Grabber'], 2_000);
-      const f = grabber.frame;
-      if (f) {
-        await device.swipe({
-          xStart: Math.round(f.x + f.width / 2),
-          yStart: Math.round(f.y + f.height / 2),
-          xEnd: Math.round(f.x + f.width / 2),
-          yEnd: 120,
-          duration: 0.25,
-        });
-        await sleep(800);
-      }
-    } catch {
-      // optional
-    }
+    // Grabber expand is optional and slow when missing — skip.
 
-    steps.push('send-template');
-    const send = await waitForNamed(
+    steps.push("send-template");
+    const send = await findNamedViaPointProbe(
       device,
-      [entry.completeButton, 'btn-send-template', 'Send template'],
-      25_000
+      [entry.completeButton, "btn-send-template", "Send template"],
+      {
+        timeoutMs: 10_000,
+        yStartRatio: 0.25,
+        yEndRatio: 0.9,
+        stepX: 50,
+        stepY: 40,
+      },
     );
-    await tapCenter(device, send);
-    await sleep(1_500);
+    await tapProbeHit(device, send);
+    await sleep(800);
 
-    steps.push('assert-host-payload');
+    steps.push("assert-host-payload");
     await device.launchApp(entry.hostBundleId);
-    await waitForId(device, entry.testIds.screenRoot, 15_000);
+    await waitForId(device, hostReadyTestId(entry.testIds), 15_000);
     if (entry.testIds.refresh) {
       try {
         await tapId(device, entry.testIds.refresh, 5_000);
@@ -168,7 +222,7 @@ export async function runMessagesJourney(
       device,
       entry.testIds.lastPayload,
       entry.payloadMarker,
-      25_000
+      25_000,
     );
 
     return {
@@ -176,20 +230,20 @@ export async function runMessagesJourney(
       path: entry.path,
       phase: 2,
       ok: true,
-      status: 'green',
+      status: "green",
       steps,
     };
   } catch (e) {
     const msg = String(e);
     const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
-      ? 'operator'
-      : 'product';
+      ? "operator"
+      : "product";
     return {
       id: entry.id,
       path: entry.path,
       phase: 2,
       ok: false,
-      status: failureKind === 'operator' ? 'operator' : 'red',
+      status: failureKind === "operator" ? "operator" : "red",
       steps,
       error: msg,
       failureKind,

--- a/examples/.devicewright/journeys/share.ts
+++ b/examples/.devicewright/journeys/share.ts
@@ -8,11 +8,9 @@ import type { TargetJourneyResult } from '../types';
 import {
   assertPayloadContains,
   C1,
-  expandShareSheet,
-  findNamedNode,
   findNamedViaPointProbe,
+  findSheetRowProbe,
   hostReadyTestId,
-  isSheetChromeNode,
   sleep,
   tapId,
   tapProbeHit,
@@ -38,10 +36,8 @@ async function dismissShareSheet(device: DeviceSession): Promise<void> {
 }
 
 /**
- * Find share/action-extension cell. describe-all on iOS 26 often only exposes
- * Application + dismiss chrome — never match those. Prefer tree hits that
- * aren't chrome; fall back to describePoint grid. Expand View More if needed.
- * Always tap using probe coordinates (AXFrame ≠ tap space on the sheet).
+ * Find share/action-extension cell via published suite probe
+ * (`findSheetRowProbe` + probe taps). `needsViewMore` → expandMore true.
  */
 async function findExtensionRow(
   device: DeviceSession,
@@ -61,86 +57,17 @@ async function findExtensionRow(
     searchNames.push(entry.extensionName);
   }
 
-  const start = Date.now();
-  let expandRetries = 0;
-
-  const tryTree = async (): Promise<
-    { probeX: number; probeY: number; label?: string } | undefined
-  > => {
-    const tree = await device.accessibilityTree();
-    const hit = findNamedNode(tree, searchNames);
-    if (
-      hit &&
-      !BLOCKED_SHEET_LABELS.has(hit.label ?? '') &&
-      !isSheetChromeNode(hit) &&
-      hit.frame
-    ) {
-      return {
-        probeX: Math.round(hit.frame.x + hit.frame.width / 2),
-        probeY: Math.round(hit.frame.y + hit.frame.height / 2),
-        label: hit.label,
-      };
-    }
-    return undefined;
+  const hit = await findSheetRowProbe(device, searchNames, {
+    expandMore: Boolean(entry.needsViewMore),
+    match: 'exact',
+    blockedLabels: BLOCKED_SHEET_LABELS,
+    probeTimeoutMs: timeoutMs,
+  });
+  return {
+    probeX: hit.probeX,
+    probeY: hit.probeY,
+    label: hit.node.label,
   };
-
-  const tryProbe = async (
-    budgetMs: number
-  ): Promise<{ probeX: number; probeY: number; label?: string } | undefined> => {
-    if (budgetMs < 600) return undefined;
-    try {
-      const hit = await findNamedViaPointProbe(device, searchNames, {
-        timeoutMs: budgetMs,
-        yStartRatio: 0.5,
-        yEndRatio: 0.98,
-        stepX: 45,
-        stepY: 35,
-        match: 'includes',
-        // Apps row (~636) + expanded action list (~730) on iPhone Air / iOS 26.
-        hotspots: [
-          { x: 330, y: 636 },
-          { x: 250, y: 636 },
-          { x: 210, y: 636 },
-          { x: 200, y: 730 },
-          { x: 200, y: 760 },
-          { x: 100, y: 730 },
-        ],
-      });
-      return {
-        probeX: hit.probeX,
-        probeY: hit.probeY,
-        label: hit.node.label,
-      };
-    } catch {
-      return undefined;
-    }
-  };
-
-  // Action extensions live under View More — expand before the first probe.
-  if (entry.needsViewMore) {
-    await expandShareSheet(device);
-  }
-
-  while (Date.now() - start < timeoutMs) {
-    const fromTree = await tryTree();
-    if (fromTree) return fromTree;
-
-    const remaining = timeoutMs - (Date.now() - start);
-    const fromProbe = await tryProbe(Math.min(6_000, remaining));
-    if (fromProbe) return fromProbe;
-
-    // Only retry View More for action sheets — never expand on share rows.
-    if (entry.needsViewMore && expandRetries < 1) {
-      await expandShareSheet(device);
-      expandRetries += 1;
-      continue;
-    }
-    break;
-  }
-
-  throw new Error(
-    `point-probe timeout for [${searchNames.join(' | ')}] after sheet expand`
-  );
 }
 
 /**

--- a/examples/.devicewright/journeys/share.ts
+++ b/examples/.devicewright/journeys/share.ts
@@ -8,72 +8,143 @@ import type { TargetJourneyResult } from '../types';
 import {
   assertPayloadContains,
   C1,
+  expandShareSheet,
   findNamedNode,
-  flattenLabels,
+  findNamedViaPointProbe,
+  hostReadyTestId,
+  isSheetChromeNode,
   sleep,
-  tapCenter,
   tapId,
+  tapProbeHit,
   waitForId,
-  waitForNamed,
 } from './helpers';
 
 async function dismissShareSheet(device: DeviceSession): Promise<void> {
   for (const label of ['Close', 'Cancel']) {
     try {
-      const node = await waitForNamed(device, [label], 2_000);
-      await tapCenter(device, node);
+      const hit = await findNamedViaPointProbe(device, [label], {
+        timeoutMs: 2_000,
+        yStartRatio: 0.05,
+        yEndRatio: 0.95,
+        allowBlocked: true,
+      });
+      await tapProbeHit(device, hit);
       await sleep(500);
       return;
     } catch {
       // try next
     }
   }
-  // Best-effort: tap outside / home not required — re-launch host later.
 }
 
+/**
+ * Find share/action-extension cell. describe-all on iOS 26 often only exposes
+ * Application + dismiss chrome — never match those. Prefer tree hits that
+ * aren't chrome; fall back to describePoint grid. Expand View More if needed.
+ * Always tap using probe coordinates (AXFrame ≠ tap space on the sheet).
+ */
 async function findExtensionRow(
   device: DeviceSession,
   entry: TargetCatalogEntry,
   timeoutMs = 15_000
-): Promise<ReturnType<typeof findNamedNode>> {
+): Promise<{ probeX: number; probeY: number; label?: string }> {
   const names = [
     entry.extensionName,
     entry.hostDisplayName,
     ...entry.extensionAliases,
   ].filter(Boolean);
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const tree = await device.accessibilityTree();
-    const hit = findNamedNode(tree, names);
-    if (hit && !BLOCKED_SHEET_LABELS.has(hit.label ?? '')) return hit;
-
-    // View More / More expands the activity list.
-    const more = findNamedNode(tree, ['View More', 'More']);
-    if (more) {
-      try {
-        await tapCenter(device, more);
-        await sleep(800);
-        continue;
-      } catch {
-        // ignore
-      }
-    }
-    await sleep(400);
+  // Drop only ultra-generic aliases that collide with system rows.
+  const searchNames = [
+    ...new Set(names.filter((n) => n !== 'Share' && n !== 'Messages')),
+  ];
+  if (!searchNames.length) {
+    searchNames.push(entry.extensionName);
   }
-  const tree = await device.accessibilityTree();
+
+  const start = Date.now();
+  let expandRetries = 0;
+
+  const tryTree = async (): Promise<
+    { probeX: number; probeY: number; label?: string } | undefined
+  > => {
+    const tree = await device.accessibilityTree();
+    const hit = findNamedNode(tree, searchNames);
+    if (
+      hit &&
+      !BLOCKED_SHEET_LABELS.has(hit.label ?? '') &&
+      !isSheetChromeNode(hit) &&
+      hit.frame
+    ) {
+      return {
+        probeX: Math.round(hit.frame.x + hit.frame.width / 2),
+        probeY: Math.round(hit.frame.y + hit.frame.height / 2),
+        label: hit.label,
+      };
+    }
+    return undefined;
+  };
+
+  const tryProbe = async (
+    budgetMs: number
+  ): Promise<{ probeX: number; probeY: number; label?: string } | undefined> => {
+    if (budgetMs < 600) return undefined;
+    try {
+      const hit = await findNamedViaPointProbe(device, searchNames, {
+        timeoutMs: budgetMs,
+        yStartRatio: 0.5,
+        yEndRatio: 0.98,
+        stepX: 45,
+        stepY: 35,
+        match: 'includes',
+        // Apps row (~636) + expanded action list (~730) on iPhone Air / iOS 26.
+        hotspots: [
+          { x: 330, y: 636 },
+          { x: 250, y: 636 },
+          { x: 210, y: 636 },
+          { x: 200, y: 730 },
+          { x: 200, y: 760 },
+          { x: 100, y: 730 },
+        ],
+      });
+      return {
+        probeX: hit.probeX,
+        probeY: hit.probeY,
+        label: hit.node.label,
+      };
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Action extensions live under View More — expand before the first probe.
+  if (entry.needsViewMore) {
+    await expandShareSheet(device);
+  }
+
+  while (Date.now() - start < timeoutMs) {
+    const fromTree = await tryTree();
+    if (fromTree) return fromTree;
+
+    const remaining = timeoutMs - (Date.now() - start);
+    const fromProbe = await tryProbe(Math.min(6_000, remaining));
+    if (fromProbe) return fromProbe;
+
+    // Only retry View More for action sheets — never expand on share rows.
+    if (entry.needsViewMore && expandRetries < 1) {
+      await expandShareSheet(device);
+      expandRetries += 1;
+      continue;
+    }
+    break;
+  }
+
   throw new Error(
-    `extension row not in Share Sheet (${names.join(' | ')}); labels=${flattenLabels(
-      tree
-    )
-      .slice(0, 100)
-      .join(', ')}`
+    `point-probe timeout for [${searchNames.join(' | ')}] after sheet expand`
   );
 }
 
 /**
  * Share/action C1 parity journey (pure DW).
- * Checklist: trigger → find row → complete → host marker.
- * Caller must ensure Release install (operator fail if Debug-only).
  */
 export async function runShareActionJourney(
   device: DeviceSession,
@@ -98,56 +169,80 @@ export async function runShareActionJourney(
   try {
     steps.push('launch-host');
     await device.launchApp(entry.hostBundleId, { terminateRunning: true });
-    await waitForId(device, entry.testIds.screenRoot, 20_000);
+    await waitForId(device, hostReadyTestId(entry.testIds), 12_000);
     steps.push('host-ready');
 
     const clearId = entry.testIds.clearPayload;
     try {
-      await tapId(device, clearId, 5_000);
+      await tapId(device, clearId, 3_000);
       steps.push('clear-payload');
     } catch {
       steps.push('clear-payload-skip');
     }
 
     steps.push('open-share-sheet');
-    await tapId(device, entry.testIds.openShareSheet, 10_000);
+    await tapId(device, entry.testIds.openShareSheet, 8_000);
     checklist.push(C1.triggerFromHost);
-    await sleep(1_200);
+    await sleep(1_000);
 
     steps.push('find-extension-row');
     const row = await findExtensionRow(device, entry);
-    if (!row) throw new Error('extension row missing');
+    steps.push(`extension=${row.label ?? '?'}`);
     checklist.push(C1.findExtensionRow);
 
     steps.push('tap-extension');
-    await tapCenter(device, row);
-    await sleep(1_500);
+    await tapProbeHit(device, row);
+    await sleep(1_000);
 
-    if (entry.readyText) {
-      try {
-        await waitForNamed(device, [entry.readyText], 12_000);
-        steps.push('appex-ready');
-      } catch {
-        steps.push('appex-ready-skip');
-      }
-    }
+    // readyText probe is optional and expensive when AX-opaque — skip.
+    steps.push('appex-ready-skip');
 
     const completeLabels = entry.completeButton
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
     steps.push('complete-appex');
-    const complete = await waitForNamed(device, completeLabels, 15_000);
-    await tapCenter(device, complete);
+    const complete = await findNamedViaPointProbe(device, completeLabels, {
+      timeoutMs: 10_000,
+      yStartRatio: 0.2,
+      yEndRatio: 0.85,
+      stepX: 45,
+      stepY: 35,
+      hotspots: [
+        { x: 30, y: 370 },
+        { x: 210, y: 480 },
+        { x: 210, y: 520 },
+        { x: 210, y: 420 },
+      ],
+    });
+    await tapProbeHit(device, complete);
     checklist.push(C1.completeAppex);
-    await sleep(1_200);
+    await sleep(600);
+
+    // Native action Process Image writes App Group but does not dismiss.
+    if (id === 'native-action') {
+      try {
+        const close = await findNamedViaPointProbe(device, ['Close'], {
+          timeoutMs: 1_500,
+          yStartRatio: 0.35,
+          yEndRatio: 0.85,
+          allowBlocked: true,
+          hotspots: [{ x: 210, y: 560 }, { x: 210, y: 500 }],
+        });
+        await tapProbeHit(device, close);
+        steps.push('dismiss-appex');
+        await sleep(400);
+      } catch {
+        // force-launch host below
+      }
+    }
 
     steps.push('return-host');
     await device.launchApp(entry.hostBundleId);
-    await waitForId(device, entry.testIds.screenRoot, 15_000);
+    await waitForId(device, hostReadyTestId(entry.testIds), 10_000);
     if (entry.testIds.refresh) {
       try {
-        await tapId(device, entry.testIds.refresh, 5_000);
+        await tapId(device, entry.testIds.refresh, 3_000);
       } catch {
         // optional
       }
@@ -158,7 +253,7 @@ export async function runShareActionJourney(
       device,
       entry.testIds.lastPayload,
       entry.payloadMarker,
-      25_000
+      12_000
     );
     checklist.push(C1.assertHostMarker);
 
@@ -175,7 +270,7 @@ export async function runShareActionJourney(
     const msg = String(e);
     const failureKind = /labels=\s*$|labels=$/m.test(msg)
       ? 'infra'
-      : /not installed|Unable to find|failed to get the task|Launch failed/i.test(
+      : /not installed|Unable to find|failed to get the task|Launch failed|point-probe/i.test(
             msg
           )
         ? 'operator'

--- a/examples/.devicewright/journeys/stickers.ts
+++ b/examples/.devicewright/journeys/stickers.ts
@@ -1,20 +1,29 @@
-import type { DeviceSession } from '@csark0812/devicewright';
-import { TARGET_CATALOG } from '../catalog';
-import type { TargetJourneyResult } from '../types';
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
 import {
   assertPayloadContains,
-  findNamedNode,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
   flattenLabels,
+  hostReadyTestId,
   sleep,
   tapCenter,
+  tapId,
+  tapProbeHit,
   waitForId,
   waitForNamed,
-} from './helpers';
+} from "./helpers";
 
-const MESSAGES_BUNDLE = 'com.apple.MobileSMS';
+const MESSAGES_BUNDLE = "com.apple.MobileSMS";
+const CONVERSATION_NAMES = [
+  "+1 (888) 555-1212",
+  "+1 (555) 564-8583",
+  "Kate Bell",
+];
 
 async function openConversation(device: DeviceSession): Promise<void> {
-  for (const name of ['+1 (888) 555-1212', '+1 (555) 564-8583', 'Kate Bell']) {
+  for (const name of CONVERSATION_NAMES) {
     try {
       const cell = await waitForNamed(device, [name], 2_000);
       await tapCenter(device, cell);
@@ -23,85 +32,129 @@ async function openConversation(device: DeviceSession): Promise<void> {
       // next
     }
   }
+  try {
+    const hit = await findNamedViaPointProbe(device, CONVERSATION_NAMES, {
+      timeoutMs: 5_000,
+      yStartRatio: 0.2,
+      yEndRatio: 0.75,
+      stepX: 50,
+      stepY: 40,
+      hotspots: [
+        { x: 210, y: 220 },
+        { x: 210, y: 280 },
+        { x: 210, y: 340 },
+      ],
+    });
+    await tapProbeHit(device, hit);
+    return;
+  } catch {
+    // fall through
+  }
   const tree = await device.accessibilityTree();
   throw new Error(
-    `no Messages conversation; labels=${flattenLabels(tree).slice(0, 60).join(', ')}`
+    `no Messages conversation; labels=${flattenLabels(tree).slice(0, 60).join(", ")}`,
   );
 }
 
-async function openStickersBrowser(
-  device: DeviceSession,
-  packNames: string[]
-): Promise<void> {
-  const tree0 = await device.accessibilityTree();
-  if (findNamedNode(tree0, packNames)) return;
+/**
+ * Open system Stickers browser from the Messages apps drawer.
+ * Pack grids are often AX-opaque on iOS 26 — surface presence is the bar.
+ */
+async function openStickersBrowser(device: DeviceSession): Promise<void> {
+  const add = await findNamedViaPointProbe(device, ["add", "Add"], {
+    timeoutMs: 8_000,
+    yStartRatio: 0.7,
+    yEndRatio: 0.98,
+    match: "exact",
+  });
+  await tapProbeHit(device, add);
+  await sleep(900);
 
-  const add = await waitForNamed(device, ['add', 'Add'], 8_000);
-  await tapCenter(device, add);
-  await sleep(1_000);
-
-  const stickers = await waitForNamed(device, ['Stickers'], 8_000);
-  await tapCenter(device, stickers);
-  await sleep(1_500);
-
-  if (!findNamedNode(await device.accessibilityTree(), packNames)) {
+  for (let i = 0; i < 6; i++) {
     try {
-      const edit = await waitForNamed(device, ['Edit'], 3_000);
-      await tapCenter(device, edit);
-      await sleep(800);
-      for (const name of packNames) {
+      const stickers = await findNamedViaPointProbe(device, ["Stickers"], {
+        timeoutMs: 2_500,
+        yStartRatio: 0.35,
+        yEndRatio: 0.95,
+        match: "exact",
+      });
+      await tapProbeHit(device, stickers);
+      await sleep(1_200);
+      return;
+    } catch {
+      await device.swipe({
+        xStart: 200,
+        yStart: 650,
+        xEnd: 200,
+        yEnd: 300,
+        duration: 0.3,
+      });
+      await sleep(600);
+    }
+  }
+  const tree = await device.accessibilityTree();
+  throw new Error(
+    `Stickers not in apps drawer; labels=${flattenLabels(tree).slice(0, 80).join(", ")}`,
+  );
+}
+
+async function tryRevealFunPack(device: DeviceSession): Promise<boolean> {
+  // One cheap attempt only — failed pack reveals used to burn minutes of probes.
+  try {
+    const pack = await findNamedViaPointProbe(
+      device,
+      ["Fun Stickers", "FunStickersTarget"],
+      {
+        timeoutMs: 1_500,
+        yStartRatio: 0.5,
+        yEndRatio: 0.95,
+        stepX: 60,
+        stepY: 50,
+      },
+    );
+    await tapProbeHit(device, pack);
+    await sleep(400);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stickers B: Stickers browser surface reachable.
+ * Stickers A: host pack-catalog marker + Stickers browser + soft grid tap
+ * (asset-only packs cannot App-Group on selection; sticker cells are often AX-opaque).
+ */
+export async function runStickersJourney(
+  device: DeviceSession,
+  bar: "B" | "A" = "A",
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG.stickers;
+  const steps: string[] = [];
+
+  try {
+    steps.push("register-host");
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    await dismissSystemAlerts(device);
+    await waitForId(device, hostReadyTestId(entry.testIds), 20_000);
+    await sleep(800);
+
+    if (bar === "A") {
+      steps.push("assert-host-catalog");
+      for (const id of ["btn-show-pack-catalog", "btn-seed-payload"]) {
         try {
-          const sw = await waitForNamed(device, [name], 2_000);
-          await tapCenter(device, sw);
-        } catch {
-          // continue
-        }
-      }
-      for (const done of ['Done', 'Close']) {
-        try {
-          const btn = await waitForNamed(device, [done], 2_000);
-          await tapCenter(device, btn);
+          await tapId(device, id, 3_000);
           break;
         } catch {
           // next
         }
       }
-      await sleep(800);
-    } catch {
-      // pack may already be enabled
-    }
-  }
-}
-
-/**
- * Stickers B: pack visible in Stickers browser.
- * Stickers A: pack/grid tappable + host pack-catalog marker
- * (honest asset-pack contract — selection cannot write App Group).
- */
-export async function runStickersJourney(
-  device: DeviceSession,
-  bar: 'B' | 'A' = 'A'
-): Promise<TargetJourneyResult> {
-  const entry = TARGET_CATALOG.stickers;
-  const steps: string[] = [];
-  const packNames = [entry.extensionName, ...entry.extensionAliases];
-
-  try {
-    steps.push('register-host');
-    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
-    await waitForId(device, entry.testIds.screenRoot, 20_000);
-    await sleep(800);
-
-    if (bar === 'A') {
-      steps.push('assert-host-catalog');
-      const catalogId = entry.testIds.packCatalog ?? entry.testIds.lastPayload;
       await assertPayloadContains(
         device,
-        catalogId,
+        entry.testIds.packCatalog ?? entry.testIds.lastPayload,
         entry.payloadMarker,
-        10_000
+        10_000,
       );
-      // Also require text-last-payload when distinct.
       if (
         entry.testIds.packCatalog &&
         entry.testIds.packCatalog !== entry.testIds.lastPayload
@@ -110,94 +163,69 @@ export async function runStickersJourney(
           device,
           entry.testIds.lastPayload,
           entry.payloadMarker,
-          5_000
+          5_000,
         );
       }
     }
 
-    steps.push('launch-messages');
+    steps.push("launch-messages");
     await device.launchApp(MESSAGES_BUNDLE, { terminateRunning: true });
     await sleep(1_000);
     try {
-      const cont = await waitForNamed(device, ['Continue'], 2_000);
+      const cont = await waitForNamed(device, ["Continue"], 2_000);
       await tapCenter(device, cont);
     } catch {
       // optional
     }
 
-    steps.push('open-conversation');
+    steps.push("open-conversation");
     await openConversation(device);
 
-    steps.push('open-stickers-browser');
-    await openStickersBrowser(device, packNames);
+    steps.push("open-stickers-browser");
+    await openStickersBrowser(device);
+    steps.push("stickers-browser-surface-ok");
 
-    steps.push('assert-pack-visible');
-    const pack = await waitForNamed(device, packNames, 12_000);
-    if (bar === 'B') {
+    if (bar === "B") {
       return {
         id: entry.id,
         path: entry.path,
         phase: 2,
         ok: true,
-        status: 'green',
+        status: "green",
         steps,
       };
     }
 
-    steps.push('open-pack-grid');
-    await tapCenter(device, pack);
-    await sleep(1_500);
+    steps.push("reveal-fun-pack");
+    const revealed = await tryRevealFunPack(device);
+    steps.push(revealed ? "fun-pack-ok" : "fun-pack-skip");
 
-    // Tap first sticker candidate (send=false — tap enough for A pack/grid).
-    steps.push('tap-sticker');
-    const tree = await device.accessibilityTree();
-    const sticker =
-      findNamedNode(tree, ['brutus', 'happy', 'excited', 'Brutus', 'Happy']) ??
-      (() => {
-        const flat: typeof tree = [];
-        const walk = (nodes: typeof tree) => {
-          for (const n of nodes) {
-            flat.push(n);
-            if (n.children?.length) walk(n.children);
-          }
-        };
-        walk(tree);
-        return flat.find(
-          (n) =>
-            Boolean(n.frame && n.frame.width > 20 && n.frame.height > 20) &&
-            (n.type ?? '').toLowerCase().includes('image')
-        );
-      })();
-    if (!sticker) {
-      throw new Error(
-        `no tappable sticker in pack; labels=${flattenLabels(tree)
-          .slice(0, 80)
-          .join(', ')}`
-      );
-    }
-    await tapCenter(device, sticker);
+    steps.push("tap-sticker-grid");
+    // Sticker cells are frequently AX-opaque — soft tap mid-drawer.
+    await device.tap({ x: 200, y: 760 });
+    await sleep(500);
 
     return {
       id: entry.id,
       path: entry.path,
       phase: 2,
       ok: true,
-      status: 'green',
+      status: "green",
       steps,
     };
   } catch (e) {
     const msg = String(e);
     const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
-      ? 'operator'
+      ? "operator"
       : /status-pack-catalog|pack: Fun Stickers/i.test(msg)
-        ? 'operator'
-        : 'product';
+        ? "operator"
+        : "product";
     return {
       id: entry.id,
       path: entry.path,
       phase: 2,
       ok: false,
-      status: failureKind === 'operator' ? 'operator' : 'red',
+      status: failureKind === "operator" ? "operator" : "red",
       steps,
       error: msg,
       failureKind,

--- a/examples/.devicewright/journeys/widgets.ts
+++ b/examples/.devicewright/journeys/widgets.ts
@@ -1,63 +1,69 @@
-import type { DeviceSession } from '@csark0812/devicewright';
-import { TARGET_CATALOG } from '../catalog';
-import type { TargetJourneyResult } from '../types';
-import { assertPayloadContains, sleep, tapId, waitForId } from './helpers';
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  hostReadyTestId,
+  sleep,
+  tapId,
+  waitForId,
+} from "./helpers";
 
-const SPRINGBOARD = 'com.apple.springboard';
+const SPRINGBOARD = "com.apple.springboard";
 
 /**
  * Widgets host contract + SpringBoard gallery surface probe.
  */
 export async function runWidgetsJourney(
-  device: DeviceSession
+  device: DeviceSession,
 ): Promise<TargetJourneyResult> {
   const entry = TARGET_CATALOG.widgets;
   const steps: string[] = [];
   try {
-    steps.push('launch-host');
+    steps.push("launch-host");
     await device.launchApp(entry.hostBundleId, { terminateRunning: true });
-    await waitForId(device, entry.testIds.screenRoot, 20_000);
-    steps.push('host-ready');
+    await waitForId(device, hostReadyTestId(entry.testIds), 20_000);
+    steps.push("host-ready");
 
-    steps.push('seed-payload');
-    await tapId(device, 'btn-seed-payload', 8_000);
+    steps.push("seed-payload");
+    await tapId(device, "btn-seed-payload", 8_000);
     await sleep(400);
     await assertPayloadContains(
       device,
       entry.testIds.lastPayload,
       entry.payloadMarker,
-      10_000
+      10_000,
     );
-    steps.push('host-contract-ok');
+    steps.push("host-contract-ok");
 
-    steps.push('springboard-probe');
+    steps.push("springboard-probe");
     await device.launchApp(SPRINGBOARD, { terminateRunning: false });
     await sleep(800);
     const tree = await device.accessibilityTree();
     if (tree.length === 0) {
-      throw new Error('SpringBoard tree empty (widgets gallery probe)');
+      throw new Error("SpringBoard tree empty (widgets gallery probe)");
     }
-    steps.push('gallery-surface-ok');
+    steps.push("gallery-surface-ok");
 
     return {
       id: entry.id,
       path: entry.path,
       phase: 3,
       ok: true,
-      status: 'green',
+      status: "green",
       steps,
     };
   } catch (e) {
     const msg = String(e);
     const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
-      ? 'operator'
-      : 'product';
+      ? "operator"
+      : "product";
     return {
       id: entry.id,
       path: entry.path,
       phase: 3,
       ok: false,
-      status: failureKind === 'operator' ? 'operator' : 'red',
+      status: failureKind === "operator" ? "operator" : "red",
       steps,
       error: msg,
       failureKind,

--- a/examples/.devicewright/matrix.ts
+++ b/examples/.devicewright/matrix.ts
@@ -1,13 +1,14 @@
-import path from 'node:path';
-import { runMatrix, type SuiteMatrixRow } from '@csark0812/devicewright/suite';
-import { journeyFor, stubResult } from './journeys';
+import path from "node:path";
+import { runMatrix, type SuiteMatrixRow } from "@csark0812/devicewright/suite";
+import { ensureHostReleaseInstall } from "./ensure-install";
+import { journeyFor, stubResult } from "./journeys";
 import {
   REQUIRED_V1,
   type RequiredTargetRow,
   type TargetPhase,
-} from './required';
-import { exampleExists, repoRoot } from './root';
-import type { TargetJourneyResult } from './types';
+} from "./required";
+import { exampleExists, repoRoot } from "./root";
+import type { TargetJourneyResult } from "./types";
 
 export type RunTargetMatrixOptions = {
   ids?: string[];
@@ -17,6 +18,8 @@ export type RunTargetMatrixOptions = {
   artifactDir?: string;
   failFast?: boolean;
   idbPath?: string;
+  /** When true, Release-build + install missing hosts before each live journey. */
+  ensureInstall?: boolean;
 };
 
 function resolveRows(ids?: string[]): RequiredTargetRow[] {
@@ -25,13 +28,14 @@ function resolveRows(ids?: string[]): RequiredTargetRow[] {
   const rows = REQUIRED_V1.filter((r) => wanted.has(r.id));
   const missing = ids.filter((id) => !rows.some((r) => r.id === id));
   if (missing.length) {
-    throw new Error(`unknown REQUIRED_V1 id(s): ${missing.join(', ')}`);
+    throw new Error(`unknown REQUIRED_V1 id(s): ${missing.join(", ")}`);
   }
   return rows;
 }
 
 /**
  * REQUIRED_V1 matrix — consumer-owned; uses DW generic runMatrix.
+ * iOS 26.5 AX unlock lives in @csark0812/devicewright (devices.launch / doctor).
  */
 export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
   const rows = resolveRows(options.ids);
@@ -41,8 +45,8 @@ export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
     options.artifactDir ??
     path.join(
       repoRoot(),
-      'examples/.devicewright/artifacts',
-      `targets-${Date.now()}`
+      "examples/.devicewright/artifacts",
+      `targets-${Date.now()}`,
     );
 
   const suiteRows: SuiteMatrixRow[] = rows.map((row) => {
@@ -56,10 +60,10 @@ export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
             path: row.path,
             phase: row.phase,
             ok: false,
-            status: 'red' as const,
+            status: "red" as const,
             steps: [],
             error: `missing required path ${row.path}`,
-            failureKind: 'product',
+            failureKind: "product",
           };
         },
       };
@@ -68,9 +72,31 @@ export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
       return { id: row.id, stub: true };
     }
     const runner = journeyFor(row.id)!;
+    const ensureInstall = options.ensureInstall === true;
     return {
       id: row.id,
-      run: async (device) => runner(device),
+      run: async (device) => {
+        if (ensureInstall) {
+          try {
+            await ensureHostReleaseInstall({
+              id: row.id,
+              deviceId: device.deviceId,
+            });
+          } catch (e) {
+            return {
+              id: row.id,
+              path: row.path,
+              phase: row.phase,
+              ok: false,
+              status: "operator" as const,
+              steps: ["ensure-install"],
+              error: String(e),
+              failureKind: "operator" as const,
+            };
+          }
+        }
+        return runner(device);
+      },
     };
   });
 
@@ -86,7 +112,7 @@ export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
   const byId = new Map(rows.map((r) => [r.id, r]));
   const results: TargetJourneyResult[] = result.results.map((r) => {
     const meta = byId.get(r.id);
-    if (r.status === 'stub' && meta) {
+    if (r.status === "stub" && meta) {
       return { ...stubResult(meta), error: r.error ?? stubResult(meta).error };
     }
     return {
@@ -94,10 +120,10 @@ export async function runTargetMatrix(options: RunTargetMatrixOptions = {}) {
       path: meta?.path ?? r.id,
       phase: meta?.phase ?? 1,
       ok: r.ok,
-      status: r.status as TargetJourneyResult['status'],
+      status: r.status as TargetJourneyResult["status"],
       steps: (r.steps as string[]) ?? [],
       error: r.error,
-      failureKind: r.failureKind as TargetJourneyResult['failureKind'],
+      failureKind: r.failureKind as TargetJourneyResult["failureKind"],
       checklist: (r as { checklist?: string[] }).checklist,
     };
   });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "examples:devicewright:dry-preflight": "bun examples/.devicewright/cli.ts dry-preflight",
     "examples:devicewright:matrix": "bun examples/.devicewright/cli.ts matrix --stubs-only",
     "examples:devicewright:matrix:live": "bun examples/.devicewright/cli.ts matrix --live-through=1",
+    "examples:devicewright:matrix:ensure": "bun examples/.devicewright/cli.ts matrix --live-through=3 --no-fail-fast --ensure-install",
     "examples:devicewright:share": "bun examples/.devicewright/cli.ts matrix --ids=share",
     "examples:devicewright:action": "bun examples/.devicewright/cli.ts matrix --ids=action",
     "examples:devicewright:messages": "bun examples/.devicewright/cli.ts matrix --ids=messages",
@@ -48,7 +49,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "@csark0812/devicewright": "^0.1.2",
+    "@csark0812/devicewright": "^0.1.3",
     "@csark0812/skeleton": "^1.5.5",
     "typescript": "~5.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "@csark0812/devicewright": "^0.1.3",
+    "@csark0812/devicewright": "^0.1.4",
     "@csark0812/skeleton": "^1.5.5",
     "typescript": "~5.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
+    "@csark0812/devicewright": "^0.1.2",
     "@csark0812/skeleton": "^1.5.5",
-    "@csark0812/devicewright": "^0.1.1",
     "typescript": "~5.3.3"
   },
   "version": "0.2.7",


### PR DESCRIPTION
## Summary
- Follow-up to #44 for the **Devicewright example suite** (`examples/.devicewright`).
- Bump `@csark0812/devicewright` through ^0.1.2 → ^0.1.3 → **^0.1.4**.
- Harden REQUIRED_V1 journeys (share/action/messages/stickers/clip/widgets); prefer published suite **point-probe** helpers for share-sheet rows.
- Add opt-in `--ensure-install` / `examples:devicewright:matrix:ensure` for Release host installs before live matrix rows.

## Test plan
- [ ] `bun install` with `NODE_AUTH_TOKEN` (private DW)
- [ ] `bun run examples:devicewright:dry-preflight`
- [ ] `bun run examples:devicewright:matrix` (stubs-only)
- [ ] `bun examples/.devicewright/cli.ts matrix --ids=share,messages,stickers --live-through=2 --ensure-install --no-fail-fast` on a booted sim