### PR TITLE
fix: unblock publish (auth + biome)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
         run: npm install -g npm@latest
 
       - run: bun install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - run: bun run typecheck
       - run: bun run build
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/index.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/index.ts
@@ -7,7 +7,7 @@
 
 export { applyPodfilePlan } from './applyPodfilePlan';
 export * from './podfile';
-export type { PodfileTargetRef, ExcludedPackagesTargetRef } from './scan';
+export type { ExcludedPackagesTargetRef, PodfileTargetRef } from './scan';
 export {
   findExcludedPackagesTargets,
   findReactNativeExtensionTargets,

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -710,6 +710,46 @@ function rubySingleQuoted(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
+/** Ruby body lines for the excludedPackages post_integrate hook (minus hash). */
+const EXCLUDED_PACKAGES_RUBY_PREFIX = [
+  EXCLUDED_PACKAGES_POST_INTEGRATE_START,
+  '# Strip host-only Expo packages from nested RN extension ExpoModulesProviders.',
+  '# Nested use_expo_modules!(exclude:) is a no-op (parent AutolinkingManager);',
+  '# Expo regenerates the provider during integrate_user_targets after post_install.',
+  'post_integrate do |installer|',
+  '  exclusions = {',
+] as const;
+
+const EXCLUDED_PACKAGES_RUBY_SUFFIX = [
+  '  }',
+  '  exclusions.each do |target_name, packages|',
+  '    next if packages.nil? || packages.empty?',
+  '    support_dir = File.join(installer.sandbox.root, \'Target Support Files\', "Pods-#{target_name}")',
+  "    script_path = File.join(support_dir, 'expo-configure-project.sh')",
+  "    provider_path = File.join(support_dir, 'ExpoModulesProvider.swift')",
+  '    unless File.exist?(script_path)',
+  '      Pod::UI.warn "[expo-targets] Missing #{script_path}; skip excludedPackages for #{target_name}"',
+  '      next',
+  '    end',
+  '    content = File.read(script_path)',
+  '    packages.each do |pkg|',
+  '      content.gsub!(/\\s*"#{Regexp.escape(pkg)}"/, \'\')',
+  '    end',
+  '    File.write(script_path, content)',
+  "    ok = system({ 'PODS_ROOT' => installer.sandbox.root.to_s }, 'bash', script_path)",
+  '    unless ok',
+  '      raise "[expo-targets] Failed to regenerate ExpoModulesProvider for #{target_name} after excludedPackages strip"',
+  '    end',
+  '    unless File.exist?(provider_path)',
+  '      raise "[expo-targets] ExpoModulesProvider missing after regenerate for #{target_name}"',
+  '    end',
+  '    Pod::UI.puts "[expo-targets] Applied excludedPackages to #{target_name}: #{packages.join(\', \')}"',
+  '  end',
+  'end',
+  EXCLUDED_PACKAGES_POST_INTEGRATE_END,
+  '',
+] as const;
+
 function buildExcludedPackagesPostIntegrate(
   exclusions: { targetName: string; packages: string[] }[]
 ): string {
@@ -720,45 +760,11 @@ function buildExcludedPackagesPostIntegrate(
     })
     .join(',\n');
 
-  // Ruby `#{...}` interpolations must not go through a TS template literal.
-  const ruby = [
-    EXCLUDED_PACKAGES_POST_INTEGRATE_START,
-    '# Strip host-only Expo packages from nested RN extension ExpoModulesProviders.',
-    '# Nested use_expo_modules!(exclude:) is a no-op (parent AutolinkingManager);',
-    '# Expo regenerates the provider during integrate_user_targets after post_install.',
-    'post_integrate do |installer|',
-    '  exclusions = {',
+  return [
+    ...EXCLUDED_PACKAGES_RUBY_PREFIX,
     hashEntries,
-    '  }',
-    '  exclusions.each do |target_name, packages|',
-    '    next if packages.nil? || packages.empty?',
-    '    support_dir = File.join(installer.sandbox.root, \'Target Support Files\', "Pods-#{target_name}")',
-    "    script_path = File.join(support_dir, 'expo-configure-project.sh')",
-    "    provider_path = File.join(support_dir, 'ExpoModulesProvider.swift')",
-    '    unless File.exist?(script_path)',
-    '      Pod::UI.warn "[expo-targets] Missing #{script_path}; skip excludedPackages for #{target_name}"',
-    '      next',
-    '    end',
-    '    content = File.read(script_path)',
-    '    packages.each do |pkg|',
-    '      content.gsub!(/\\s*"#{Regexp.escape(pkg)}"/, \'\')',
-    '    end',
-    '    File.write(script_path, content)',
-    "    ok = system({ 'PODS_ROOT' => installer.sandbox.root.to_s }, 'bash', script_path)",
-    '    unless ok',
-    '      raise "[expo-targets] Failed to regenerate ExpoModulesProvider for #{target_name} after excludedPackages strip"',
-    '    end',
-    '    unless File.exist?(provider_path)',
-    '      raise "[expo-targets] ExpoModulesProvider missing after regenerate for #{target_name}"',
-    '    end',
-    '    Pod::UI.puts "[expo-targets] Applied excludedPackages to #{target_name}: #{packages.join(\', \')}"',
-    '  end',
-    'end',
-    EXCLUDED_PACKAGES_POST_INTEGRATE_END,
-    '',
+    ...EXCLUDED_PACKAGES_RUBY_SUFFIX,
   ].join('\n');
-
-  return ruby;
 }
 
 /**

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
@@ -21,8 +21,7 @@ const PLATFORM_LINE = /platform\s+:ios,\s+'([^']+)'/;
 const STANDALONE_TARGET =
   /target\s+'([^']+)'\s+do\s+platform\s+:ios,\s+'([^']+)'/g;
 /** Keep in sync with EXCLUDED_PACKAGES_MARKER in podfile.ts */
-const EXCLUDED_PACKAGES_LINE =
-  /# \[expo-targets-excluded-packages\]\s*(.+)/;
+const EXCLUDED_PACKAGES_LINE = /# \[expo-targets-excluded-packages\]\s*(.+)/;
 
 /**
  * The main target's block, up to the `post_install` hook when there is one.

--- a/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.test.ts
+++ b/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.test.ts
@@ -13,12 +13,12 @@ describe('clearRootGeneratedSwiftFiles', () => {
       const productDir = path.join(outDir, 'ShareMinimalTarget');
       fs.mkdirSync(productDir, { recursive: true });
 
-      fs.writeFileSync(path.join(outDir, 'LiveActivityBridge.swift'), '// host\n');
-      fs.writeFileSync(path.join(outDir, 'KeepMe.txt'), 'not swift\n');
       fs.writeFileSync(
-        path.join(productDir, 'Info.plist'),
-        '<plist/>\n'
+        path.join(outDir, 'LiveActivityBridge.swift'),
+        '// host\n'
       );
+      fs.writeFileSync(path.join(outDir, 'KeepMe.txt'), 'not swift\n');
+      fs.writeFileSync(path.join(productDir, 'Info.plist'), '<plist/>\n');
       fs.writeFileSync(
         path.join(productDir, 'ReactNativeViewController.swift'),
         '// sealed\n'
@@ -32,9 +32,7 @@ describe('clearRootGeneratedSwiftFiles', () => {
       expect(fs.existsSync(path.join(outDir, 'KeepMe.txt'))).toBe(true);
       expect(fs.existsSync(path.join(productDir, 'Info.plist'))).toBe(true);
       expect(
-        fs.existsSync(
-          path.join(productDir, 'ReactNativeViewController.swift')
-        )
+        fs.existsSync(path.join(productDir, 'ReactNativeViewController.swift'))
       ).toBe(true);
     } finally {
       removeTempDir(root);

--- a/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
+++ b/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
@@ -161,7 +161,10 @@ function ensureGeneratedGroup(
   if (!generatedGroupKey && appGroupKey) {
     // Name-only group (no path) — file refs use ios/<App>/ExpoTargetsGenerated/…
     // like AppDelegate under the app group (path = ETTrick/AppDelegate.swift).
-    generatedGroupKey = project.pbxCreateGroup(Paths.GENERATED_DIR_NAME, undefined);
+    generatedGroupKey = project.pbxCreateGroup(
+      Paths.GENERATED_DIR_NAME,
+      undefined
+    );
     const mainGroup = project.hash.project.objects.PBXGroup[appGroupKey];
     if (mainGroup?.children) {
       mainGroup.children.push({

--- a/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/buildInfoPlist.test.ts
@@ -78,7 +78,7 @@ describe('getTargetInfoPlistForType golden output', () => {
   });
 });
 
-describe('getTargetInfoPlistForType options', () => {
+describe('getTargetInfoPlistForType displayName', () => {
   test('displayName becomes CFBundleDisplayName and CFBundleName (not PRODUCT_NAME)', () => {
     const parsed = plist.parse(
       getTargetInfoPlistForType('stickers', { displayName: 'Fun Stickers' })
@@ -94,7 +94,9 @@ describe('getTargetInfoPlistForType options', () => {
     expect(parsed.CFBundleDisplayName).toBe('Super');
     expect(parsed.CFBundleName).toBe('Super');
   });
+});
 
+describe('getTargetInfoPlistForType options', () => {
   test('watch companion sets WKCompanionAppBundleIdentifier', () => {
     const parsed = plist.parse(
       getTargetInfoPlistForType('watch', {

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -189,9 +189,7 @@ describe('planBuildSettings', () => {
     expect(settings.PRODUCT_NAME).toBe('"MyShareTarget"');
     expect(settings.IPHONEOS_DEPLOYMENT_TARGET).toBe('15.1');
     expect(settings.INFOPLIST_FILE).toBe(`"${INFO_PLIST_REFERENCE}"`);
-    expect(settings.CODE_SIGN_ENTITLEMENTS).toBe(
-      `"${ENTITLEMENTS_REFERENCE}"`
-    );
+    expect(settings.CODE_SIGN_ENTITLEMENTS).toBe(`"${ENTITLEMENTS_REFERENCE}"`);
   });
 
   test('falls back to Swift 5.0 and version 1.0.0 (1)', () => {


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN` to publish workflow `bun install` (private `@csark0812/devicewright`)
- Fix biome complexity/format so CI is green for 0.2.8 release

## Test plan
- [x] biome ci clean
- [x] podfile + buildInfoPlist unit tests
- [ ] Merge then `workflow_dispatch` publish patch → 0.2.8