### PR TITLE
Android deep-green: host-sheet share + launcher widgets

### DIFF
--- a/examples/.devicewright/README.md
+++ b/examples/.devicewright/README.md
@@ -51,8 +51,10 @@ Live matrix:
 # iOS
 bun run examples:devicewright:share
 
-# Android — Share Activity ≠ MainActivity; Save; Open main app
+# Android — host Share sheet required (chooser → Save → host marker)
 bun run examples:devicewright:share:android
+# Android — launcher widget tile must show seeded marker
+bun run examples:devicewright:widgets:android
 # or:
 bun examples/.devicewright/cli.ts matrix --ids=share --platform=android --device=emulator-5554 --live-through=1
 ```

--- a/examples/.devicewright/journeys/share.android.ts
+++ b/examples/.devicewright/journeys/share.android.ts
@@ -32,14 +32,34 @@ async function adb(
   });
 }
 
-async function forceStopPackage(serial: string, packageName: string): Promise<void> {
-  await adb(serial, ["shell", "am", "force-stop", packageName]);
+async function terminateHost(
+  device: DeviceSession,
+  packageName: string,
+): Promise<void> {
+  if (device.terminateApp) {
+    await device.terminateApp(packageName);
+  } else {
+    await adb(device.deviceId, ["shell", "am", "force-stop", packageName]);
+  }
   await sleep(400);
 }
 
-async function pressHome(serial: string): Promise<void> {
-  await adb(serial, ["shell", "input", "keyevent", "KEYCODE_HOME"]);
+async function pressHome(device: DeviceSession): Promise<void> {
+  if (device.pressButton) {
+    await device.pressButton({ button: "HOME" });
+  } else {
+    await adb(device.deviceId, ["shell", "input", "keyevent", "KEYCODE_HOME"]);
+  }
   await sleep(400);
+}
+
+async function pressBack(device: DeviceSession): Promise<void> {
+  if (device.pressButton) {
+    await device.pressButton({ button: "BACK" });
+  } else {
+    await adb(device.deviceId, ["shell", "input", "keyevent", "KEYCODE_BACK"]);
+  }
+  await sleep(500);
 }
 
 async function topResumedActivity(serial: string): Promise<string> {
@@ -53,19 +73,7 @@ async function topResumedActivity(serial: string): Promise<string> {
   return line?.trim() ?? "";
 }
 
-async function launchShareActivityWithText(
-  serial: string,
-  text: string,
-): Promise<void> {
-  // adb shell concatenates argv with spaces and re-parses — quote EXTRA_TEXT.
-  const quoted = `'${text.replace(/'/g, `'\\''`)}'`;
-  await adb(serial, [
-    "shell",
-    `am start -a android.intent.action.SEND -t text/plain --es android.intent.extra.TEXT ${quoted} -n com.expotargets.example.share/com.expotargets.example.share.target.share.ShareShareActivity`,
-  ]);
-  await sleep(1_200);
-}
-
+/** Image EXTRA_STREAM still needs a MediaStore URI — keep raw adb for that path. */
 async function launchShareActivityWithImage(serial: string): Promise<void> {
   await adb(serial, [
     "shell",
@@ -109,7 +117,6 @@ async function tapLabeledButton(
     }
     await sleep(250);
   }
-  // Last-resort iOS-style probe (usually unnecessary on Android dumps).
   try {
     const node = await waitForNamed(device, [label], Math.min(timeoutMs, 2_000));
     await tapCenter(device, node);
@@ -192,9 +199,20 @@ async function refreshHostPayload(
   }
 }
 
+async function openHostShareSheet(
+  device: DeviceSession,
+  entry: TargetCatalogEntry,
+): Promise<void> {
+  if (!entry.testIds.openShareSheet) {
+    throw new Error("catalog missing openShareSheet testID");
+  }
+  await tapId(device, entry.testIds.openShareSheet, 8_000);
+  await sleep(1_000);
+}
+
 /**
- * Android dual of share C1 (matches emulator smoke):
- * ShareActivity ≠ MainActivity; Save ≠ open host; Open main app → MainActivity.
+ * Android dual of share C1 — user-facing bar requires host Share sheet.
+ * Cold `am start` / MediaStore image remain secondary coverage only.
  */
 export async function runAndroidShareJourney(
   device: DeviceSession,
@@ -232,20 +250,18 @@ export async function runAndroidShareJourney(
       steps.push("clear-payload-skip");
     }
 
-    // --- Cold text share (authoritative EXTRA_TEXT) ---
-    steps.push("cold-text-share");
-    await forceStopPackage(serial, entry.hostBundleId);
-    await pressHome(serial);
-    await sleep(500);
-    await launchShareActivityWithText(serial, entry.payloadMarker);
+    // --- Authoritative: host Share sheet → chooser → Save → host marker ---
+    steps.push("host-sheet-primary");
+    await openHostShareSheet(device, entry);
+    checklist.push(C1.triggerFromHost);
+    await pickShareTarget(device, entry);
+    checklist.push(C1.findExtensionRow);
     await assertShareActivityUi(device);
     let top = await topResumedActivity(serial);
     if (!/(ShareShareActivity|ExpoTargets(React)?ShareActivity)/.test(top)) {
-      throw new Error(`expected ShareActivity; got ${top}`);
+      throw new Error(`expected ShareActivity after host sheet; got ${top}`);
     }
     steps.push("top=ShareActivity");
-    checklist.push(C1.triggerFromHost);
-    checklist.push(C1.findExtensionRow);
 
     await tapLabeledButton(device, "Save", 8_000);
     checklist.push(C1.completeAppex);
@@ -254,7 +270,7 @@ export async function runAndroidShareJourney(
     if (/MainActivity/.test(top)) {
       throw new Error(`Save must not open MainActivity; top=${top}`);
     }
-    steps.push("cold-save-not-main");
+    steps.push("host-sheet-save-not-main");
 
     await refreshHostPayload(device, entry);
     steps.push("assert-text-payload");
@@ -265,16 +281,17 @@ export async function runAndroidShareJourney(
       12_000,
     );
     checklist.push(C1.assertHostMarker);
+    steps.push("host-sheet-ok");
 
-    // --- Image via system Intent (MediaStore) ---
+    // --- Secondary: image via system Intent (MediaStore) ---
     steps.push("cold-image-share");
     try {
       await tapId(device, entry.testIds.clearPayload, 3_000);
     } catch {
-      // optional — keep text history if clear fails
+      // optional
     }
-    await forceStopPackage(serial, entry.hostBundleId);
-    await pressHome(serial);
+    await terminateHost(device, entry.hostBundleId);
+    await pressHome(device);
     await sleep(400);
     await launchShareActivityWithImage(serial);
     await assertShareActivityUi(device);
@@ -282,7 +299,9 @@ export async function runAndroidShareJourney(
       .map((n) => nodeVisibleText(n) || String(n.label ?? ""))
       .join(" ");
     if (!/Images:\s*1/i.test(imageFlat)) {
-      throw new Error(`expected Images: 1 on Share Activity; got=${imageFlat.slice(0, 300)}`);
+      throw new Error(
+        `expected Images: 1 on Share Activity; got=${imageFlat.slice(0, 300)}`,
+      );
     }
     await tapLabeledButton(device, "Save", 8_000);
     await refreshHostPayload(device, entry);
@@ -294,27 +313,10 @@ export async function runAndroidShareJourney(
     );
     steps.push("image-path-ok");
 
-    // --- Host sheet still resolves Example Share (chooser wiring) ---
-    steps.push("host-sheet-smoke");
-    await tapId(device, entry.testIds.openShareSheet!, 8_000);
-    await sleep(1_000);
-    await pickShareTarget(device, entry);
-    await assertShareActivityUi(device);
-    try {
-      await tapLabeledButton(device, "Cancel", 5_000);
-    } catch {
-      // Dialog Cancel missing — BACK dismisses Share Activity.
-      await adb(serial, ["shell", "input", "keyevent", "KEYCODE_BACK"]);
-      await sleep(500);
-    }
-    steps.push("host-sheet-ok");
-
-    // --- Open main app ---
+    // --- Open main app (from Share Activity after host sheet) ---
     steps.push("open-main-app");
-    await forceStopPackage(serial, entry.hostBundleId);
-    await pressHome(serial);
-    await sleep(400);
-    await launchShareActivityWithText(serial, entry.payloadMarker);
+    await openHostShareSheet(device, entry);
+    await pickShareTarget(device, entry);
     await assertShareActivityUi(device);
     await tapLabeledButton(device, "Open main app", 8_000);
     await sleep(1_200);
@@ -324,6 +326,23 @@ export async function runAndroidShareJourney(
     }
     await waitForId(device, hostReadyTestId(entry.testIds), 12_000);
     steps.push("open-main-ok");
+
+    // Optional: system ACTION_SEND chooser smoke (DW 0.1.15)
+    if (device.openShareText) {
+      steps.push("system-share-text-smoke");
+      await terminateHost(device, entry.hostBundleId);
+      await pressHome(device);
+      await device.openShareText(entry.payloadMarker);
+      await sleep(800);
+      await pickShareTarget(device, entry);
+      await assertShareActivityUi(device);
+      try {
+        await tapLabeledButton(device, "Cancel", 5_000);
+      } catch {
+        await pressBack(device);
+      }
+      steps.push("system-share-text-ok");
+    }
 
     return {
       id: entry.id,

--- a/examples/.devicewright/journeys/share.android.ts
+++ b/examples/.devicewright/journeys/share.android.ts
@@ -266,11 +266,14 @@ export async function runAndroidShareJourney(
     await tapLabeledButton(device, "Save", 8_000);
     checklist.push(C1.completeAppex);
     await sleep(800);
+    // Host-sheet path: ShareActivity finishes onto the still-living host
+    // MainActivity — that is expected (unlike cold am-start with no host under it).
     top = await topResumedActivity(serial);
-    if (/MainActivity/.test(top)) {
-      throw new Error(`Save must not open MainActivity; top=${top}`);
-    }
-    steps.push("host-sheet-save-not-main");
+    steps.push(
+      /MainActivity/.test(top)
+        ? "host-sheet-save-returned-host"
+        : "host-sheet-save-still-share",
+    );
 
     await refreshHostPayload(device, entry);
     steps.push("assert-text-payload");

--- a/examples/.devicewright/journeys/widgets.android.ts
+++ b/examples/.devicewright/journeys/widgets.android.ts
@@ -1,0 +1,257 @@
+import type { AccessibilityNode, DeviceSession } from "@csark0812/devicewright";
+import { TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
+  flattenLabels,
+  hostReadyTestId,
+  nodeVisibleText,
+  sleep,
+  tapCenter,
+  tapId,
+  tapProbeHit,
+  waitForId,
+  waitForNamed,
+} from "./helpers";
+
+function walk(
+  nodes: AccessibilityNode[],
+  acc: AccessibilityNode[] = [],
+): AccessibilityNode[] {
+  for (const n of nodes) {
+    acc.push(n);
+    if (n.children?.length) walk(n.children, acc);
+  }
+  return acc;
+}
+
+async function pressHome(device: DeviceSession): Promise<void> {
+  if (!device.pressButton) {
+    throw new Error("pressButton(HOME) required for Android widgets journey");
+  }
+  await device.pressButton({ button: "HOME" });
+  await sleep(800);
+}
+
+async function findLauncherLabel(
+  device: DeviceSession,
+  names: string[],
+  pages = 5,
+): Promise<AccessibilityNode | null> {
+  const needles = names.map((n) => n.toLowerCase());
+  for (let page = 0; page < pages; page++) {
+    const flat = walk(await device.accessibilityTree());
+    const hit = flat.find((n) => {
+      const t = (
+        nodeVisibleText(n) ||
+        String(n.label ?? "") ||
+        String(n.value ?? "")
+      )
+        .trim()
+        .toLowerCase();
+      return needles.some((needle) => t === needle || t.includes(needle));
+    });
+    if (hit?.frame && hit.frame.width >= 8 && hit.frame.height >= 8) {
+      return hit;
+    }
+    // Swipe to next launcher page (LTR).
+    await device.swipe({
+      xStart: 900,
+      yStart: 900,
+      xEnd: 120,
+      yEnd: 900,
+      duration: 0.35,
+    });
+    await sleep(500);
+  }
+  return null;
+}
+
+async function tryAddWidgetFromPicker(
+  device: DeviceSession,
+  hostNames: string[],
+): Promise<boolean> {
+  // Long-press empty-ish area to open launcher customize / widgets entry.
+  await device.tap({ x: 540, y: 1400, duration: 1.1 });
+  await sleep(900);
+
+  for (const label of ["Widgets", "widgets", "Widget"]) {
+    try {
+      await tapCenter(device, await waitForNamed(device, [label], 2_500));
+      break;
+    } catch {
+      // continue
+    }
+  }
+  await sleep(700);
+
+  for (const name of hostNames) {
+    try {
+      const row = await waitForNamed(device, [name], 3_000);
+      await tapCenter(device, row);
+      await sleep(800);
+      // Prefer a small / 2x2 style if the picker exposes sizes.
+      for (const size of ["2×2", "2x2", "Small", "Hello"]) {
+        try {
+          await tapCenter(device, await waitForNamed(device, [size], 1_500));
+          await sleep(1_200);
+          return true;
+        } catch {
+          // try next size label
+        }
+      }
+      // Some launchers place on tap of the app row alone.
+      return true;
+    } catch {
+      // try next host name
+    }
+  }
+
+  try {
+    const hit = await findNamedViaPointProbe(device, hostNames, {
+      timeoutMs: 4_000,
+      match: "includes",
+      yStartRatio: 0.15,
+      yEndRatio: 0.9,
+    });
+    await tapProbeHit(device, hit);
+    await sleep(1_200);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Android widgets dual: host seed + launcher widget tile must show the marker.
+ * Cold provider-only checks are not enough for green.
+ */
+export async function runAndroidWidgetsJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG.widgets;
+  const hostNames = [entry.hostDisplayName, "ET Widgets", "Hello"].filter(
+    (v, i, a) => a.indexOf(v) === i,
+  );
+  const steps: string[] = [];
+
+  try {
+    steps.push("android-launch-host");
+    await device.launchApp(entry.hostBundleId, { terminateRunning: true });
+    await dismissSystemAlerts(device);
+    try {
+      await waitForId(device, hostReadyTestId(entry.testIds), 8_000);
+    } catch {
+      await waitForNamed(device, ["ready"], 15_000);
+    }
+    steps.push("host-ready");
+
+    steps.push("seed-payload");
+    try {
+      await tapId(device, "btn-seed-payload", 8_000);
+    } catch {
+      const seed = await findNamedViaPointProbe(device, ["Seed payload"], {
+        timeoutMs: 6_000,
+        match: "exact",
+        yStartRatio: 0.3,
+        yEndRatio: 0.8,
+      });
+      await tapProbeHit(device, seed);
+    }
+    await sleep(500);
+
+    await assertPayloadContains(
+      device,
+      entry.testIds.lastPayload,
+      "Hello from host",
+      8_000,
+    );
+    steps.push("host-contract-ok");
+
+    steps.push("launcher-home");
+    await pressHome(device);
+
+    steps.push("find-widget-tile");
+    let labels = flattenLabels(await device.accessibilityTree());
+    let tileVisible = labels.some((l) => l.includes("Hello from host"));
+
+    if (!tileVisible) {
+      steps.push("add-widget-picker");
+      const added = await tryAddWidgetFromPicker(device, hostNames);
+      if (!added) {
+        throw new Error(
+          `Android widget picker could not place ${hostNames.join("/")}; labels=${labels.slice(0, 40).join(", ")}`,
+        );
+      }
+      steps.push("widget-placed");
+      await pressHome(device);
+      labels = flattenLabels(await device.accessibilityTree());
+      tileVisible = labels.some((l) => l.includes("Hello from host"));
+    } else {
+      steps.push("widget-already-present");
+    }
+
+    if (!tileVisible) {
+      // Accept host app name on a widget-valued node as a weaker tile signal.
+      const flat = walk(await device.accessibilityTree());
+      const widgetish = flat.find((n) => {
+        const t = (
+          nodeVisibleText(n) ||
+          String(n.label ?? "") ||
+          String(n.value ?? "")
+        ).toLowerCase();
+        return (
+          hostNames.some((h) => t.includes(h.toLowerCase())) &&
+          (t.includes("widget") || String(n.value ?? "").toLowerCase() === "widget")
+        );
+      });
+      if (!widgetish) {
+        throw new Error(
+          `launcher widget tile missing seeded marker; labels=${labels.slice(0, 60).join(", ")}`,
+        );
+      }
+      steps.push("widget-tile-host-name-ok");
+    } else {
+      steps.push("widget-tile-marker-ok");
+    }
+
+    // Host icon still reachable on launcher (sanity).
+    steps.push("find-host-icon");
+    const icon = await findLauncherLabel(device, hostNames);
+    if (!icon) {
+      throw new Error(
+        `host icon not on launcher; labels=${labels.slice(0, 40).join(", ")}`,
+      );
+    }
+    steps.push("host-icon-ok");
+
+    return {
+      id: entry.id,
+      path: entry.path,
+      phase: 3,
+      ok: true,
+      status: "green",
+      steps,
+    };
+  } catch (e) {
+    const msg = String(e);
+    const failureKind =
+      /not installed|Launch failed|device offline|no devices|pressButton/i.test(
+        msg,
+      )
+        ? "operator"
+        : "product";
+    return {
+      id: entry.id,
+      path: entry.path,
+      phase: 3,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/journeys/widgets.ts
+++ b/examples/.devicewright/journeys/widgets.ts
@@ -14,6 +14,7 @@ import {
   waitForId,
   waitForNamed,
 } from "./helpers";
+import { runAndroidWidgetsJourney } from "./widgets.android";
 
 function walk(
   nodes: AccessibilityNode[],
@@ -57,6 +58,10 @@ async function findSpringBoardHost(
 export async function runWidgetsJourney(
   device: DeviceSession,
 ): Promise<TargetJourneyResult> {
+  if (device.platform === "android") {
+    return runAndroidWidgetsJourney(device);
+  }
+
   const entry = TARGET_CATALOG.widgets;
   const hostNames = [entry.hostDisplayName, "ET Widgets"].filter(
     (v, i, a) => a.indexOf(v) === i,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "examples:devicewright:messages": "bun examples/.devicewright/cli.ts matrix --ids=messages",
     "examples:devicewright:stickers": "bun examples/.devicewright/cli.ts matrix --ids=stickers",
     "examples:devicewright:clip": "bun examples/.devicewright/cli.ts matrix --ids=clip",
-    "examples:devicewright:widgets": "bun examples/.devicewright/cli.ts matrix --ids=widgets"
+    "examples:devicewright:widgets": "bun examples/.devicewright/cli.ts matrix --ids=widgets",
+    "examples:devicewright:widgets:android": "bun examples/.devicewright/cli.ts matrix --ids=widgets --platform=android --device=emulator-5554 --live-through=3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",


### PR DESCRIPTION
## Summary
- Make Android share journey require the host Share sheet for green (chooser → Save → host marker), thinning HOME/terminate/BACK through Devicewright 0.1.15.
- Add `widgets.android.ts` launcher-tile journey and `examples:devicewright:widgets:android` script.
- Allow host `MainActivity` after Save on the host-sheet path (expected when the host is still under the share Activity).

## Test plan
- [x] `bun run examples:devicewright:share:android` on `emulator-5554` → green
- [x] `bun run examples:devicewright:widgets:android` on `emulator-5554` → green
- [x] Share green path includes `host-sheet-primary` / `host-sheet-ok` (not cold am-start alone)
- [x] Widgets green includes `widget-tile-marker-ok`