### PR TITLE
fix(mcp-dev): scoped @csark0812/mcp-dev CI publish

### DIFF
--- a/.github/workflows/publish-mcp-dev.yml
+++ b/.github/workflows/publish-mcp-dev.yml
@@ -1,10 +1,17 @@
 name: publish-mcp-dev
 
+# Trusted publisher on npmjs.com must match this filename exactly:
+#   publish-mcp-dev.yml
+# Package: @csark0812/mcp-dev
+# Repo: csark0812/expo-targets
+# No NPM_TOKEN required for publish (OIDC). bun install still needs NODE_AUTH_TOKEN
+# to resolve private @csark0812/devicewright if the lockfile pulls it transitively.
+
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to publish (e.g. 0.1.1). Leave empty to bump.
+        description: Version to publish (e.g. 0.1.2). Leave empty to bump.
         required: false
       bump_type:
         description: Bump type when version is empty
@@ -37,6 +44,7 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
+          scope: "@csark0812"
 
       - name: Install npm (OIDC provenance)
         run: npm install -g npm@latest
@@ -44,7 +52,8 @@ jobs:
       - run: bun install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      - run: bun run --filter mcp-dev build
+
+      - run: bun run --filter @csark0812/mcp-dev build
       - run: bun test --cwd packages/mcp-dev src
       - name: Typecheck mcp-dev
         working-directory: packages/mcp-dev
@@ -81,27 +90,41 @@ jobs:
             git tag "$TAG"
           fi
 
-      - run: bun run --filter mcp-dev build
+      - run: bun run --filter @csark0812/mcp-dev build
+
+      - name: Assert publishable bin
+        working-directory: packages/mcp-dev
+        run: |
+          test -f build/bin/mcp-dev.js
+          head -1 build/bin/mcp-dev.js | grep -q '^#!'
+          node -e "
+            const pkg = require('./package.json');
+            if (pkg.name !== '@csark0812/mcp-dev') throw new Error('bad name: ' + pkg.name);
+            if (pkg.bin?.['mcp-dev'] !== './build/bin/mcp-dev.js') {
+              throw new Error('bad bin: ' + JSON.stringify(pkg.bin));
+            }
+          "
+          npm pack --dry-run | grep -F 'build/bin/mcp-dev.js'
 
       - name: Push release commit and tag
         run: git push origin HEAD --follow-tags
 
-      - name: Publish mcp-dev
+      - name: Publish @csark0812/mcp-dev
         working-directory: packages/mcp-dev
         run: npm publish --access public --provenance
 
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: mcp-dev-v${{ steps.version.outputs.NEW_VERSION }}
-          name: mcp-dev@${{ steps.version.outputs.NEW_VERSION }}
+          name: "@csark0812/mcp-dev@${{ steps.version.outputs.NEW_VERSION }}"
           body: |
-            ## mcp-dev@${{ steps.version.outputs.NEW_VERSION }}
+            ## @csark0812/mcp-dev@${{ steps.version.outputs.NEW_VERSION }}
 
