### PR TITLE
fix(mcp-dev): repository.url for npm provenance

### DIFF
--- a/packages/mcp-dev/package.json
+++ b/packages/mcp-dev/package.json
@@ -15,6 +15,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/csark0812/expo-targets"
+  },
+  "homepage": "https://github.com/csark0812/expo-targets/tree/main/packages/mcp-dev#readme",
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf build",


### PR DESCRIPTION
## Summary
- Add `repository.url` so Sigstore provenance validation passes on `npm publish --provenance`

## Test plan
- [ ] Merge
- [ ] Re-run `publish-mcp-dev` with version `0.1.2` (git already bumped; npm never got it)
- [ ] `npm view @csark0812/mcp-dev version` → 0.1.2