### PR TITLE
feat(examples): deep-green quicklook-thumbnail

### DIFF
--- a/examples/.devicewright/journeys/index.ts
+++ b/examples/.devicewright/journeys/index.ts
@@ -22,6 +22,7 @@ import { runNotificationContentJourney } from "./notification-content";
 import { runNotificationServiceJourney } from "./notification-service";
 import { runPhotoEditingJourney } from "./photo-editing";
 import { runQuicklookPreviewJourney } from "./quicklook-preview";
+import { runQuicklookThumbnailJourney } from "./quicklook-thumbnail";
 import { runSafariJourney } from "./safari";
 import { runShareActionJourney } from "./share";
 import { runSpotlightJourney } from "./spotlight";
@@ -59,6 +60,7 @@ export { runNotificationContentJourney } from "./notification-content";
 export { runNotificationServiceJourney } from "./notification-service";
 export { runPhotoEditingJourney } from "./photo-editing";
 export { runQuicklookPreviewJourney } from "./quicklook-preview";
+export { runQuicklookThumbnailJourney } from "./quicklook-thumbnail";
 export { runSafariJourney } from "./safari";
 export { runShareActionJourney } from "./share";
 export { runSpotlightJourney } from "./spotlight";
@@ -86,7 +88,6 @@ export type JourneyRunner = (
 
 /** ids proven via generic Settings→Apps→search host→host settings page. */
 const APPS_SETTINGS_IDS = [
-  "quicklook-thumbnail",
   "unwanted-communication",
   "spotlight-delegate",
   "bg-download",
@@ -129,6 +130,7 @@ const LIVE: Record<string, JourneyRunner> = {
   "call-directory": (d) => runCallDirectoryJourney(d),
   "message-filter": (d) => runMessageFilterJourney(d),
   "quicklook-preview": (d) => runQuicklookPreviewJourney(d),
+  "quicklook-thumbnail": (d) => runQuicklookThumbnailJourney(d),
   spotlight: (d) => runSpotlightJourney(d),
   "location-push": (d) => runLocationPushJourney(d),
   watch: (d) => runWatchJourney(d, "watch"),

--- a/examples/.devicewright/journeys/quicklook-thumbnail.ts
+++ b/examples/.devicewright/journeys/quicklook-thumbnail.ts
@@ -1,0 +1,287 @@
+/**
+ * Quick Look Thumbnail deep journey.
+ *
+ * GREEN (P): pluginkit lists quicklook.thumbnail + Files browses et-thumb.etqlt
+ * and App Group shows qlThumb:* / ET QL Thumb (provider invoke).
+ *
+ * Thumbnail pixels are not AX-readable; App Group from provideThumbnail is the
+ * primary P proof. Files folder listing is the invoke surface.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { DeviceSession } from "@csark0812/devicewright";
+import { claimForId } from "../claims";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
+  flattenLabels,
+  sleep,
+  tapId,
+  tapProbeHit,
+  waitForNamed,
+} from "./helpers";
+import { tapLabelInTree } from "./settings-nav";
+
+const FILES_BUNDLE = "com.apple.DocumentsApp";
+const FIXTURE_NAME = "et-thumb.etqlt";
+
+function pluginkitHasQuickLookThumbnail(udid: string, appexId: string): boolean {
+  const r = spawnSync(
+    "xcrun",
+    ["simctl", "spawn", udid, "pluginkit", "-mAvvvvv"],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024, env: process.env },
+  );
+  const out = `${r.stdout ?? ""}\n${r.stderr ?? ""}`;
+  return (
+    out.toLowerCase().includes(appexId.toLowerCase()) &&
+    /quicklook\.thumbnail/i.test(out)
+  );
+}
+
+function writeFixtureToDocuments(
+  udid: string,
+  hostBundleId: string,
+  steps: string[],
+): void {
+  const container = spawnSync(
+    "xcrun",
+    ["simctl", "get_app_container", udid, hostBundleId, "data"],
+    { encoding: "utf8" },
+  );
+  if (container.status !== 0) {
+    throw new Error(
+      `get_app_container data failed: ${container.stderr || container.stdout}`,
+    );
+  }
+  const docs = path.join(container.stdout.trim(), "Documents");
+  fs.mkdirSync(docs, { recursive: true });
+  const fixturePath = path.join(docs, FIXTURE_NAME);
+  // Unique stamp so Files / QL thumbnail cache cannot reuse a prior reply.
+  fs.writeFileSync(
+    fixturePath,
+    `expo-targets quicklook-thumbnail fixture\nET QL Thumb\n${Date.now()}\n`,
+    "utf8",
+  );
+  steps.push(`fixture-written:${FIXTURE_NAME}`);
+}
+
+async function openFilesBrowse(device: DeviceSession, steps: string[]): Promise<void> {
+  await device.launchApp(FILES_BUNDLE, { terminateRunning: true });
+  await sleep(1_400);
+  await dismissSystemAlerts(device);
+  for (let i = 0; i < 4; i++) {
+    const labels = flattenLabels(await device.accessibilityTree());
+    if (
+      labels.some((l) => /^Locations$/i.test(l.trim())) ||
+      labels.some((l) => /On My iPhone|iCloud Drive/i.test(l))
+    ) {
+      steps.push("files-browse-surface");
+      return;
+    }
+    const tapped = await tapLabelInTree(device, ["Browse"], { exactOnly: true });
+    if (!tapped) {
+      await device.tap({ x: 315, y: 880 });
+      steps.push("files-browse-tab-hotspot");
+    } else {
+      steps.push("files-browse-tab");
+    }
+    await sleep(700);
+  }
+}
+
+async function openHostFolderInFiles(
+  device: DeviceSession,
+  steps: string[],
+): Promise<void> {
+  await openFilesBrowse(device, steps);
+  await sleep(500);
+
+  const openedOnMy = await tapLabelInTree(device, ["On My iPhone", "On My iPad"], {
+    exactOnly: false,
+  });
+  if (!openedOnMy) {
+    try {
+      const hit = await findNamedViaPointProbe(
+        device,
+        ["On My iPhone", "On My iPad"],
+        { timeoutMs: 4_000, match: "includes" },
+      );
+      await tapProbeHit(device, hit);
+    } catch {
+      throw new Error("Files: On My iPhone row missing");
+    }
+  }
+  steps.push("files-on-my-iphone");
+  await sleep(900);
+
+  const hostOpened = await tapLabelInTree(
+    device,
+    ["ET QLThumb", "ET QLThumb Target", "quicklook-thumbnail"],
+    { exactOnly: false },
+  );
+  if (!hostOpened) {
+    try {
+      const hit = await findNamedViaPointProbe(
+        device,
+        ["ET QLThumb", "QLThumb"],
+        { timeoutMs: 5_000, match: "includes", yStartRatio: 0.15, yEndRatio: 0.95 },
+      );
+      await tapProbeHit(device, hit);
+    } catch (e) {
+      const labels = flattenLabels(await device.accessibilityTree());
+      throw new Error(
+        `Files: host folder missing; labels=${labels.slice(0, 60).join(", ")}; ${e}`,
+      );
+    }
+  }
+  steps.push("files-host-folder");
+  await sleep(1_200);
+
+  // Listing the folder should request thumbnails; confirm fixture row exists.
+  const labels = flattenLabels(await device.accessibilityTree());
+  if (
+    labels.some(
+      (l) =>
+        l.toLowerCase().includes(FIXTURE_NAME.toLowerCase()) ||
+        l.toLowerCase().includes("et-thumb") ||
+        l.toLowerCase().includes(".etqlt"),
+    )
+  ) {
+    steps.push("files-fixture-visible");
+  } else {
+    // Icon view may omit filename AX — try opening via probe anyway.
+    try {
+      const hit = await findNamedViaPointProbe(
+        device,
+        [FIXTURE_NAME, "et-thumb", ".etqlt"],
+        { timeoutMs: 4_000, match: "includes" },
+      );
+      await tapProbeHit(device, hit);
+      steps.push("files-fixture-opened");
+      await sleep(1_000);
+    } catch {
+      steps.push("files-fixture-ax-opaque");
+    }
+  }
+
+  // Extra settle for QLThumbnailGenerationService → appex.
+  await sleep(2_500);
+}
+
+export async function runQuicklookThumbnailJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG["quicklook-thumbnail"];
+  const pathStr = entry?.path ?? "examples/quicklook-thumbnail";
+  const claim = claimForId("quicklook-thumbnail");
+  const steps: string[] = [];
+
+  try {
+    if (!entry) throw new Error("quicklook-thumbnail: missing catalog entry");
+
+    await dismissSystemAlerts(device);
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    steps.push("launch-host");
+    await dismissSystemAlerts(device);
+    await waitForNamed(device, ["ready"], 15_000);
+    steps.push("host-ready");
+
+    // Clear prior App Group so a green cannot come from a stale provider run.
+    try {
+      await tapId(device, entry.testIds.clearPayload, 4_000);
+      steps.push("cleared-payload");
+      await sleep(400);
+    } catch {
+      steps.push("clear-payload-miss");
+    }
+
+    const appexId = `${entry.hostBundleId}.quicklook-thumbnail`;
+    if (!pluginkitHasQuickLookThumbnail(device.deviceId, appexId)) {
+      throw new Error(
+        `quicklook.thumbnail appex missing from pluginkit (${appexId})`,
+      );
+    }
+    steps.push("pluginkit-quicklook-thumbnail");
+
+    writeFixtureToDocuments(device.deviceId, entry.hostBundleId, steps);
+
+    await openHostFolderInFiles(device, steps);
+
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    await waitForNamed(device, ["ready"], 12_000);
+
+    // Poll App Group — Files may request thumbs asynchronously after browse.
+    let appGroupOk = false;
+    for (let i = 0; i < 10; i++) {
+      try {
+        await assertPayloadContains(
+          device,
+          entry.testIds.lastPayload,
+          "ET QL Thumb",
+          3_000,
+        );
+        steps.push("ql-thumb-appgroup");
+        appGroupOk = true;
+        break;
+      } catch {
+        try {
+          await tapId(device, "btn-refresh", 2_000);
+        } catch {
+          /* optional */
+        }
+        await sleep(800);
+      }
+    }
+    if (!appGroupOk) {
+      steps.push("ql-thumb-appgroup-missing");
+    }
+
+    if (appGroupOk) {
+      return {
+        id: "quicklook-thumbnail",
+        path: pathStr,
+        phase: 5,
+        ok: true,
+        status: "green",
+        steps,
+      };
+    }
+
+    if (claim) {
+      return {
+        id: "quicklook-thumbnail",
+        path: pathStr,
+        phase: 5,
+        ok: true,
+        status: "os-limit",
+        steps,
+        failureKind: "os-limit",
+        error: claim.reason,
+      };
+    }
+
+    const labels = flattenLabels(await device.accessibilityTree());
+    throw new Error(
+      `Quick Look thumbnail provider did not write App Group after browsing ${FIXTURE_NAME}; labels=${labels.slice(0, 80).join(", ")}`,
+    );
+  } catch (e) {
+    const msg = String(e);
+    const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
+      ? "operator"
+      : "product";
+    return {
+      id: "quicklook-thumbnail",
+      path: pathStr,
+      phase: 5,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/touchpoints.ts
+++ b/examples/.devicewright/touchpoints.ts
@@ -229,7 +229,8 @@ export const TOUCHPOINTS: readonly TouchpointDef[] = [
   {
     id: "quicklook-thumbnail",
     tranche: "T6",
-    touchpoint: "Settings Apps host registration",
+    touchpoint:
+      "pluginkit quicklook.thumbnail + Files browses et-thumb.etqlt → App Group ET QL Thumb",
     status: "concrete",
   },
   {

--- a/examples/quicklook-thumbnail/App.tsx
+++ b/examples/quicklook-thumbnail/App.tsx
@@ -1,18 +1,69 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { AppGroupStorage } from 'expo-targets';
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+const storage = new AppGroupStorage(
+  'group.com.expotargets.example.quicklook-thumbnail'
+);
 
 export default function App() {
+  const [ready, setReady] = useState(false);
+  const [payload, setPayload] = useState('none');
+
+  const refresh = useCallback(() => {
+    const marker = storage.get<string>('qlThumb:marker');
+    const file = storage.get<string>('qlThumb:lastFile');
+    if (marker || file) {
+      setPayload(JSON.stringify({ marker, file }));
+    } else {
+      setPayload('none');
+    }
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 2000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
   return (
     <View style={styles.container} testID="screen-root">
       <StatusBar style="auto" />
       <Text style={styles.title}>ET QLThumb</Text>
-      <Text testID="status-target-ready">ready</Text>
+      <Text testID="status-target-ready">{ready ? 'ready' : 'loading'}</Text>
       <Text testID="text-extension-type">quicklook-thumbnail</Text>
       <Text testID="text-bundle-suffix">
         com.expotargets.example.quicklook-thumbnail
       </Text>
-      <Text testID="btn-clear-payload">clear</Text>
-      <Text testID="text-last-payload">none</Text>
+      <Text accessibilityLabel="ql-thumb-fixture-hint">
+        Write et-thumb.etqlt into Documents (journey uses simctl)
+      </Text>
+      <TouchableOpacity
+        testID="btn-refresh"
+        accessibilityLabel="Refresh"
+        style={styles.button}
+        onPress={refresh}
+      >
+        <Text style={styles.buttonText}>Refresh</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        testID="btn-clear-payload"
+        accessibilityLabel="Clear payload"
+        style={styles.button}
+        onPress={() => {
+          storage.remove('qlThumb:marker');
+          storage.remove('qlThumb:lastFile');
+          storage.remove('qlThumb:lastAt');
+          setPayload('none');
+        }}
+      >
+        <Text style={styles.buttonText}>Clear</Text>
+      </TouchableOpacity>
+      <Text testID="text-last-payload" style={styles.payload}>
+        {payload}
+      </Text>
     </View>
   );
 }
@@ -23,6 +74,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 24,
+    gap: 10,
   },
   title: { fontSize: 20, fontWeight: '600', marginBottom: 12 },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: '600' },
+  payload: { marginTop: 8, textAlign: 'center' },
 });

--- a/examples/quicklook-thumbnail/app.json
+++ b/examples/quicklook-thumbnail/app.json
@@ -16,7 +16,27 @@
         ]
       },
       "infoPlist": {
-        "CFBundleDisplayName": "ET QLThumb"
+        "CFBundleDisplayName": "ET QLThumb",
+        "UIFileSharingEnabled": true,
+        "LSSupportsOpeningDocumentsInPlace": true,
+        "UTExportedTypeDeclarations": [
+          {
+            "UTTypeIdentifier": "com.expotargets.etqlt",
+            "UTTypeDescription": "ET Quick Look thumbnail fixture",
+            "UTTypeConformsTo": ["public.data", "public.content"],
+            "UTTypeTagSpecification": {
+              "public.filename-extension": ["etqlt"]
+            }
+          }
+        ],
+        "CFBundleDocumentTypes": [
+          {
+            "CFBundleTypeName": "ET Quick Look thumbnail fixture",
+            "CFBundleTypeRole": "Viewer",
+            "LSItemContentTypes": ["com.expotargets.etqlt"],
+            "CFBundleTypeExtensions": ["etqlt"]
+          }
+        ]
       }
     },
     "plugins": [

--- a/examples/quicklook-thumbnail/targets/quicklook-thumbnail/expo-target.config.json
+++ b/examples/quicklook-thumbnail/targets/quicklook-thumbnail/expo-target.config.json
@@ -9,7 +9,11 @@
     "displayName": "ET QLThumb Target",
     "infoPlist": {
       "NSExtension": {
-        "NSExtensionPrincipalClass": "ThumbnailProvider"
+        "NSExtensionPrincipalClass": "ThumbnailProvider",
+        "NSExtensionAttributes": {
+          "QLSupportedContentTypes": ["com.expotargets.etqlt"],
+          "QLThumbnailMinimumDimension": 0
+        }
       }
     }
   }

