### PR TITLE
fix(targets): always exclude Updates/DevClient from RN appexes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ targets/my-widget/
 | `appGroup`         | _inherited_ | App Group ID. If not specified, automatically inherited from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
 | `liveActivity`     | —           | Widget-only ActivityKit schema (`attributesName`, `static`, `contentState`) — CNG into `ExpoTargetsGenerated/` (see [widgets.md](./widgets.md))                  |
 | `entry`            | —           | React Native entry point for share/action/clip/messages (see [Entry Field](#entry-field) below)                                                                  |
-| `excludedPackages` | `[]`        | Expo packages to omit from the nested extension's `ExpoModulesProvider` (via Podfile `post_integrate`; needs `entry`) — e.g. `expo-updates`, `expo-dev-client`  |
+| `excludedPackages` | auto for RN `entry` | Extra packages to omit from the nested `ExpoModulesProvider` (`post_integrate`). `expo-updates` + `expo-dev-client` are always merged for RN-native `entry` targets; list only extras (e.g. reanimated) |
 
 ### Entry Field
 
@@ -649,7 +649,6 @@ The `targetIcon` for action extensions can be an SF Symbol name (e.g., `"photo.f
   "platforms": ["ios"],
   "appGroup": "group.com.yourapp",
   "entry": "./targets/share-to-app/index.tsx",
-  "excludedPackages": ["expo-updates", "expo-dev-client"],
   "ios": {
     "activationRules": [{ "type": "url" }]
   }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,6 @@ Add the plugin and App Groups to your `app.json`:
   "platforms": ["ios"],
   "appGroup": "group.com.yourcompany.myapp",
   "entry": "./targets/my-share/index.tsx",
-  "excludedPackages": ["expo-updates", "expo-dev-client"],
   "ios": {
     "deploymentTarget": "14.0"
   }
@@ -107,7 +106,7 @@ Add the plugin and App Groups to your `app.json`:
 
 Update the placeholder `appGroup` to match your `app.json`.
 
-`excludedPackages` must include `expo-updates` and `expo-dev-client` so the extension host does not link packages that assume a full app process (they break extension builds).
+For RN `entry` targets, the plugin **always** strips `expo-updates` and `expo-dev-client` from the nested `ExpoModulesProvider` (they crash appex processes). Add `excludedPackages` only for **extra** packages (e.g. reanimated). `npx expo-targets doctor` warns when heavy host deps look unused by the entry.
 
 ### Naming Conventions
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -79,15 +79,14 @@ Or manually configure `expo-target.config.json`:
   "name": "ShareExt",
   "platforms": ["ios"],
   "appGroup": "group.com.yourcompany.yourapp",
-  "entry": "./targets/share-ext/index.tsx",
-  "excludedPackages": ["expo-updates", "expo-dev-client"]
+  "entry": "./targets/share-ext/index.tsx"
 }
 ```
 
 Key fields:
 
 - `entry`: Path to your React Native entry file **(relative to project root)**
-- `excludedPackages`: Expo packages to omit from the extension's `ExpoModulesProvider` (via CocoaPods `post_integrate`). Always exclude `expo-updates` and `expo-dev-client` for Messages/share/action/clip — they crash appex processes and leave a blank sheet. Nested `use_expo_modules!(exclude:)` alone does **not** work.
+- `excludedPackages`: Optional **additional** packages to omit from the extension's `ExpoModulesProvider` (via CocoaPods `post_integrate`). `expo-updates` and `expo-dev-client` are **auto-merged** for RN-native `entry` targets — do not list them. Nested `use_expo_modules!(exclude:)` alone does **not** work.
 
 ### 2. Create the Entry Point
 
@@ -337,33 +336,41 @@ Omit host-only Expo modules from the nested extension's `ExpoModulesProvider`. N
 strips the listed packages from `expo-configure-project.sh` in a `post_integrate`
 hook and regenerates the provider.
 
-Always exclude `expo-updates` and `expo-dev-client` for Messages / share / action /
-clip — Updates asserts before the RN factory is ready and blanks the sheet:
+For RN-native targets with `entry`, **`expo-updates` and `expo-dev-client` are always
+union-merged** (no escape hatch) — Updates asserts before the RN factory is ready and
+blanks the sheet. List only **additional** packages:
 
 ```json
 {
   "excludedPackages": [
-    "expo-updates",
-    "expo-dev-client",
     "@react-native-community/netinfo",
     "react-native-reanimated"
   ]
 }
 ```
 
-**Common exclusions:**
+`npx expo-targets doctor` **warns** when heavy host dependencies (reanimated, Sentry,
+screens, netinfo, …) are present but not imported from the extension entry and not yet
+excluded — advisory only; it never auto-strips.
+
+**Auto-excluded (always):**
+
+| Package           | Reason                 | Savings |
+| ----------------- | ---------------------- | ------- |
+| `expo-updates`    | Crashes appex process  | ~500KB  |
+| `expo-dev-client` | Host-only dev tooling  | ~800KB  |
+
+**Common extra exclusions:**
 
 | Package                   | Reason                     | Savings |
 | ------------------------- | -------------------------- | ------- |
-| `expo-updates`            | OTA updates not needed     | ~500KB  |
-| `expo-dev-client`         | Dev tools not needed       | ~800KB  |
 | `react-native-reanimated` | Heavy animation library    | ~1.5MB  |
 | `@sentry/react-native`    | Error reporting not needed | ~1MB    |
 | `react-native-screens`    | Native nav not needed      | ~300KB  |
 
 ### Tips for Smaller Bundles
 
-1. **Exclude aggressively** — Start minimal, add packages only when needed
+1. **Exclude aggressively** — Start minimal, add packages only when needed; run `npx expo-targets doctor`
 2. **Avoid heavy UI libraries** — Use basic React Native components
 3. **Keep extension logic minimal** — Do heavy processing in your main app
 4. **Test on physical devices** — Simulators are more forgiving with memory

--- a/examples/messages/targets/messages/expo-target.config.json
+++ b/examples/messages/targets/messages/expo-target.config.json
@@ -4,7 +4,6 @@
   "displayName": "Example Messages",
   "platforms": ["ios"],
   "entry": "./targets/messages/index.tsx",
-  "excludedPackages": ["expo-updates", "expo-dev-client"],
   "appGroup": "group.com.expotargets.example.messages",
   "ios": {
     "bundleIdentifier": "com.expotargets.example.messages.messages",

--- a/packages/create-expo-target/src/generateConfig.ts
+++ b/packages/create-expo-target/src/generateConfig.ts
@@ -23,7 +23,6 @@ function applyReactNativeConfig(
 ): void {
   if (options.platforms.includes('ios') && options.useReactNative) {
     config.entry = `./targets/${options.kebabName}/index.tsx`;
-    config.excludedPackages = ['expo-updates', 'expo-dev-client'];
   }
 }
 

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { warnHeavyExclusions } from './heavyExclusions';
+import { loadProject } from '../project';
+
+const roots: string[] = [];
+
+function makeProject(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-heavy-'));
+  roots.push(root);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('warnHeavyExclusions', () => {
+  test('warns when heavy dep is unused by entry and not excluded', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'package.json': JSON.stringify({
+        dependencies: { 'react-native-reanimated': '3.0.0' },
+      }),
+      'targets/share/expo-target.config.json': JSON.stringify({
+        type: 'share',
+        name: 'Share',
+        platforms: ['ios'],
+        entry: './targets/share/index.tsx',
+      }),
+      'targets/share/index.tsx':
+        "import { View } from 'react-native';\nexport default function App() { return null; }\n",
+    });
+    const warnings = warnHeavyExclusions(loadProject(root));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain('react-native-reanimated');
+    expect(warnings[0]?.fix).toContain('excludedPackages');
+  });
+
+  test('quiet when entry imports the package', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'package.json': JSON.stringify({
+        dependencies: { 'react-native-reanimated': '3.0.0' },
+      }),
+      'targets/share/expo-target.config.json': JSON.stringify({
+        type: 'share',
+        name: 'Share',
+        platforms: ['ios'],
+        entry: './targets/share/index.tsx',
+      }),
+      'targets/share/index.tsx':
+        "import Animated from 'react-native-reanimated';\nexport default function App() { return null; }\n",
+    });
+    expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
+  });
+
+  test('quiet when already in excludedPackages', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'package.json': JSON.stringify({
+        dependencies: { 'react-native-reanimated': '3.0.0' },
+      }),
+      'targets/share/expo-target.config.json': JSON.stringify({
+        type: 'share',
+        name: 'Share',
+        platforms: ['ios'],
+        entry: './targets/share/index.tsx',
+        excludedPackages: ['react-native-reanimated'],
+      }),
+      'targets/share/index.tsx':
+        "import { View } from 'react-native';\nexport default function App() { return null; }\n",
+    });
+    expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
+  });
+});

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { resolveExcludedPackages } from '../../../plugin/build/resolveExcludedPackages';
+import type { CheckResult, ProjectContext } from '../types';
+
+/** Heavy / host-leaning packages worth warning about when unused by the entry. */
+export const HEAVY_EXCLUSION_CANDIDATES = [
+  'react-native-reanimated',
+  '@sentry/react-native',
+  'react-native-screens',
+  '@react-native-community/netinfo',
+] as const;
+
+const RN_NATIVE_TYPES = new Set([
+  'share',
+  'action',
+  'clip',
+  'messages',
+  'notification-content',
+]);
+
+const IMPORT_RE =
+  /(?:from\s+|require\s*\(\s*)['"](@?[^'"]+)['"]/g;
+
+function readPackageDeps(projectRoot: string): Set<string> {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    return new Set();
+  }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return new Set([
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ]);
+  } catch {
+    return new Set();
+  }
+}
+
+function packageRoot(specifier: string): string {
+  if (specifier.startsWith('@')) {
+    const parts = specifier.split('/');
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
+  }
+  return specifier.split('/')[0] ?? specifier;
+}
+
+function collectImportsFromEntry(
+  projectRoot: string,
+  entryRel: string
+): Set<string> {
+  const seen = new Set<string>();
+  const visited = new Set<string>();
+  const queue: string[] = [path.resolve(projectRoot, entryRel)];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || visited.has(file) || !fs.existsSync(file)) {
+      continue;
+    }
+    visited.add(file);
+    let source: string;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    for (const match of source.matchAll(IMPORT_RE)) {
+      const spec = match[1];
+      if (!spec) continue;
+      if (spec.startsWith('.') || spec.startsWith('/')) {
+        const dir = path.dirname(file);
+        const resolved = resolveLocal(dir, spec);
+        if (resolved) {
+          queue.push(resolved);
+        }
+        continue;
+      }
+      seen.add(packageRoot(spec));
+    }
+  }
+
+  return seen;
+}
+
+function resolveLocal(fromDir: string, spec: string): string | null {
+  const base = path.resolve(fromDir, spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.js`,
+    `${base}.jsx`,
+    path.join(base, 'index.ts'),
+    path.join(base, 'index.tsx'),
+    path.join(base, 'index.js'),
+    path.join(base, 'index.jsx'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) {
+      return c;
+    }
+  }
+  return null;
+}
+
+export function warnHeavyExclusions(ctx: ProjectContext): CheckResult[] {
+  const deps = readPackageDeps(ctx.projectRoot);
+  const warnings: CheckResult[] = [];
+
+  for (const target of ctx.targets) {
+    const { type, entry, name, excludedPackages } = target.config;
+    if (!entry || !type || !RN_NATIVE_TYPES.has(type)) {
+      continue;
+    }
+
+    const resolved = new Set(
+      resolveExcludedPackages({
+        type,
+        entry,
+        excludedPackages,
+      }) ?? []
+    );
+
+    const imported = collectImportsFromEntry(ctx.projectRoot, entry);
+    const targetLabel = name ?? target.dirName;
+    const unused: string[] = [];
+
+    for (const candidate of HEAVY_EXCLUSION_CANDIDATES) {
+      if (!deps.has(candidate)) continue;
+      if (imported.has(candidate)) continue;
+      if (resolved.has(candidate)) continue;
+      unused.push(candidate);
+    }
+
+    if (unused.length === 0) {
+      continue;
+    }
+
+    warnings.push({
+      ok: false,
+      level: 'warn',
+      title: 'Heavy exclusions',
+      message: `Target "${targetLabel}": host depends on ${unused.join(', ')} but ${unused.length === 1 ? 'it is' : 'they are'} not imported from ${entry}`,
+      fix: `Add ${unused.map((p) => `"${p}"`).join(', ')} to excludedPackages to shrink the nested ExpoModulesProvider`,
+    });
+  }
+
+  return warnings;
+}

--- a/packages/expo-targets/cli/src/doctor.ts
+++ b/packages/expo-targets/cli/src/doctor.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 import { checkAppGroups } from './checks/appGroups';
 import { warnDualWidgets } from './checks/dualWidgets';
 import { checkEntries } from './checks/entries';
+import { warnHeavyExclusions } from './checks/heavyExclusions';
 import { checkMetro } from './checks/metro';
 import { checkNameSync } from './checks/nameSync';
 import { checkPlugin } from './checks/plugin';
@@ -33,7 +34,11 @@ function collectFailures(ctx: ReturnType<typeof loadProject>): CheckResult[] {
 }
 
 function collectWarnings(ctx: ReturnType<typeof loadProject>): CheckResult[] {
-  return [...warnSealedZone(ctx), ...warnDualWidgets(ctx)];
+  return [
+    ...warnSealedZone(ctx),
+    ...warnDualWidgets(ctx),
+    ...warnHeavyExclusions(ctx),
+  ];
 }
 
 function passedChecks(ctx: ReturnType<typeof loadProject>): string[] {

--- a/packages/expo-targets/cli/src/types.ts
+++ b/packages/expo-targets/cli/src/types.ts
@@ -15,6 +15,7 @@ export interface TargetConfig {
   platforms?: string[];
   entry?: string;
   appGroup?: string;
+  excludedPackages?: string[];
   liveActivity?: { attributesName?: string };
   ios?: {
     intents?: { ui?: boolean | { name?: string } };

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -428,12 +428,12 @@ type TargetConfigReactNativeCompatible = BaseTargetConfig & {
    */
   entry?: string;
   /**
-   * Exclude specific Expo packages from the nested extension's ExpoModulesProvider.
-   * Applied in a CocoaPods `post_integrate` hook (nested `use_expo_modules!(exclude:)`
-   * is a no-op). Prefer excluding `expo-updates` and `expo-dev-client` for Messages /
-   * share / action / clip — they assert in appex processes and blank the RN sheet.
-   * Only applies when `entry` is specified.
-   * @example ['expo-dev-client', 'expo-updates']
+   * Extra Expo packages to omit from the nested extension's ExpoModulesProvider
+   * (via CocoaPods `post_integrate`). For RN-native targets with `entry`,
+   * `expo-updates` and `expo-dev-client` are **always** union-merged — no escape
+   * hatch. Use this field only for additional packages (e.g. reanimated, Sentry).
+   * Nested `use_expo_modules!(exclude:)` alone is a no-op.
+   * @example ['react-native-reanimated', '@sentry/react-native']
    */
   excludedPackages?: string[];
   ios?: IOSTargetConfigWithReactNative;

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  HOST_ONLY_EXCLUDED_PACKAGES,
+  resolveExcludedPackages,
+} from './resolveExcludedPackages';
+
+describe('resolveExcludedPackages', () => {
+  test('omitted list → force-merges host-only packages for RN entry', () => {
+    expect(
+      resolveExcludedPackages({
+        type: 'share',
+        entry: './targets/share/index.tsx',
+      })
+    ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES]);
+  });
+
+  test('user extras are additive; host-only always present', () => {
+    expect(
+      resolveExcludedPackages({
+        type: 'share',
+        entry: './targets/share/index.tsx',
+        excludedPackages: ['react-native-reanimated'],
+      })
+    ).toEqual([
+      ...HOST_ONLY_EXCLUDED_PACKAGES,
+      'react-native-reanimated',
+    ]);
+  });
+
+  test('empty array still gets host-only packages', () => {
+    expect(
+      resolveExcludedPackages({
+        type: 'messages',
+        entry: './targets/messages/index.tsx',
+        excludedPackages: [],
+      })
+    ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES]);
+  });
+
+  test('dedupes when user already lists host-only packages', () => {
+    expect(
+      resolveExcludedPackages({
+        type: 'action',
+        entry: './targets/action/index.tsx',
+        excludedPackages: ['expo-updates', 'expo-font'],
+      })
+    ).toEqual(['expo-updates', 'expo-dev-client', 'expo-font']);
+  });
+
+  test('non-RN or no entry → no force-inject', () => {
+    expect(
+      resolveExcludedPackages({
+        type: 'widget',
+        excludedPackages: ['expo-updates'],
+      })
+    ).toEqual(['expo-updates']);
+
+    expect(
+      resolveExcludedPackages({
+        type: 'share',
+      })
+    ).toBeUndefined();
+
+    expect(
+      resolveExcludedPackages({
+        type: 'safari',
+        entry: './targets/safari/popup.tsx',
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
@@ -1,0 +1,38 @@
+import type { ExtensionType } from './config';
+import { REACT_NATIVE_NATIVE_TYPES } from './domain';
+
+/** Host-only Expo packages that crash / blank RN appex processes. Always merged in. */
+export const HOST_ONLY_EXCLUDED_PACKAGES = [
+  'expo-updates',
+  'expo-dev-client',
+] as const;
+
+export type ResolveExcludedPackagesInput = {
+  type: ExtensionType | string;
+  entry?: string;
+  excludedPackages?: string[];
+};
+
+function isRnNativeType(type: string): boolean {
+  return (REACT_NATIVE_NATIVE_TYPES as string[]).includes(type);
+}
+
+/**
+ * Resolve Expo packages to strip from a nested RN extension's ExpoModulesProvider.
+ * For RN-native targets with an `entry`, always union-merge HOST_ONLY_EXCLUDED_PACKAGES
+ * (no escape hatch). User lists are additive only.
+ */
+export function resolveExcludedPackages(
+  input: ResolveExcludedPackagesInput
+): string[] | undefined {
+  const { type, entry, excludedPackages } = input;
+  if (!(entry && isRnNativeType(type))) {
+    return excludedPackages?.length ? [...excludedPackages] : undefined;
+  }
+
+  const merged = new Set<string>([
+    ...HOST_ONLY_EXCLUDED_PACKAGES,
+    ...(excludedPackages ?? []),
+  ]);
+  return [...merged];
+}

--- a/packages/expo-targets/plugin/src/withTargetsDir.ts
+++ b/packages/expo-targets/plugin/src/withTargetsDir.ts
@@ -8,13 +8,13 @@ import {
   type TargetCodegenConfig,
   writeTargetsTypesFile,
 } from './codegen/typedTargets';
-import { isReactNativeNative } from './domain';
 import {
   ensureHostAppGroups,
   warnMissingMetroWrapper,
 } from './ensureHostAppGroups';
 import { withIOSTarget } from './ios/config-plugins/withIOSTarget';
 import { Logger } from './logger';
+import { resolveExcludedPackages } from './resolveExcludedPackages';
 
 interface EvaluatedTarget {
   config: any;
@@ -218,11 +218,11 @@ const withTargetIos: ConfigPlugin<{
         }
       : undefined;
 
-  const excludedPackages =
-    evaluatedConfig.excludedPackages ??
-    (evaluatedConfig.entry && isReactNativeNative(evaluatedConfig.type)
-      ? ['expo-updates', 'expo-dev-client']
-      : undefined);
+  const excludedPackages = resolveExcludedPackages({
+    type: evaluatedConfig.type,
+    entry: evaluatedConfig.entry,
+    excludedPackages: evaluatedConfig.excludedPackages,
+  });
 
   let next = withIOSTarget(config, {
     ...(evaluatedConfig.ios || {}),


### PR DESCRIPTION
## Summary
- Auto-exclude `expo-updates` / `expo-dev-client` from React Native appexes (post_integrate + doctor) so host-only Updates never ships in the extension.
- Document the fail-closed exclusion path for RN-native targets.

## Test plan
- [ ] `bun test` for `resolveExcludedPackages` / `heavyExclusions`
- [ ] Prebuild an RN share example; confirm Podfile/post_integrate strips Updates from the appex target
- [ ] Share appex still builds without linking EXUpdates