### PR TITLE
feat(devicewright): companion targets wallet-ui + intent-ui

### DIFF
--- a/examples/.devicewright/journeys/intent-ui.ts
+++ b/examples/.devicewright/journeys/intent-ui.ts
@@ -1,0 +1,73 @@
+/**
+ * Intent UI companion journey.
+ *
+ * Generated alongside `intent` when `ios.intents.ui: true`. Proves the
+ * intents-ui-service appex is installed; Siri presentation remains os-limit.
+ */
+import { spawnSync } from "node:child_process";
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import { dismissSystemAlerts, waitForNamed } from "./helpers";
+
+function pluginkitHasIntentUi(udid: string, appexId: string): boolean {
+  const r = spawnSync(
+    "xcrun",
+    ["simctl", "spawn", udid, "pluginkit", "-mAvvvvv"],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024, env: process.env },
+  );
+  const out = `${r.stdout ?? ""}\n${r.stderr ?? ""}`;
+  return (
+    out.toLowerCase().includes(appexId.toLowerCase()) &&
+    /intents-ui-service/i.test(out)
+  );
+}
+
+export async function runIntentUiJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG["intent-ui"];
+  const path = entry?.path ?? "examples/intent";
+  const steps: string[] = [];
+
+  try {
+    if (!entry) throw new Error("intent-ui: missing catalog entry");
+
+    await dismissSystemAlerts(device);
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    steps.push("launch-host");
+    await dismissSystemAlerts(device);
+    await waitForNamed(device, ["ready"], 15_000);
+    steps.push("host-ready");
+
+    const appexId = `${entry.hostBundleId}.intent-ui`;
+    if (!pluginkitHasIntentUi(device.deviceId, appexId)) {
+      throw new Error(`Intent UI appex missing from pluginkit (${appexId})`);
+    }
+    steps.push("pluginkit-intent-ui");
+
+    return {
+      id: "intent-ui",
+      path,
+      phase: 5,
+      ok: true,
+      status: "green",
+      steps,
+    };
+  } catch (e) {
+    const msg = String(e);
+    const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
+      ? "operator"
+      : "product";
+    return {
+      id: "intent-ui",
+      path,
+      phase: 5,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/journeys/wallet-ui.ts
+++ b/examples/.devicewright/journeys/wallet-ui.ts
@@ -1,0 +1,75 @@
+/**
+ * Wallet UI (authorization) companion journey.
+ *
+ * Generated alongside `wallet` when `ios.wallet.ui: true`. Proves the auth
+ * appex is installed via pluginkit; PassKit issuer UI flow remains os-limit.
+ */
+import { spawnSync } from "node:child_process";
+import type { DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import { dismissSystemAlerts, waitForNamed } from "./helpers";
+
+function pluginkitHasWalletUi(udid: string, appexId: string): boolean {
+  const r = spawnSync(
+    "xcrun",
+    ["simctl", "spawn", udid, "pluginkit", "-mAvvvvv"],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024, env: process.env },
+  );
+  const out = `${r.stdout ?? ""}\n${r.stderr ?? ""}`;
+  return (
+    out.toLowerCase().includes(appexId.toLowerCase()) &&
+    /issuer-provisioning\.authorization/i.test(out)
+  );
+}
+
+export async function runWalletUiJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG["wallet-ui"];
+  const path = entry?.path ?? "examples/wallet";
+  const steps: string[] = [];
+
+  try {
+    if (!entry) throw new Error("wallet-ui: missing catalog entry");
+
+    await dismissSystemAlerts(device);
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    steps.push("launch-host");
+    await dismissSystemAlerts(device);
+    await waitForNamed(device, ["ready"], 15_000);
+    steps.push("host-ready");
+
+    const appexId = `${entry.hostBundleId}.wallet-ui`;
+    if (!pluginkitHasWalletUi(device.deviceId, appexId)) {
+      throw new Error(`Wallet UI appex missing from pluginkit (${appexId})`);
+    }
+    steps.push("pluginkit-wallet-ui");
+
+    return {
+      id: "wallet-ui",
+      path,
+      phase: 4,
+      ok: true,
+      status: "os-limit",
+      steps,
+      failureKind: "os-limit",
+      error: "PassKit issuer provisioning requires Apple entitlement allow-list",
+    };
+  } catch (e) {
+    const msg = String(e);
+    const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
+      ? "operator"
+      : "product";
+    return {
+      id: "wallet-ui",
+      path,
+      phase: 4,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `REQUIRED_V2` rows + catalog entries for companion types **`wallet-ui`** and **`intent-ui`**
- New pluginkit Devicewright journeys (`wallet-ui.ts`, `intent-ui.ts`)
- Replaces intent-ui Swift stub with real `INUIHostedViewControlling` principal

## Stack

PR 2/4 — stacks on #47

## Test plan

- [ ] Devicewright: `wallet-ui`, `intent-ui` after wallet/intent example prebuild
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc126-ba55-75e7-b56a-f1c9fe413648?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc126-ba55-75e7-b56a-f1c9fe413648&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

