### PR TITLE
feat(examples): deepen unwanted-communication and call-directory

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -36,6 +36,8 @@ Each open leftover:
 | live-activity | Watch chrome when pair boots without AX | CLAIMS after S3a | TBD on operator miss | eng |
 | message-filter | Messages Unknown Senders / Text Message Filter list / inbound SMS invoke | CLAIMS | [spikes/message-filter-ql-spotlight-2026-08-04.md](../examples/.devicewright/artifacts/spikes/message-filter-ql-spotlight-2026-08-04.md) | eng |
 | spotlight | CSImportExtension indexer → App Group / Spotlight hit | CLAIMS | [spikes/message-filter-ql-spotlight-2026-08-04.md](../examples/.devicewright/artifacts/spikes/message-filter-ql-spotlight-2026-08-04.md) | eng |
+| call-directory | Phone → Call Blocking & Identification lists ET CallDir Target | CLAIMS | [spikes/unwanted-communication-call-directory-2026-08-04.md](../examples/.devicewright/artifacts/spikes/unwanted-communication-call-directory-2026-08-04.md) | eng |
+| unwanted-communication | Phone → SMS/Call Reporting lists ET Unwanted Target | CLAIMS | [spikes/unwanted-communication-call-directory-2026-08-04.md](../examples/.devicewright/artifacts/spikes/unwanted-communication-call-directory-2026-08-04.md) | eng |
 
 Entitlement/Settings items use `home: wont-do` or the hard-stop table below; **revisit** when DW/Sim coverage improves (plan edit + spike re-run).
 

--- a/examples/.devicewright/artifacts/spikes/unwanted-communication-call-directory-2026-08-04.md
+++ b/examples/.devicewright/artifacts/spikes/unwanted-communication-call-directory-2026-08-04.md
@@ -1,0 +1,34 @@
+# Spike: unwanted-communication / call-directory (2026-08-04)
+
+**Device:** iPhone Air `0E7FA53F-23B3-4F10-BAE1-AED7515401B2` · iOS 26.5  
+**DW:** `@csark0812/devicewright@0.1.14`  
+**Artifact:** `targets-1785869838049`
+
+## Verdicts
+
+| id | Status | Evidence |
+| -- | ------ | -------- |
+| **call-directory** | **os-limit (CLAIMS)** | pluginkit OK; Settings → Apps → Phone confirm on Call Blocking / Announce Calls times out; Settings search “Call Blocking” → surface unavailable (Air / non-telephony) |
+| **unwanted-communication** | **os-limit (CLAIMS)** | pluginkit `classification-ui` OK; real `ClassificationViewController` ships; Phone → SMS/Call Reporting and Settings search (“SMS/Call Reporting”, “Call Reporting”) miss — no reporting picker / extension list on this Sim |
+
+## call-directory — deeper probe
+
+1. Host Release install + `pluginkit` lists `com.apple.callkit.call-directory` for `…call-directory.call-directory`.
+2. Settings root has no reliable **Phone** row for Call Blocking on Air (journey falls through).
+3. Settings → Apps → search **Phone** → `searchAppsAndOpen` confirm on Call Blocking / Announce Calls / Silence Unknown / Cellular **times out** (`apps-phone-settings-unavailable`).
+4. Settings search **Call Blocking** → `call-blocking-settings-unavailable` (no usable result → list).
+5. GREEN would need Call Blocking & Identification listing **ET CallDir Target** — not available on this Sim.
+
+## unwanted-communication — deeper probe
+
+1. Stub replaced with `ILClassificationUIExtensionViewController` (`ClassificationViewController`); App Group keys `uc:*` ready for invoke.
+2. `pluginkit` lists `com.apple.identitylookup.classification-ui` for `…unwanted-communication.unwanted-communication`.
+3. Settings → Phone path: no SMS/Call Reporting row reached on Air.
+4. Settings → Apps → Phone: same confirm-label timeout as CD (Phone detail opaque / missing telephony chrome).
+5. Settings search **SMS/Call Reporting** and **Call Reporting**: AX stays on Settings root (General / Accessibility / …) — no reporting picker results; `sms-call-reporting-unavailable`.
+6. GREEN would need SMS/Call Reporting (or proven alias) listing **ET Unwanted Target** — not available on this Sim. Reporting UI invoke remains out of scope for P.
+
+## Follow-ups
+
+- Revisit both on a telephony-capable Sim / device where Phone → Call Blocking and SMS/Call Reporting exist.
+- Keep CLAIMS; do not soft-green on Apps host registration alone.

