### PR TITLE
fix: excludedPackages + Messages displayName (#42, #22, #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-08-05
+
+### Fixed
+
+- **`excludedPackages` for nested RN extensions (#42):** Config was plumbed but ignored. Nested targets now record exclusions in the Podfile and a `post_integrate` hook strips those packages from `expo-configure-project.sh` then regenerates `ExpoModulesProvider.swift` (nested `use_expo_modules!(exclude:)` is a no-op). Fixes blank Messages/share sheets when the host links `expo-updates` / `expo-dev-client`.
+- **Messages `displayName` (#22):** `CFBundleDisplayName` and `CFBundleName` both receive the literal `displayName` (not `$(PRODUCT_NAME)` / `*Target`).
+
 ### Changed
 
 - **Breaking (iOS sealed build):** Plugin-generated target artifacts move from `targets/*/ios/build/` to `ios/<App>/ExpoTargetsGenerated/<SanitizedProductName>/` (Info.plist, entitlements, Assets, RN/Messages stubs, Safari Resources). Host Live Activity / App Shortcuts Swift stays flat under `ExpoTargetsGenerated/*.swift`. Re-run `expo prebuild` (or `expo-targets sync`). Update any scripts that `cp` into the old path — on apply the plugin deletes that target’s legacy `targets/<name>/ios/build` when present. Do not hand-edit sealed or legacy build dirs. See `docs/widgets.md` and Safari Resources in `docs/configuration.md`.
@@ -15,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/limits.md`: max Sim-greenable (**P**) policy, S3a spike gate, leftover register, currently-green expansion backlog.
 - Live Activity CLAIMS narrowed to DI / push / StandBy (+ Watch after S3a); NCE expand→custom UI required (removed `notification-content` os-limit row).
 - **Product posture:** expo-targets owns Expo’s negative space (share/action/clip/messages/stickers/wallet and related Apple targets). Native WidgetKit + Live Activities are **first-class** here; official [`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) remains an alternate React/Expo-UI path — do not dual-generate. See `docs/widgets.md` and `docs/deprecations.md`.
+- `docs/widgets.md`: configurable widgets (Edit Widget) via native `AppIntentConfiguration` + App Group / `createTarget` (issue #15).
 - `create-expo-target`: Share/Action/Clip/Messages lead the menu; Widget scaffolds native WidgetKit; React Native defaults to **Yes** for share/action/clip.
 - Docs governed by `@csark0812/skeleton` (registry + `AGENTS.md`); bumped to `^1.5.7` (audit hang fix).
 - iOS config-plugin pipeline split into Observe → Plan → Apply; Biome replaces ESLint/Prettier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `widget` - Home screen widgets (Glance API or RemoteViews)
 
-[Unreleased]: https://github.com/csark0812/expo-targets/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/csark0812/expo-targets/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/csark0812/expo-targets/compare/v0.2.7...v0.2.8
 [0.2.0]: https://github.com/csark0812/expo-targets/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/csark0812/expo-targets/releases/tag/v0.1.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,11 +62,11 @@ targets/my-widget/
 
 | Field              | Default     | Description                                                                                                                                                      |
 | ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `displayName`      | `name`      | Human-readable name shown in widget picker                                                                                                                       |
+| `displayName`      | `name`      | Human-readable name (`CFBundleDisplayName` / `CFBundleName` on iOS; widget picker label)                                                                          |
 | `appGroup`         | _inherited_ | App Group ID. If not specified, automatically inherited from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
 | `liveActivity`     | —           | Widget-only ActivityKit schema (`attributesName`, `static`, `contentState`) — CNG into `ExpoTargetsGenerated/` (see [widgets.md](./widgets.md))                  |
 | `entry`            | —           | React Native entry point for share/action/clip/messages (see [Entry Field](#entry-field) below)                                                                  |
-| `excludedPackages` | `[]`        | Packages to exclude from RN bundle                                                                                                                               |
+| `excludedPackages` | `[]`        | Expo packages to omit from the nested extension's `ExpoModulesProvider` (via Podfile `post_integrate`; needs `entry`) — e.g. `expo-updates`, `expo-dev-client`  |
 
 ### Entry Field
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -83,7 +83,7 @@ Or manually configure `expo-target.config.json`:
 Key fields:
 
 - `entry`: Path to your React Native entry file **(relative to project root)**
-- `excludedPackages`: Packages to exclude from the extension bundle (reduces size)
+- `excludedPackages`: Expo packages to omit from the extension's `ExpoModulesProvider` (via CocoaPods `post_integrate`). Always exclude `expo-updates` and `expo-dev-client` for Messages/share/action/clip — they crash appex processes and leave a blank sheet. Nested `use_expo_modules!(exclude:)` alone does **not** work.
 
 ### 2. Create the Entry Point
 
@@ -327,7 +327,13 @@ iOS extensions have **strict memory limits**. Exceeding them causes iOS to termi
 
 ### Excluding Packages
 
-Reduce bundle size by excluding packages your extension doesn't need:
+Omit host-only Expo modules from the nested extension's `ExpoModulesProvider`. Nested
+`use_expo_modules!(exclude:)` is a no-op (parent AutolinkingManager); expo-targets
+strips the listed packages from `expo-configure-project.sh` in a `post_integrate`
+hook and regenerates the provider.
+
+Always exclude `expo-updates` and `expo-dev-client` for Messages / share / action /
+clip — Updates asserts before the RN factory is ready and blanks the sheet:
 
 ```json
 {

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -65,6 +65,50 @@ Opting into Live Activity writes `liveActivity` into `expo-target.config.json`, 
 
 See [`examples/trick`](../examples/trick) for a full host + widget pairing.
 
+## Configurable widgets (Edit Widget)
+
+iOS "Edit Widget" (long-press → Edit) uses WidgetKit **App Intent / Intent**
+configuration — native Swift only. expo-targets does not generate
+`AppIntentConfiguration` for you yet; deepen under `targets/<name>/ios/`.
+
+1. Swap `StaticConfiguration` for `AppIntentConfiguration` (iOS 17+) or
+   `IntentConfiguration` + an Intents definition (older).
+2. Persist the user's selection in the App Group `UserDefaults` suite (same
+   `appGroup` as the target).
+3. From the host app, read/write that suite with `createTarget('…').get/set` /
+   `AppGroupStorage`, then `refresh()`.
+
+Sketch:
+
+```swift
+// targets/hello-widget/ios/Widget.swift (deepen — not CNG)
+struct SelectListIntent: WidgetConfigurationIntent {
+  static var title: LocalizedStringResource = "List"
+  @Parameter(title: "List") var listId: String?
+}
+
+struct HelloWidget: Widget {
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(kind: kind, intent: SelectListIntent.self, provider: Provider()) { entry in
+      HelloWidgetView(entry: entry)
+    }
+    .configurationDisplayName("Hello Widget")
+  }
+}
+
+// In Provider timeline: read intent.listId, fall back to App Group defaults.
+```
+
+```ts
+// Host RN — after the user picks a default list in-app
+const widget = createTarget("HelloWidget");
+widget.set("listId", selectedId);
+widget.refresh();
+```
+
+React/Expo-UI-first configurable widgets: see official
+[`expo-widgets`](https://docs.expo.dev/versions/latest/sdk/widgets/) (do not dual-generate).
+
 ## Android widgets
 
 Android home-screen widgets (Glance / RemoteViews) stay **bridge-grade** and intentional while Expo’s official widgets stack is iOS-led. Other Apple extension types have no Android equivalent — see [limits.md](./limits.md).

--- a/examples/messages/targets/messages/expo-target.config.json
+++ b/examples/messages/targets/messages/expo-target.config.json
@@ -4,6 +4,7 @@
   "displayName": "Example Messages",
   "platforms": ["ios"],
   "entry": "./targets/messages/index.tsx",
+  "excludedPackages": ["expo-updates", "expo-dev-client"],
   "appGroup": "group.com.expotargets.example.messages",
   "ios": {
     "bundleIdentifier": "com.expotargets.example.messages.messages",

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -428,9 +428,11 @@ type TargetConfigReactNativeCompatible = BaseTargetConfig & {
    */
   entry?: string;
   /**
-   * Exclude specific Expo packages from the extension bundle
-   * Reduces bundle size by removing unused modules
-   * Only applies when `entry` is specified
+   * Exclude specific Expo packages from the nested extension's ExpoModulesProvider.
+   * Applied in a CocoaPods `post_integrate` hook (nested `use_expo_modules!(exclude:)`
+   * is a no-op). Prefer excluding `expo-updates` and `expo-dev-client` for Messages /
+   * share / action / clip — they assert in appex processes and blank the RN sheet.
+   * Only applies when `entry` is specified.
    * @example ['expo-dev-client', 'expo-updates']
    */
   excludedPackages?: string[];

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '../../../logger';
 import type { PodfilePlan } from '../../plan/types';
 import {
+  ensureExcludedPackagesPostIntegrate,
   ensureExtensionDeploymentTargets,
   ensureMainTargetUsesFrameworks,
   ensureReactNativeExtensionFrameworkPaths,
@@ -14,6 +15,7 @@ import {
   updatePodfilePlatform,
 } from './podfile';
 import {
+  findExcludedPackagesTargets,
   findReactNativeExtensionTargets,
   findStandaloneExtensionTargets,
   highestDeploymentTarget,
@@ -35,6 +37,7 @@ function targetBlockFor(
       deploymentTarget: plan.deploymentTarget,
       extensionType: plan.extensionType,
       podsRbContent: plan.podsRbContent,
+      excludedPackages: plan.excludedPackages,
     });
   }
 
@@ -51,6 +54,7 @@ function targetBlockFor(
 /**
  * `inherit! :search_paths` alone is not enough for Swift imports in React
  * Native extensions; they need explicit framework search paths.
+ * Also rebuild the excludedPackages post_integrate hook from all nested markers.
  */
 function applyReactNativePostInstall(
   podfile: string,
@@ -62,14 +66,18 @@ function applyReactNativePostInstall(
     fallbackDeploymentTarget: plan.deploymentTarget,
   });
 
-  if (reactNativeTargets.length === 0) {
-    return podfile;
+  let next = podfile;
+  if (reactNativeTargets.length > 0) {
+    next = ensureReactNativeExtensionFrameworkPaths(
+      next,
+      reactNativeTargets,
+      mainTargetName
+    );
   }
 
-  return ensureReactNativeExtensionFrameworkPaths(
-    podfile,
-    reactNativeTargets,
-    mainTargetName
+  return ensureExcludedPackagesPostIntegrate(
+    next,
+    findExcludedPackagesTargets(next, mainTargetName)
   );
 }
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/index.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/index.ts
@@ -7,8 +7,9 @@
 
 export { applyPodfilePlan } from './applyPodfilePlan';
 export * from './podfile';
-export type { PodfileTargetRef } from './scan';
+export type { PodfileTargetRef, ExcludedPackagesTargetRef } from './scan';
 export {
+  findExcludedPackagesTargets,
   findReactNativeExtensionTargets,
   findStandaloneExtensionTargets,
   highestDeploymentTarget,

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { normalizePodfile } from '../../../../test-utils/normalizePodfile';
 import {
+  ensureExcludedPackagesPostIntegrate,
   ensureMainTargetUsesFrameworks,
   generateReactNativeTargetBlock,
   generateStandaloneTargetBlock,
@@ -62,6 +63,7 @@ describe('generateReactNativeTargetBlock', () => {
       extensionType: 'share',
     });
     expect(block).toContain('inherit! :search_paths');
+    expect(block).not.toContain('[expo-targets-excluded-packages]');
   });
 
   test('clip also inherits search_paths (host copies frameworks into AppClips)', () => {
@@ -71,6 +73,55 @@ describe('generateReactNativeTargetBlock', () => {
       extensionType: 'clip',
     });
     expect(block).toContain('inherit! :search_paths');
+  });
+
+  test('records excludedPackages as a marker comment', () => {
+    const block = generateReactNativeTargetBlock({
+      targetName: 'ExampleMessagesTarget',
+      deploymentTarget: '16.4',
+      extensionType: 'messages',
+      excludedPackages: ['expo-updates', 'expo-dev-client'],
+    });
+    expect(block).toContain(
+      '# [expo-targets-excluded-packages] expo-updates,expo-dev-client'
+    );
+  });
+});
+
+describe('ensureExcludedPackagesPostIntegrate', () => {
+  test('injects an idempotent post_integrate hook', () => {
+    const once = ensureExcludedPackagesPostIntegrate(plainPodfile, [
+      {
+        targetName: 'ExampleMessagesTarget',
+        packages: ['expo-updates', 'expo-dev-client'],
+      },
+    ]);
+    expect(once).toContain('# [expo-targets-excluded-packages-start]');
+    expect(once).toContain('post_integrate do |installer|');
+    expect(once).toContain(
+      "'ExampleMessagesTarget' => ['expo-updates', 'expo-dev-client']"
+    );
+    expect(once).toContain('expo-configure-project.sh');
+    expect(once).toContain('Pods-#{target_name}');
+
+    const twice = ensureExcludedPackagesPostIntegrate(once, [
+      {
+        targetName: 'ExampleMessagesTarget',
+        packages: ['expo-updates', 'expo-dev-client'],
+      },
+    ]);
+    expect(twice.split('# [expo-targets-excluded-packages-start]').length).toBe(
+      2
+    );
+  });
+
+  test('removes the hook when exclusions are empty', () => {
+    const withHook = ensureExcludedPackagesPostIntegrate(plainPodfile, [
+      { targetName: 'ExampleMessagesTarget', packages: ['expo-updates'] },
+    ]);
+    const cleared = ensureExcludedPackagesPostIntegrate(withHook, []);
+    expect(cleared).not.toContain('# [expo-targets-excluded-packages-start]');
+    expect(cleared).not.toContain('post_integrate do |installer|');
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -154,13 +154,17 @@ function indentCustomPods(podsRbContent?: string): string {
   return `\n${indented}\n`;
 }
 
+/** Parseable marker: packages to strip from this nested target's ExpoModulesProvider. */
+export const EXCLUDED_PACKAGES_MARKER = '# [expo-targets-excluded-packages]';
+
 /**
  * Generate a Podfile target block for a React Native extension.
  * Extension targets only inherit search paths, with no explicit pod dependencies.
  * This avoids linking incompatible modules like Expo that contain UIApplication APIs.
  *
- * Note: ExpoTargetsMessages is accessed via the main app's autolinking through shared
- * registry defined in generated code, so no direct pod dependency is needed.
+ * `excludedPackages` is recorded as a comment marker so a `post_integrate` hook can
+ * strip those names from `expo-configure-project.sh` and regenerate the provider.
+ * Nested `use_expo_modules!(exclude:)` is a no-op (parent AutolinkingManager).
  *
  * @param podsRbContent - Optional content from a pods.rb file in the target directory.
  *                        Allows custom CocoaPods configuration (e.g., Firebase, third-party SDKs).
@@ -171,13 +175,22 @@ export function generateReactNativeTargetBlock({
   deploymentTarget,
   extensionType: _extensionType,
   podsRbContent,
+  excludedPackages,
 }: {
   targetName: string;
   deploymentTarget: string;
   extensionType: string;
   podsRbContent?: string;
+  excludedPackages?: string[];
 }): string {
   const customPods = indentCustomPods(podsRbContent);
+  const packages = (excludedPackages ?? [])
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const excludeLine =
+    packages.length > 0
+      ? `\n    ${EXCLUDED_PACKAGES_MARKER} ${packages.join(',')}`
+      : '';
 
   // App Clips still use search_paths here; framework embedding for the clip
   // product is handled by a dedicated PBX shell phase (inherit! :complete
@@ -185,7 +198,7 @@ export function generateReactNativeTargetBlock({
   return `
   target '${targetName}' do
     platform :ios, '${deploymentTarget}'
-    inherit! :search_paths${customPods}
+    inherit! :search_paths${excludeLine}${customPods}
   end
 `;
 }
@@ -686,4 +699,87 @@ export function ensureReactNativeExtensionFrameworkPaths(
     '\n' +
     afterInsert
   );
+}
+
+const EXCLUDED_PACKAGES_POST_INTEGRATE_START =
+  '# [expo-targets-excluded-packages-start]';
+const EXCLUDED_PACKAGES_POST_INTEGRATE_END =
+  '# [expo-targets-excluded-packages-end]';
+
+function rubySingleQuoted(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function buildExcludedPackagesPostIntegrate(
+  exclusions: { targetName: string; packages: string[] }[]
+): string {
+  const hashEntries = exclusions
+    .map(({ targetName, packages }) => {
+      const pkgs = packages.map(rubySingleQuoted).join(', ');
+      return `    ${rubySingleQuoted(targetName)} => [${pkgs}]`;
+    })
+    .join(',\n');
+
+  // Ruby `#{...}` interpolations must not go through a TS template literal.
+  const ruby = [
+    EXCLUDED_PACKAGES_POST_INTEGRATE_START,
+    '# Strip host-only Expo packages from nested RN extension ExpoModulesProviders.',
+    '# Nested use_expo_modules!(exclude:) is a no-op (parent AutolinkingManager);',
+    '# Expo regenerates the provider during integrate_user_targets after post_install.',
+    'post_integrate do |installer|',
+    '  exclusions = {',
+    hashEntries,
+    '  }',
+    '  exclusions.each do |target_name, packages|',
+    '    next if packages.nil? || packages.empty?',
+    '    support_dir = File.join(installer.sandbox.root, \'Target Support Files\', "Pods-#{target_name}")',
+    "    script_path = File.join(support_dir, 'expo-configure-project.sh')",
+    "    provider_path = File.join(support_dir, 'ExpoModulesProvider.swift')",
+    '    unless File.exist?(script_path)',
+    '      Pod::UI.warn "[expo-targets] Missing #{script_path}; skip excludedPackages for #{target_name}"',
+    '      next',
+    '    end',
+    '    content = File.read(script_path)',
+    '    packages.each do |pkg|',
+    '      content.gsub!(/\\s*"#{Regexp.escape(pkg)}"/, \'\')',
+    '    end',
+    '    File.write(script_path, content)',
+    "    ok = system({ 'PODS_ROOT' => installer.sandbox.root.to_s }, 'bash', script_path)",
+    '    unless ok',
+    '      raise "[expo-targets] Failed to regenerate ExpoModulesProvider for #{target_name} after excludedPackages strip"',
+    '    end',
+    '    unless File.exist?(provider_path)',
+    '      raise "[expo-targets] ExpoModulesProvider missing after regenerate for #{target_name}"',
+    '    end',
+    '    Pod::UI.puts "[expo-targets] Applied excludedPackages to #{target_name}: #{packages.join(\', \')}"',
+    '  end',
+    'end',
+    EXCLUDED_PACKAGES_POST_INTEGRATE_END,
+    '',
+  ].join('\n');
+
+  return ruby;
+}
+
+/**
+ * Ensure a top-level `post_integrate` hook strips `excludedPackages` from each
+ * nested RN target's `expo-configure-project.sh` and regenerates its provider.
+ * Idempotent via START/END markers. No exclusions → remove any prior hook.
+ */
+export function ensureExcludedPackagesPostIntegrate(
+  podfileContent: string,
+  exclusions: { targetName: string; packages: string[] }[]
+): string {
+  const without = removeMarkedBlock(
+    podfileContent,
+    EXCLUDED_PACKAGES_POST_INTEGRATE_START,
+    EXCLUDED_PACKAGES_POST_INTEGRATE_END
+  );
+
+  if (exclusions.length === 0) {
+    return without.trimEnd() + '\n';
+  }
+
+  const block = buildExcludedPackagesPostIntegrate(exclusions);
+  return `${without.trimEnd()}\n\n${block}`;
 }

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
@@ -11,10 +11,18 @@ export interface PodfileTargetRef {
   deploymentTarget: string;
 }
 
+export interface ExcludedPackagesTargetRef {
+  targetName: string;
+  packages: string[];
+}
+
 const NESTED_TARGET_START = /^\s+target\s+'([^']+)'\s+do/;
 const PLATFORM_LINE = /platform\s+:ios,\s+'([^']+)'/;
 const STANDALONE_TARGET =
   /target\s+'([^']+)'\s+do\s+platform\s+:ios,\s+'([^']+)'/g;
+/** Keep in sync with EXCLUDED_PACKAGES_MARKER in podfile.ts */
+const EXCLUDED_PACKAGES_LINE =
+  /# \[expo-targets-excluded-packages\]\s*(.+)/;
 
 /**
  * The main target's block, up to the `post_install` hook when there is one.
@@ -95,6 +103,32 @@ export function findReactNativeExtensionTargets(
       deploymentTarget:
         block.match(PLATFORM_LINE)?.[1] || fallbackDeploymentTarget,
     }));
+}
+
+/**
+ * Nested RN targets that declare `excludedPackages` via the marker comment.
+ * Used to rebuild the `post_integrate` strip hook after each target apply.
+ */
+export function findExcludedPackagesTargets(
+  podfile: string,
+  mainTargetName: string
+): ExcludedPackagesTargetRef[] {
+  const body = mainTargetBody(podfile, mainTargetName);
+  if (!body) {
+    return [];
+  }
+
+  return nestedTargetBlocks(body, mainTargetName)
+    .filter(({ block }) => block.includes('inherit! :search_paths'))
+    .map(({ name, block }) => {
+      const match = block.match(EXCLUDED_PACKAGES_LINE);
+      const packages = (match?.[1] ?? '')
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean);
+      return { targetName: name, packages };
+    })
+    .filter((t) => t.packages.length > 0);
 }
 
 /**

--- a/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.test.ts
@@ -79,11 +79,20 @@ describe('getTargetInfoPlistForType golden output', () => {
 });
 
 describe('getTargetInfoPlistForType options', () => {
-  test('displayName becomes CFBundleDisplayName (not PRODUCT_NAME)', () => {
+  test('displayName becomes CFBundleDisplayName and CFBundleName (not PRODUCT_NAME)', () => {
     const parsed = plist.parse(
       getTargetInfoPlistForType('stickers', { displayName: 'Fun Stickers' })
-    ) as { CFBundleDisplayName?: string };
+    ) as { CFBundleDisplayName?: string; CFBundleName?: string };
     expect(parsed.CFBundleDisplayName).toBe('Fun Stickers');
+    expect(parsed.CFBundleName).toBe('Fun Stickers');
+  });
+
+  test('messages displayName is literal in both CFBundle keys', () => {
+    const parsed = plist.parse(
+      getTargetInfoPlistForType('messages', { displayName: 'Super' })
+    ) as { CFBundleDisplayName?: string; CFBundleName?: string };
+    expect(parsed.CFBundleDisplayName).toBe('Super');
+    expect(parsed.CFBundleName).toBe('Super');
   });
 
   test('watch companion sets WKCompanionAppBundleIdentifier', () => {

--- a/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.ts
@@ -356,9 +356,12 @@ export function getTargetInfoPlistForType(
 
   const basePlist = deepMerge(createBasePlist(), characteristics.basePlist);
   // Literal displayName wins over $(PRODUCT_NAME). INFOPLIST_KEY_* does not
-  // override an existing Info.plist key, so write it here.
+  // override an existing Info.plist key, so write it here. Set both DisplayName
+  // and Name — Messages drawer and other chrome read either key.
   if (options.displayName?.trim()) {
-    basePlist.CFBundleDisplayName = options.displayName.trim();
+    const name = options.displayName.trim();
+    basePlist.CFBundleDisplayName = name;
+    basePlist.CFBundleName = name;
   }
   if (type === 'watch' && options.companionAppBundleIdentifier?.trim()) {
     basePlist.WKCompanionAppBundleIdentifier =


### PR DESCRIPTION
## Summary
- Honor `excludedPackages` for nested RN extensions via Podfile `post_integrate` (strip + regenerate `ExpoModulesProvider`) — fixes #42
- Write literal `displayName` into both `CFBundleDisplayName` and `CFBundleName` — fixes #22
- Document configurable widgets (Edit Widget) in `docs/widgets.md` — closes #15

## Test plan
- [x] `bun test` podfile + buildInfoPlist unit tests
- [x] `bun run validate:changed`
- [ ] After merge: confirm publish workflow bumps to 0.2.8 and npm packages publish