### PR TITLE
fix(mcp-dev): npm pack assert reads stderr

### DIFF
--- a/.github/workflows/publish-mcp-dev.yml
+++ b/.github/workflows/publish-mcp-dev.yml
@@ -104,7 +104,7 @@ jobs:
               throw new Error('bad bin: ' + JSON.stringify(pkg.bin));
             }
           "
-          npm pack --dry-run | grep -F 'build/bin/mcp-dev.js'
+          npm pack --dry-run 2>&1 | grep -F 'build/bin/mcp-dev.js'
 
       - name: Push release commit and tag
         run: git push origin HEAD --follow-tags


### PR DESCRIPTION
## Summary
- `npm pack --dry-run` lists files on stderr; the publish assert grepped stdout and failed after a good pack

## Test plan
- [ ] Merge and re-run `publish-mcp-dev` (patch → 0.1.2)
- [ ] Confirm publish + `npx -y @csark0812/mcp-dev --help`