--- a/examples/.devicewright/catalog.ts
+++ b/examples/.devicewright/catalog.ts
@@ -469,9 +469,9 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "call-directory",
     path: "examples/call-directory",
     hostBundleId: "com.expotargets.example.call-directory",
-    hostDisplayName: "ET call-directory",
-    extensionName: "ET call-directory",
-    extensionAliases: ["call-directory"],
+    hostDisplayName: "ET CallDir",
+    extensionName: "ET CallDir Target",
+    extensionAliases: ["ET CallDir Target", "ET CallDir", "call-directory"],
     payloadMarker: "ready",
     completeButton: "",
     testIds: {

--- a/examples/.devicewright/claims.ts
+++ b/examples/.devicewright/claims.ts
@@ -61,11 +61,20 @@ export const OS_LIMIT_CLAIMS: readonly ClaimsEntry[] = [
     reason: "Account auth modification requires system Settings",
   },
   { id: "authentication-services", reason: "SSO / AppSSO entitlement gated" },
-  { id: "call-directory", reason: "Call Directory Settings enablement" },
+  {
+    id: "call-directory",
+    reason:
+      "Phone → Call Blocking & Identification is unavailable on non-telephony Sims (Air): Settings Apps→Phone confirm on Call Blocking / Announce Calls times out; Settings search “Call Blocking” finds no usable surface — cannot list or enable ET CallDir Target (pluginkit alone is not green)",
+  },
   {
     id: "message-filter",
     reason:
       "Messages Settings detail is AX-blank on Simulator (Apps→Messages often Settings|Apps|BackButton only); Unknown Senders / Text Message Filter / Manage Filtering / SMS Filtering Settings search returns no results; App-prefs:com.apple.MobileSMS / App-prefs:MESSAGES are no-ops on this Sim — cannot list or enable ET MsgFilter Target or prove inbound filter invoke",
+  },
+  {
+    id: "unwanted-communication",
+    reason:
+      "Phone → SMS/Call Reporting (and Settings search for SMS/Call Reporting / Call Reporting) is unavailable on Air / non-telephony Sims; Apps→Phone confirm times out like Call Blocking — cannot list ET Unwanted Target despite classification-ui pluginkit registration",
   },
   {
     id: "spotlight",

--- a/examples/.devicewright/journeys/call-directory.ts
+++ b/examples/.devicewright/journeys/call-directory.ts
@@ -20,7 +20,6 @@ import {
   waitForNamed,
 } from "./helpers";
 import {
-  navigatePath,
   openSettingsApps,
   scrollUntilVisible,
   searchAppsAndOpen,
@@ -68,15 +67,19 @@ async function tryOpenCallBlockingSettings(
       ) {
         steps.push("phone-settings-ok");
         try {
-          await navigatePath(
+          const openedBlocking = await tapLabelInTree(
             device,
             [
               "Call Blocking & Identification",
               "Call Blocking and Identification",
             ],
-            steps,
+            { exactOnly: false },
           );
-          return true;
+          if (openedBlocking) {
+            steps.push("call-blocking-nav");
+            return true;
+          }
+          steps.push("call-blocking-nav-failed");
         } catch {
           steps.push("call-blocking-nav-failed");
         }
@@ -99,15 +102,27 @@ async function tryOpenCallBlockingSettings(
     });
     steps.push("apps-phone-settings");
     try {
-      await navigatePath(
+      const openedBlocking = await tapLabelInTree(
         device,
         [
           "Call Blocking & Identification",
           "Call Blocking and Identification",
         ],
-        steps,
+        { exactOnly: false },
       );
-      return true;
+      if (openedBlocking) {
+        steps.push("apps-phone-call-blocking-nav");
+        return true;
+      }
+      const phoneLabels = flattenLabels(await device.accessibilityTree());
+      if (
+        phoneLabels.some((l) =>
+          /call blocking|call directory|identification/i.test(l),
+        )
+      ) {
+        steps.push("apps-phone-call-blocking-surface");
+        return true;
+      }
     } catch {
       const phoneLabels = flattenLabels(await device.accessibilityTree());
       if (

--- a/examples/.devicewright/journeys/index.ts
+++ b/examples/.devicewright/journeys/index.ts
@@ -24,6 +24,7 @@ import { runPhotoEditingJourney } from "./photo-editing";
 import { runQuicklookPreviewJourney } from "./quicklook-preview";
 import { runQuicklookThumbnailJourney } from "./quicklook-thumbnail";
 import { runSafariJourney } from "./safari";
+import { runUnwantedCommunicationJourney } from "./unwanted-communication";
 import { runShareActionJourney } from "./share";
 import { runSpotlightJourney } from "./spotlight";
 import { runStickersJourney } from "./stickers";
@@ -62,6 +63,7 @@ export { runPhotoEditingJourney } from "./photo-editing";
 export { runQuicklookPreviewJourney } from "./quicklook-preview";
 export { runQuicklookThumbnailJourney } from "./quicklook-thumbnail";
 export { runSafariJourney } from "./safari";
+export { runUnwantedCommunicationJourney } from "./unwanted-communication";
 export { runShareActionJourney } from "./share";
 export { runSpotlightJourney } from "./spotlight";
 export {
@@ -88,7 +90,6 @@ export type JourneyRunner = (
 
 /** ids proven via generic Settings→Apps→search host→host settings page. */
 const APPS_SETTINGS_IDS = [
-  "unwanted-communication",
   "spotlight-delegate",
   "bg-download",
   "matter",
@@ -129,6 +130,7 @@ const LIVE: Record<string, JourneyRunner> = {
   "broadcast-setup-ui": (d) => runBroadcastSetupUiJourney(d),
   "call-directory": (d) => runCallDirectoryJourney(d),
   "message-filter": (d) => runMessageFilterJourney(d),
+  "unwanted-communication": (d) => runUnwantedCommunicationJourney(d),
   "quicklook-preview": (d) => runQuicklookPreviewJourney(d),
   "quicklook-thumbnail": (d) => runQuicklookThumbnailJourney(d),
   spotlight: (d) => runSpotlightJourney(d),

--- a/examples/.devicewright/journeys/unwanted-communication.ts
+++ b/examples/.devicewright/journeys/unwanted-communication.ts
@@ -1,0 +1,319 @@
+/**
+ * Unwanted Communication Reporting deep journey.
+ *
+ * GREEN (P): pluginkit lists identitylookup.classification-ui + Settings Phone
+ * SMS/Call Reporting (or proven alias) lists ET Unwanted Target.
+ *
+ * Reporting UI invoke (user reports junk) is not required for P — Settings list
+ * is the floor (mirrors call-directory). CLAIMS only after S3a proves non-P.
+ */
+import { spawnSync } from "node:child_process";
+import type { DeviceSession } from "@csark0812/devicewright";
+import { claimForId } from "../claims";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  dismissSystemAlerts,
+  flattenLabels,
+  sleep,
+  waitForNamed,
+} from "./helpers";
+import {
+  openSettingsApps,
+  scrollUntilVisible,
+  searchAppsAndOpen,
+  tapLabelInTree,
+} from "./settings-nav";
+
+const SETTINGS_BUNDLE = "com.apple.Preferences";
+
+const EXTENSION_LABELS = [
+  "ET Unwanted Target",
+  "ET Unwanted",
+  "Unwanted",
+];
+
+/** Settings labels for the SMS / Call Reporting picker (iOS 18–26 variants). */
+const REPORTING_SURFACE_LABELS = [
+  "SMS/Call Reporting",
+  "SMS / Call Reporting",
+  "SMS and Call Reporting",
+  "Call Reporting",
+  "SMS Reporting",
+  "Unwanted Communication Reporting",
+  "Reporting",
+];
+
+function pluginkitHasClassificationUi(udid: string, appexId: string): boolean {
+  const r = spawnSync(
+    "xcrun",
+    ["simctl", "spawn", udid, "pluginkit", "-mAvvvvv"],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024, env: process.env },
+  );
+  const out = `${r.stdout ?? ""}\n${r.stderr ?? ""}`;
+  return (
+    out.toLowerCase().includes(appexId.toLowerCase()) &&
+    /identitylookup\.classification-ui/i.test(out)
+  );
+}
+
+async function tryOpenSmsCallReporting(
+  device: DeviceSession,
+  steps: string[],
+): Promise<boolean> {
+  // Path A: Settings → Phone → SMS/Call Reporting
+  await device.launchApp(SETTINGS_BUNDLE, { terminateRunning: true });
+  steps.push("settings-launch");
+  await sleep(700);
+
+  const phoneVisible = await scrollUntilVisible(device, ["Phone"], 12);
+  if (phoneVisible) {
+    const openedPhone = await tapLabelInTree(device, ["Phone"], {
+      exactOnly: true,
+    });
+    if (openedPhone) {
+      steps.push("nav:Phone");
+      await sleep(600);
+      const phoneLabels = flattenLabels(await device.accessibilityTree());
+      steps.push(`phone-labels:${phoneLabels.slice(0, 40).join("|")}`);
+      if (
+        phoneLabels.some((l) =>
+          /sms|call reporting|reporting|unwanted/i.test(l),
+        )
+      ) {
+        steps.push("phone-settings-ok");
+        const openedReporting = await tapLabelInTree(
+          device,
+          REPORTING_SURFACE_LABELS,
+          { exactOnly: false },
+        );
+        if (openedReporting) {
+          steps.push("sms-call-reporting-nav");
+          await sleep(600);
+          return true;
+        }
+        steps.push("sms-call-reporting-nav-failed");
+      }
+    }
+  }
+
+  // Path B: Settings → Apps → Phone (iOS 26 Apps Settings)
+  try {
+    await openSettingsApps(device, steps);
+    await searchAppsAndOpen(device, "Phone", ["Phone"], steps, {
+      exactRow: true,
+      confirmLabels: [
+        "Call Blocking & Identification",
+        "Call Blocking and Identification",
+        "Announce Calls",
+        "Silence Unknown Callers",
+        "SMS/Call Reporting",
+        "SMS / Call Reporting",
+        "Cellular",
+        "My Number",
+      ],
+    });
+    steps.push("apps-phone-settings");
+    await sleep(800);
+
+    for (let i = 0; i < 6; i++) {
+      const labels = flattenLabels(await device.accessibilityTree());
+      if (labels.length > 5) break;
+      await sleep(400);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const opened = await tapLabelInTree(device, REPORTING_SURFACE_LABELS, {
+        exactOnly: false,
+      });
+      if (opened) {
+        steps.push("apps-phone-sms-call-reporting");
+        await sleep(600);
+        return true;
+      }
+      await device
+        .swipe({
+          xStart: 210,
+          yStart: 720,
+          xEnd: 210,
+          yEnd: 220,
+          duration: 0.35,
+        })
+        .catch(() => undefined);
+      await sleep(400);
+    }
+
+    const phoneLabels = flattenLabels(await device.accessibilityTree());
+    steps.push(`apps-phone-labels:${phoneLabels.slice(0, 50).join("|")}`);
+    if (
+      phoneLabels.some((l) =>
+        /sms|call reporting|reporting|unwanted/i.test(l),
+      )
+    ) {
+      steps.push("apps-phone-reporting-surface");
+      return true;
+    }
+  } catch (e) {
+    steps.push(`apps-phone-settings-unavailable:${String(e).slice(0, 120)}`);
+  }
+
+  // Path C: Settings search
+  await device.launchApp(SETTINGS_BUNDLE, { terminateRunning: true });
+  await sleep(500);
+  const searchField = await tapLabelInTree(device, ["Search"]);
+  if (searchField) {
+    steps.push("settings-search");
+    await device.type("SMS/Call Reporting");
+    await sleep(800);
+    const searchLabels = flattenLabels(await device.accessibilityTree());
+    steps.push(`settings-search-labels:${searchLabels.slice(0, 30).join("|")}`);
+    if (searchLabels.some((l) => /no results for/i.test(l))) {
+      steps.push("settings-search-no-sms-call-reporting");
+    } else {
+      const opened = await tapLabelInTree(device, REPORTING_SURFACE_LABELS, {
+        exactOnly: false,
+      });
+      if (opened) {
+        steps.push("settings-search-sms-call-reporting");
+        return true;
+      }
+    }
+
+    // Alternate query
+    await device.launchApp(SETTINGS_BUNDLE, { terminateRunning: true });
+    await sleep(400);
+    if (await tapLabelInTree(device, ["Search"])) {
+      await device.type("Call Reporting");
+      await sleep(700);
+      const alt = flattenLabels(await device.accessibilityTree());
+      steps.push(`settings-search-alt:${alt.slice(0, 25).join("|")}`);
+      if (!alt.some((l) => /no results for/i.test(l))) {
+        const opened = await tapLabelInTree(device, REPORTING_SURFACE_LABELS, {
+          exactOnly: false,
+        });
+        if (opened) {
+          steps.push("settings-search-call-reporting");
+          return true;
+        }
+      } else {
+        steps.push("settings-search-no-call-reporting");
+      }
+    }
+  }
+
+  steps.push("sms-call-reporting-unavailable");
+  return false;
+}
+
+export async function runUnwantedCommunicationJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG["unwanted-communication"];
+  const pathStr = entry?.path ?? "examples/unwanted-communication";
+  const claim = claimForId("unwanted-communication");
+  const steps: string[] = [];
+  const appexLabels = [
+    entry?.extensionName,
+    entry?.hostDisplayName,
+    ...EXTENSION_LABELS,
+  ].filter(Boolean) as string[];
+
+  try {
+    if (!entry) throw new Error("unwanted-communication: missing catalog entry");
+
+    await dismissSystemAlerts(device);
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    steps.push("launch-host");
+    await dismissSystemAlerts(device);
+    await waitForNamed(device, ["ready"], 15_000);
+    steps.push("host-ready");
+
+    const appexId = `${entry.hostBundleId}.unwanted-communication`;
+    if (!pluginkitHasClassificationUi(device.deviceId, appexId)) {
+      throw new Error(
+        `classification-ui appex missing from pluginkit (${appexId})`,
+      );
+    }
+    steps.push("pluginkit-classification-ui");
+
+    const settingsAvailable = await tryOpenSmsCallReporting(device, steps);
+    if (!settingsAvailable) {
+      if (claim) {
+        return {
+          id: "unwanted-communication",
+          path: pathStr,
+          phase: 5,
+          ok: true,
+          status: "os-limit",
+          steps,
+          failureKind: "os-limit",
+          error: claim.reason,
+        };
+      }
+      throw new Error(
+        "SMS/Call Reporting Settings surface unavailable after Phone / Apps→Phone / search hunt",
+      );
+    }
+
+    let listed = false;
+    for (let i = 0; i < 12; i++) {
+      const tree = await device.accessibilityTree();
+      const labels = flattenLabels(tree);
+      listed = labels.some((l) =>
+        appexLabels.some((a) => l.toLowerCase().includes(a.toLowerCase())),
+      );
+      if (listed) break;
+      await sleep(450);
+    }
+
+    if (listed) {
+      steps.push("unwanted-communication-listed");
+      const opened = await tapLabelInTree(device, appexLabels);
+      if (opened) steps.push("unwanted-communication-opened");
+      return {
+        id: "unwanted-communication",
+        path: pathStr,
+        phase: 5,
+        ok: true,
+        status: "green",
+        steps,
+      };
+    }
+
+    const finalLabels = flattenLabels(await device.accessibilityTree());
+    steps.push(`reporting-list-labels:${finalLabels.slice(0, 60).join("|")}`);
+    steps.push("unwanted-communication-not-listed");
+
+    if (claim) {
+      return {
+        id: "unwanted-communication",
+        path: pathStr,
+        phase: 5,
+        ok: true,
+        status: "os-limit",
+        steps,
+        failureKind: "os-limit",
+        error: claim.reason,
+      };
+    }
+
+    throw new Error(
+      `ET Unwanted Target not listed on SMS/Call Reporting; labels=${finalLabels.slice(0, 80).join(", ")}`,
+    );
+  } catch (e) {
+    const msg = String(e);
+    const failureKind = /not installed|Unable to find|Launch failed/i.test(msg)
+      ? "operator"
+      : "product";
+    return {
+      id: "unwanted-communication",
+      path: pathStr,
+      phase: 5,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/touchpoints.ts
+++ b/examples/.devicewright/touchpoints.ts
@@ -244,7 +244,7 @@ export const TOUCHPOINTS: readonly TouchpointDef[] = [
     id: "call-directory",
     tranche: "T7",
     touchpoint:
-      "Settings Phone → Call Blocking & Identification lists ET CallDir Target",
+      "pluginkit callkit.call-directory + Settings Phone → Call Blocking & Identification lists ET CallDir Target (CLAIMS — Phone/Call Blocking opaque on Air)",
     status: "concrete",
   },
   {
@@ -257,7 +257,8 @@ export const TOUCHPOINTS: readonly TouchpointDef[] = [
   {
     id: "unwanted-communication",
     tranche: "T7",
-    touchpoint: "Settings Apps host registration",
+    touchpoint:
+      "pluginkit classification-ui + Settings Phone → SMS/Call Reporting lists ET Unwanted Target (CLAIMS — reporting picker opaque on non-telephony Sim)",
     status: "concrete",
   },
   {

--- a/examples/unwanted-communication/App.tsx
+++ b/examples/unwanted-communication/App.tsx
@@ -1,18 +1,69 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { AppGroupStorage } from 'expo-targets';
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+const storage = new AppGroupStorage(
+  'group.com.expotargets.example.unwanted-communication'
+);
 
 export default function App() {
+  const [ready, setReady] = useState(false);
+  const [payload, setPayload] = useState('none');
+
+  const refresh = useCallback(() => {
+    const marker = storage.get<string>('uc:marker');
+    const request = storage.get<string>('uc:lastRequest');
+    if (marker || request) {
+      setPayload(JSON.stringify({ marker, request }));
+    } else {
+      setPayload('none');
+    }
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 2000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
   return (
     <View style={styles.container} testID="screen-root">
       <StatusBar style="auto" />
       <Text style={styles.title}>ET Unwanted</Text>
-      <Text testID="status-target-ready">ready</Text>
+      <Text testID="status-target-ready">{ready ? 'ready' : 'loading'}</Text>
       <Text testID="text-extension-type">unwanted-communication</Text>
       <Text testID="text-bundle-suffix">
         com.expotargets.example.unwanted-communication
       </Text>
-      <Text testID="btn-clear-payload">clear</Text>
-      <Text testID="text-last-payload">none</Text>
+      <Text accessibilityLabel="uc-settings-hint">
+        Settings Phone → SMS/Call Reporting lists ET Unwanted Target
+      </Text>
+      <TouchableOpacity
+        testID="btn-refresh"
+        accessibilityLabel="Refresh"
+        style={styles.button}
+        onPress={refresh}
+      >
+        <Text style={styles.buttonText}>Refresh</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        testID="btn-clear-payload"
+        accessibilityLabel="Clear payload"
+        style={styles.button}
+        onPress={() => {
+          storage.remove('uc:marker');
+          storage.remove('uc:lastRequest');
+          storage.remove('uc:lastAt');
+          setPayload('none');
+        }}
+      >
+        <Text style={styles.buttonText}>Clear</Text>
+      </TouchableOpacity>
+      <Text testID="text-last-payload" style={styles.payload}>
+        {payload}
+      </Text>
     </View>
   );
 }
@@ -23,6 +74,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 24,
+    gap: 10,
   },
   title: { fontSize: 20, fontWeight: '600', marginBottom: 12 },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: '600' },
+  payload: { marginTop: 8, textAlign: 'center' },
 });

--- a/examples/unwanted-communication/targets/unwanted-communication/expo-target.config.json
+++ b/examples/unwanted-communication/targets/unwanted-communication/expo-target.config.json
@@ -9,7 +9,7 @@
     "displayName": "ET Unwanted Target",
     "infoPlist": {
       "NSExtension": {
-        "NSExtensionPrincipalClass": "UnwantedCommunicationReportingExtension"
+        "NSExtensionPrincipalClass": "ClassificationViewController"
       }
     }
   }

--- a/examples/unwanted-communication/targets/unwanted-communication/ios/ClassificationViewController.swift
+++ b/examples/unwanted-communication/targets/unwanted-communication/ios/ClassificationViewController.swift
@@ -1,0 +1,51 @@
+import IdentityLookup
+import IdentityLookupUI
+import UIKit
+
+/// Unwanted Communication Reporting principal — Settings Phone → SMS/Call Reporting.
+@objc(ClassificationViewController)
+class ClassificationViewController: ILClassificationUIExtensionViewController {
+  private let markerLabel = UILabel()
+  private let appGroup = "group.com.expotargets.example.unwanted-communication"
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+
+    markerLabel.text = "ET Unwanted"
+    markerLabel.accessibilityIdentifier = "uc-classification-marker"
+    markerLabel.accessibilityLabel = "ET Unwanted"
+    markerLabel.textAlignment = .center
+    markerLabel.font = .preferredFont(forTextStyle: .title2)
+    markerLabel.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(markerLabel)
+
+    NSLayoutConstraint.activate([
+      markerLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      markerLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      markerLabel.leadingAnchor.constraint(
+        greaterThanOrEqualTo: view.leadingAnchor,
+        constant: 16
+      ),
+      markerLabel.trailingAnchor.constraint(
+        lessThanOrEqualTo: view.trailingAnchor,
+        constant: -16
+      ),
+    ])
+  }
+
+  override func prepare(for request: ILClassificationRequest) {
+    let defaults = UserDefaults(suiteName: appGroup)
+    defaults?.set("ET Unwanted", forKey: "uc:marker")
+    defaults?.set(String(describing: type(of: request)), forKey: "uc:lastRequest")
+    defaults?.set(Date().timeIntervalSince1970, forKey: "uc:lastAt")
+    defaults?.synchronize()
+    extensionContext.isReadyForClassificationResponse = true
+  }
+
+  override func classificationResponse(
+    for request: ILClassificationRequest
+  ) -> ILClassificationResponse {
+    ILClassificationResponse(action: .reportJunk)
+  }
+}

--- a/examples/unwanted-communication/targets/unwanted-communication/ios/UnwantedCommunicationReportingExtension.swift
+++ b/examples/unwanted-communication/targets/unwanted-communication/ios/UnwantedCommunicationReportingExtension.swift
@@ -1,8 +1,0 @@
-import Foundation
-import UIKit
-
-/// Minimal unwanted-communication stub for expo-targets example (UnwantedCommunication).
-@objc(UnwantedCommunicationReportingExtension)
-class UnwantedCommunicationReportingExtension: NSObject {
-  // Extension principal — replace with full Apple API conformance as needed.
-}


### PR DESCRIPTION
## Summary
- Deepen `unwanted-communication`: real `ILClassificationUIExtensionViewController`, dedicated Phone → SMS/Call Reporting journey (out of Apps-Settings soft-green).
- Harden `call-directory`: catalog labels → ET CallDir; Call Blocking tap alternatives; enriched CLAIMS.
- Air / DW 0.1.14 falsify (`targets-1785870175467`): both **os-limit** with S3a spike — Phone telephony Settings opaque on non-telephony Sim.

## Test plan
- [x] `bun examples/.devicewright/cli.ts matrix --ids=unwanted-communication,call-directory --live-through=5 --no-fail-fast --ensure-install` (uninstall/rebuild first)
- [x] Re-run after CLAIMS → both `os-limit`, matrix exit 0
- [x] Spike + `docs/limits.md` leftover rows
- [x] `bun run lint`