--- a/examples/quicklook-thumbnail/targets/quicklook-thumbnail/ios/ThumbnailProvider.swift
+++ b/examples/quicklook-thumbnail/targets/quicklook-thumbnail/ios/ThumbnailProvider.swift
@@ -1,8 +1,39 @@
-import Foundation
+import QuickLookThumbnailing
 import UIKit
 
-/// Minimal quicklook-thumbnail stub for expo-targets example (QuicklookThumbnail).
+/// Quick Look thumbnail principal — Files browse of `.etqlt` should invoke this.
 @objc(ThumbnailProvider)
-class ThumbnailProvider: NSObject {
-  // Extension principal — replace with full Apple API conformance as needed.
+class ThumbnailProvider: QLThumbnailProvider {
+  override func provideThumbnail(
+    for request: QLFileThumbnailRequest,
+    _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
+  ) {
+    let defaults = UserDefaults(suiteName: "group.com.expotargets.example.quicklook-thumbnail")
+    defaults?.set(request.fileURL.lastPathComponent, forKey: "qlThumb:lastFile")
+    defaults?.set("ET QL Thumb", forKey: "qlThumb:marker")
+    defaults?.set(Date().timeIntervalSince1970, forKey: "qlThumb:lastAt")
+    defaults?.synchronize()
+
+    let size = request.maximumSize
+    handler(
+      QLThumbnailReply(contextSize: size, currentContextDrawing: {
+        UIColor.systemTeal.setFill()
+        UIBezierPath(rect: CGRect(origin: .zero, size: size)).fill()
+
+        let label = "ET QL Thumb" as NSString
+        let attrs: [NSAttributedString.Key: Any] = [
+          .font: UIFont.boldSystemFont(ofSize: max(10, min(size.width, size.height) * 0.14)),
+          .foregroundColor: UIColor.white,
+        ]
+        let textSize = label.size(withAttributes: attrs)
+        let origin = CGPoint(
+          x: (size.width - textSize.width) / 2,
+          y: (size.height - textSize.height) / 2
+        )
+        label.draw(at: origin, withAttributes: attrs)
+        return true
+      }),
+      nil
+    )
+  }
 }

--- a/packages/expo-targets/plugin/src/domain/characteristics.ts
+++ b/packages/expo-targets/plugin/src/domain/characteristics.ts
@@ -360,7 +360,7 @@ const BASE_TYPE_CHARACTERISTICS: Record<
     requiresCode: true,
     targetType: 'app_extension',
     embedType: 'foundation-extension',
-    frameworks: [],
+    frameworks: ['QuickLookThumbnailing'],
     productType: 'com.apple.product-type.app-extension',
     extensionPointIdentifier: 'com.apple.quicklook.thumbnail',
     defaultUsesAppGroups: false,


### PR DESCRIPTION
## Summary
- Deepen `quicklook-thumbnail` from Apps-Settings-only to a real Files → `QLThumbnailProvider` P journey (mirrors greened `quicklook-preview`).
- Real principal + `com.expotargets.etqlt` UTI + App Group marker; link `QuickLookThumbnailing` in characteristics.
- Operator proof on Air / DW 0.1.14: `targets-1785867820781` → **green** (`pluginkit` + fixture visible + App Group).

## Test plan
- [x] `bun examples/.devicewright/cli.ts matrix --ids=quicklook-thumbnail --live-through=5 --ensure-install` on Air (uninstall first if stale host)
- [x] DW live demo: Clear → Files teal thumb → host `{"marker":"ET QL Thumb",...}`
- [x] `bun run lint`