-            Published via workflow_dispatch.
+            Published via workflow_dispatch (OIDC trusted publisher).
 
             ### npm
             ```bash
-            npx -y mcp-dev@${{ steps.version.outputs.NEW_VERSION }} --help
+            npx -y @csark0812/mcp-dev@${{ steps.version.outputs.NEW_VERSION }} --help
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -976,8 +976,8 @@
       },
     },
     "packages/mcp-dev": {
-      "name": "mcp-dev",
-      "version": "0.1.0",
+      "name": "@csark0812/mcp-dev",
+      "version": "0.1.1",
       "bin": {
         "mcp-dev": "./build/bin/mcp-dev.js",
       },
@@ -1142,6 +1142,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
     "@csark0812/devicewright": ["@csark0812/devicewright@0.1.12", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.0", "zod": "^3.24.0" }, "bin": { "devicewright": "build/bin/cli.js", "devicewright-mcp": "build/bin/mcp.js", "devicewright-doctor": "build/bin/doctor.js" } }, "sha512-lw3xLF0OKFCKmdFyqkdkuP+5j2M1KU23Xqb4ylPAErxs+hwi2PjBJMJH/KJhSMBsSj3SBtqSv+zoSQPmyj68sQ=="],
+
+    "@csark0812/mcp-dev": ["@csark0812/mcp-dev@workspace:packages/mcp-dev"],
 
     "@csark0812/skeleton": ["@csark0812/skeleton@1.5.7", "", { "dependencies": { "ajv": "^8.17.1", "github-slugger": "^2.0.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "yaml": "^2.8.0" }, "bin": { "skeleton": "dist/cli.js" } }, "sha512-+ymzlfDxlwx2J8bSk2UrKF05XQFMuJsnoGtnJYmu2tOHNZxCFcvyE6Gzevc8XBICKGfyovOI/ET1fBih+IjSrg=="],
 
@@ -1924,8 +1926,6 @@
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mcp-dev": ["mcp-dev@workspace:packages/mcp-dev"],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "biome format --write .",
     "check": "biome check .",
     "typecheck": "tsc -p packages/expo-targets --noEmit && tsc -p packages/create-expo-target --noEmit && tsc -p packages/expo-targets-cli --noEmit && tsc -p packages/mcp-dev --noEmit",
-    "mcp-dev": "bun run --filter mcp-dev build && node packages/mcp-dev/build/bin/mcp-dev.js",
+    "mcp-dev": "bun run --filter @csark0812/mcp-dev build && node packages/mcp-dev/build/bin/mcp-dev.js",
     "validate:changed": "skeleton validate changed",
     "validate:ci": "skeleton validate changed --base origin/main",
     "audit:docs": "skeleton audit docs",

--- a/packages/mcp-dev/PUBLISH.md
+++ b/packages/mcp-dev/PUBLISH.md
@@ -1,0 +1,35 @@
+# Publish @csark0812/mcp-dev
+
+Public scoped package. CI uses **trusted publishing (OIDC)** — no long-lived `NPM_TOKEN` for publish.
+
+Unscoped `mcp-dev` is blocked by npm (too similar to `mcpdev`). Always publish as `@csark0812/mcp-dev`.
+
+## Trusted Publisher (paste these exact values)
+
+On https://www.npmjs.com/package/@csark0812/mcp-dev → **Settings** → **Trusted Publisher** → **GitHub Actions**:
+
+| Field | Value |
+| --- | --- |
+| Organization or user | `csark0812` |
+| Repository | `expo-targets` |
+| Workflow filename | `publish-mcp-dev.yml` |
+| Environment | _(leave empty)_ |
+
+Workflow path in repo: `.github/workflows/publish-mcp-dev.yml` — npm wants the **filename only**.
+
+## After attaching
+
+1. Merge the scoped-name CI fix to `main` (so the workflow on default branch matches).
+2. **Actions → publish-mcp-dev → Run workflow**.
+3. Leave **version** empty to patch-bump (`0.1.1` → `0.1.2`) so the next release restores a valid `bin` (the bootstrap `0.1.1` tarball had `bin` stripped).
+
+## Local emergency publish
+
+Only if OIDC is broken and you are logged in as `csark0812`:
+
+```bash
+cd packages/mcp-dev
+bun run build
+test -f build/bin/mcp-dev.js
+npm publish --access public --ignore-scripts
+```

--- a/packages/mcp-dev/README.md
+++ b/packages/mcp-dev/README.md
@@ -7,10 +7,12 @@ Logs go to **stderr** only. MCP protocol bytes stay on **stdout**.
 ## Install
 
 ```bash
-npm install -g mcp-dev
+npm install -g @csark0812/mcp-dev
 # or
-npx -y mcp-dev --help
+npx -y @csark0812/mcp-dev --help
 ```
+
+Package name is scoped (`@csark0812/mcp-dev`). The CLI bin remains `mcp-dev`.
 
 ## Cursor mcp.json
 
@@ -23,7 +25,7 @@ After publish:
       "command": "npx",
       "args": [
         "-y",
-        "mcp-dev",
+        "@csark0812/mcp-dev",
         "--watch",
         "src/**/*.ts",
         "--rebuild",

--- a/packages/mcp-dev/package.json
+++ b/packages/mcp-dev/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcp-dev",
+  "name": "@csark0812/mcp-dev",
   "version": "0.1.1",
   "description": "Metro-like stdio supervisor for developing MCP servers (watch, rebuild, restart).",
   "license": "MIT",
@@ -12,6 +12,9 @@
     "build",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf build",

--- a/packages/mcp-dev/src/cli.ts
+++ b/packages/mcp-dev/src/cli.ts
@@ -37,7 +37,7 @@ Examples:
     node packages/my-mcp/build/bin/mcp.js
 
   # After publish:
-  npx -y mcp-dev --watch "src/**/*.ts" --rebuild "npm run build" -- node ./build/mcp.js
+  npx -y @csark0812/mcp-dev --watch "src/**/*.ts" --rebuild "npm run build" -- node ./build/mcp.js
 `;
 }
 


### PR DESCRIPTION
## Summary
- Rename package to `@csark0812/mcp-dev` (unscoped `mcp-dev` blocked by npm as too similar to `mcpdev`)
- Update `publish-mcp-dev.yml` filters, OIDC scope, bin assert, and release notes
- Document Trusted Publisher values in `packages/mcp-dev/PUBLISH.md`

Bootstrap `@csark0812/mcp-dev@0.1.1` already exists on npm (local publish). Next CI run should patch to `0.1.2` so `bin` is restored.

## Test plan
- [ ] Attach Trusted Publisher on npm (see PUBLISH.md)
- [ ] Merge this PR to `main`
- [ ] Actions → publish-mcp-dev → Run workflow (empty version → patch)
- [ ] `npm view @csark0812/mcp-dev version` and `npx -y @csark0812/mcp-dev --help`