### PR TITLE
feat(devicewright): Android action, file-provider, keyboard deep-green

### DIFF
--- a/examples/.devicewright/README.md
+++ b/examples/.devicewright/README.md
@@ -55,6 +55,8 @@ bun run examples:devicewright:share
 bun run examples:devicewright:share:android
 # Android — launcher widget tile must show seeded marker
 bun run examples:devicewright:widgets:android
+# Android — DocumentsUI lists Expo Targets root + host android-docs marker
+bun run examples:devicewright:file-provider:android
 # or:
 bun examples/.devicewright/cli.ts matrix --ids=share --platform=android --device=emulator-5554 --live-through=1
 ```

--- a/examples/.devicewright/catalog.ts
+++ b/examples/.devicewright/catalog.ts
@@ -7,6 +7,11 @@ export type TargetCatalogEntry = {
   id: string;
   path: string;
   hostBundleId: string;
+  /**
+   * Android applicationId when it must diverge from iOS `hostBundleId`
+   * (hyphens are valid in Apple bundle IDs, not in Android packages).
+   */
+  androidPackage?: string;
   hostDisplayName: string;
   extensionName: string;
   extensionAliases: string[];
@@ -349,6 +354,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "credentials-provider",
     path: "examples/credentials-provider",
     hostBundleId: "com.expotargets.example.credentials-provider",
+    androidPackage: "com.expotargets.example.credentialsprovider",
     hostDisplayName: "ET credentials-provider",
     extensionName: "ET credentials-provider",
     extensionAliases: ["credentials-provider"],
@@ -409,6 +415,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "file-provider",
     path: "examples/file-provider",
     hostBundleId: "com.expotargets.example.file-provider",
+    androidPackage: "com.expotargets.example.fileprovider",
     hostDisplayName: "ET FileProv",
     extensionName: "ET FileProv Target",
     extensionAliases: ["ET FileProv Target", "file-provider"],
@@ -417,6 +424,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     testIds: {
       screenRoot: "screen-root",
       clearPayload: "btn-clear-payload",
+      refresh: "btn-refresh",
       lastPayload: "text-last-payload",
     },
   },
@@ -424,6 +432,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "file-provider-ui",
     path: "examples/file-provider-ui",
     hostBundleId: "com.expotargets.example.file-provider-ui",
+    androidPackage: "com.expotargets.example.fileproviderui",
     hostDisplayName: "ET FileProvUI",
     extensionName: "ET FileProvUI Target",
     extensionAliases: ["ET FileProvUI Target", "file-provider-ui"],
@@ -469,6 +478,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "call-directory",
     path: "examples/call-directory",
     hostBundleId: "com.expotargets.example.call-directory",
+    androidPackage: "com.expotargets.example.calldirectory",
     hostDisplayName: "ET CallDir",
     extensionName: "ET CallDir Target",
     extensionAliases: ["ET CallDir Target", "ET CallDir", "call-directory"],
@@ -604,6 +614,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "network-packet-tunnel",
     path: "examples/network-packet-tunnel",
     hostBundleId: "com.expotargets.example.network-packet-tunnel",
+    androidPackage: "com.expotargets.example.networkpackettunnel",
     hostDisplayName: "ET network-packet-tunnel",
     extensionName: "ET network-packet-tunnel",
     extensionAliases: ["network-packet-tunnel"],
@@ -754,6 +765,7 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     id: "print-service",
     path: "examples/print-service",
     hostBundleId: "com.expotargets.example.print-service",
+    androidPackage: "com.expotargets.example.printservice",
     hostDisplayName: "ET Print",
     extensionName: "ET Print Target",
     extensionAliases: ["ET Print Target", "print-service"],
@@ -826,6 +838,17 @@ export const TARGET_CATALOG: Record<string, TargetCatalogEntry> = {
     },
   },
 };
+
+/** Launch id for Devicewright — Android may diverge when iOS IDs contain hyphens. */
+export function hostLaunchId(
+  entry: TargetCatalogEntry,
+  platform: "ios" | "android",
+): string {
+  if (platform === "android" && entry.androidPackage) {
+    return entry.androidPackage;
+  }
+  return entry.hostBundleId;
+}
 
 /** System Share Sheet rows we must never tap (mirrors ShareSheetSmoke). */
 export const BLOCKED_SHEET_LABELS = new Set([

--- a/examples/.devicewright/journeys/action.android.ts
+++ b/examples/.devicewright/journeys/action.android.ts
@@ -16,7 +16,7 @@ import {
   waitForNamed,
 } from "./helpers";
 
-const ANDROID_SHARE_IDS = new Set(["share"]);
+const ANDROID_ACTION_IDS = new Set(["action"]);
 
 async function tapLabeledButton(
   device: DeviceSession,
@@ -66,7 +66,7 @@ async function confirmChooserIfNeeded(device: DeviceSession): Promise<void> {
   }
 }
 
-async function pickShareTarget(
+async function pickActionTarget(
   device: DeviceSession,
   entry: TargetCatalogEntry,
 ): Promise<void> {
@@ -74,8 +74,8 @@ async function pickShareTarget(
     entry.extensionName,
     entry.hostDisplayName,
     ...entry.extensionAliases,
-  ].filter((n) => n && n !== "Share");
-  const ordered = [...new Set(["Example Share", "ET Share", ...names])];
+  ].filter(Boolean);
+  const ordered = [...new Set(["Example Action", "ET Action", ...names])];
   let tapped = false;
   for (const name of ordered) {
     try {
@@ -88,55 +88,53 @@ async function pickShareTarget(
   }
   if (!tapped) {
     throw new Error(
-      `android share chooser missing target; tried=${ordered.join(",")}`,
+      `android action chooser missing target; tried=${ordered.join(",")}`,
     );
   }
   await confirmChooserIfNeeded(device);
   await sleep(1_000);
 }
 
+/** Flat AX text for Process|Save|Action chrome (no dumpsys). */
 async function treeFlat(device: DeviceSession): Promise<string> {
   return (await device.accessibilityTree())
     .map((n) => nodeVisibleText(n) || String(n.label ?? n.value ?? ""))
     .join("\n");
 }
 
-async function assertShareActivityUi(device: DeviceSession): Promise<void> {
-  const flat = await treeFlat(device);
-  if (!/Open main app/i.test(flat)) {
-    throw new Error(
-      `expected Share Activity (Open main app); got=${flat.slice(0, 400)}`,
-    );
-  }
-  if (!/Save/i.test(flat)) {
-    throw new Error(`expected Save on Share Activity; got=${flat.slice(0, 400)}`);
-  }
-}
-
-async function waitForShareChrome(
+async function waitForActionChrome(
   device: DeviceSession,
-  timeoutMs = 8_000,
-): Promise<void> {
+  timeoutMs = 4_000,
+): Promise<"visible" | "auto-dismissed"> {
   const deadline = Date.now() + timeoutMs;
-  let last = "";
   while (Date.now() < deadline) {
-    last = await treeFlat(device);
-    if (/Open main app/i.test(last) && /Save/i.test(last)) {
-      return;
+    const flat = await treeFlat(device);
+    if (/Process|Save|kind:image|Images:/i.test(flat)) {
+      return "visible";
     }
-    await sleep(250);
+    // Host ready again = ActionActivity already closed (auto-Process).
+    if (/status-target-ready|btn-open-share-sheet|btn-clear-payload/i.test(flat)) {
+      return "auto-dismissed";
+    }
+    await sleep(200);
   }
-  throw new Error(
-    `Share Activity chrome not visible; got=${last.slice(0, 400)}`,
-  );
+  return "auto-dismissed";
 }
 
-async function waitForHostMain(
+async function completeAction(
   device: DeviceSession,
   entry: TargetCatalogEntry,
-  timeoutMs = 12_000,
 ): Promise<void> {
-  await waitForId(device, hostReadyTestId(entry.testIds), timeoutMs);
+  const label = entry.completeButton || "Process";
+  try {
+    await tapLabeledButton(device, label, 3_000);
+  } catch {
+    try {
+      await tapLabeledButton(device, "Save", 1_500);
+    } catch {
+      await sleep(500);
+    }
+  }
 }
 
 async function refreshHostPayload(
@@ -144,7 +142,7 @@ async function refreshHostPayload(
   entry: TargetCatalogEntry,
 ): Promise<void> {
   await device.launchApp(entry.hostBundleId, { terminateRunning: false });
-  await waitForHostMain(device, entry);
+  await waitForId(device, hostReadyTestId(entry.testIds), 12_000);
   if (entry.testIds.refresh) {
     try {
       await tapId(device, entry.testIds.refresh, 3_000);
@@ -166,16 +164,15 @@ async function openHostShareSheet(
 }
 
 /**
- * Android dual of share C1 — host Share sheet required; Devicewright session only.
- * No raw adb: HOME/BACK/terminate/openShareText are DW 0.1.15+ session APIs.
- * (EXTRA_STREAM image cold-start has no DW peer yet — not required for green.)
+ * Android dual of action C1 — host Share sheet required; Devicewright session only.
+ * ActionExtension auto-Processes ~350ms; green is host marker `grayscale`.
  */
-export async function runAndroidShareJourney(
+export async function runAndroidActionJourney(
   device: DeviceSession,
   id: keyof typeof TARGET_CATALOG,
 ): Promise<TargetJourneyResult> {
   const entry = TARGET_CATALOG[id];
-  if (!entry || !ANDROID_SHARE_IDS.has(String(id))) {
+  if (!entry || !ANDROID_ACTION_IDS.has(String(id))) {
     return {
       id: String(id),
       path: entry?.path ?? String(id),
@@ -183,7 +180,7 @@ export async function runAndroidShareJourney(
       ok: false,
       status: "stub",
       steps: ["android-unsupported"],
-      error: `android share journey not wired for ${String(id)}`,
+      error: `android action journey not wired for ${String(id)}`,
       failureKind: "stub",
     };
   }
@@ -195,7 +192,7 @@ export async function runAndroidShareJourney(
     steps.push("android-launch-host");
     await device.launchApp(entry.hostBundleId, { terminateRunning: true });
     await dismissSystemAlerts(device);
-    await waitForHostMain(device, entry, 15_000);
+    await waitForId(device, hostReadyTestId(entry.testIds), 15_000);
     steps.push("host-ready");
 
     try {
@@ -205,22 +202,24 @@ export async function runAndroidShareJourney(
       steps.push("clear-payload-skip");
     }
 
-    // --- Authoritative: host Share sheet → chooser → Save → host marker ---
     steps.push("host-sheet-primary");
     await openHostShareSheet(device, entry);
     checklist.push(C1.triggerFromHost);
-    await pickShareTarget(device, entry);
+    await pickActionTarget(device, entry);
     checklist.push(C1.findExtensionRow);
-    await waitForShareChrome(device);
-    await assertShareActivityUi(device);
-    steps.push("share-chrome-ok");
 
-    await tapLabeledButton(device, "Save", 8_000);
+    const chrome = await waitForActionChrome(device);
+    if (chrome === "visible") {
+      steps.push("action-chrome-ok");
+      await completeAction(device, entry);
+    } else {
+      steps.push("action-auto-dismissed");
+    }
     checklist.push(C1.completeAppex);
-    await sleep(800);
-    // Host may already be under the sheet — relaunch/refresh for payload.
+    await sleep(600);
+
     await refreshHostPayload(device, entry);
-    steps.push("assert-text-payload");
+    steps.push("assert-action-marker");
     await assertPayloadContains(
       device,
       entry.testIds.lastPayload,
@@ -230,32 +229,31 @@ export async function runAndroidShareJourney(
     checklist.push(C1.assertHostMarker);
     steps.push("host-sheet-ok");
 
-    // --- Open main app (DW session only) ---
-    steps.push("open-main-app");
-    await openHostShareSheet(device, entry);
-    await pickShareTarget(device, entry);
-    await waitForShareChrome(device);
-    await tapLabeledButton(device, "Open main app", 8_000);
-    await sleep(1_200);
-    await waitForHostMain(device, entry);
-    steps.push("open-main-ok");
-
     // Soft smoke: DW openShareText. OEM choosers often omit our target — never fail green.
     steps.push("system-share-text-smoke");
+    try {
+      await tapId(device, entry.testIds.clearPayload, 3_000);
+    } catch {
+      // optional
+    }
     await device.terminateApp(entry.hostBundleId);
     await device.pressButton({ button: "HOME" });
     await sleep(400);
-    await device.openShareText(entry.payloadMarker);
+    await device.openShareText("expo-targets action process-text sample");
     await sleep(800);
     try {
-      await pickShareTarget(device, entry);
-      await waitForShareChrome(device, 6_000);
-      try {
-        await tapLabeledButton(device, "Cancel", 5_000);
-      } catch {
-        await device.pressButton({ button: "BACK" });
+      await pickActionTarget(device, entry);
+      const smokeChrome = await waitForActionChrome(device, 3_000);
+      if (smokeChrome === "visible") {
+        try {
+          await tapLabeledButton(device, "Cancel", 2_000);
+        } catch {
+          await device.pressButton({ button: "BACK" });
+        }
+        steps.push("system-share-text-ok");
+      } else {
+        steps.push("system-share-text-auto-dismiss");
       }
-      steps.push("system-share-text-ok");
     } catch {
       await device.pressButton({ button: "BACK" }).catch(() => undefined);
       steps.push("system-share-text-chooser-skip");

--- a/examples/.devicewright/journeys/file-provider.android.ts
+++ b/examples/.devicewright/journeys/file-provider.android.ts
@@ -1,0 +1,229 @@
+/**
+ * Android dual of file-provider — DocumentsUI must list the provider root.
+ * DeviceSession only (launchApp / openUrl / pressButton / AX). No raw adb.
+ */
+import type { DeviceSession } from "@csark0812/devicewright";
+import { hostLaunchId, TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
+  flattenLabels,
+  hostReadyTestId,
+  sleep,
+  tapCenter,
+  tapId,
+  tapProbeHit,
+  waitForId,
+  waitForNamed,
+} from "./helpers";
+
+const DOCUMENTS_UI = "com.google.android.documentsui";
+const ROOT_MARKERS = ["Expo Targets", "ET FileProv"] as const;
+const SEED_MARKERS = ["et-fp-seed.txt", "et-fp-seed"] as const;
+
+function labelsHit(labels: string[], needles: readonly string[]): boolean {
+  const lower = labels.map((l) => l.toLowerCase());
+  return needles.some((n) =>
+    lower.some((l) => l === n.toLowerCase() || l.includes(n.toLowerCase())),
+  );
+}
+
+async function waitForRootListed(
+  device: DeviceSession,
+  timeoutMs = 12_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (labelsHit(flattenLabels(await device.accessibilityTree()), ROOT_MARKERS)) {
+      return true;
+    }
+    await sleep(400);
+  }
+  return false;
+}
+
+async function tryOpenRoot(device: DeviceSession): Promise<boolean> {
+  try {
+    const node = await waitForNamed(device, [...ROOT_MARKERS], 3_000);
+    await tapCenter(device, node);
+    await sleep(1_000);
+    return true;
+  } catch {
+    try {
+      const hit = await findNamedViaPointProbe(device, [...ROOT_MARKERS], {
+        timeoutMs: 4_000,
+        match: "includes",
+        yStartRatio: 0.1,
+        yEndRatio: 0.95,
+      });
+      await tapProbeHit(device, hit);
+      await sleep(1_000);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function seedVisible(device: DeviceSession): Promise<boolean> {
+  return labelsHit(
+    flattenLabels(await device.accessibilityTree()),
+    SEED_MARKERS,
+  );
+}
+
+async function tapNamed(
+  device: DeviceSession,
+  names: string[],
+  timeoutMs = 3_000,
+): Promise<boolean> {
+  try {
+    const node = await waitForNamed(device, names, timeoutMs);
+    await tapCenter(device, node);
+    await sleep(700);
+    return true;
+  } catch {
+    try {
+      const hit = await findNamedViaPointProbe(device, names, {
+        timeoutMs: Math.min(timeoutMs, 3_000),
+        match: "includes",
+        yStartRatio: 0.0,
+        yEndRatio: 0.35,
+      });
+      await tapProbeHit(device, hit);
+      await sleep(700);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function openDocumentsSurface(
+  device: DeviceSession,
+  steps: string[],
+): Promise<void> {
+  // DocumentsUI + Show roots drawer lists registered DocumentsProvider roots.
+  // (DW has no OPEN_DOCUMENT intent peer yet — launchApp is enough.)
+  await device.launchApp(DOCUMENTS_UI, { terminateRunning: true });
+  steps.push("launch-documentsui");
+  await sleep(1_400);
+  await dismissSystemAlerts(device);
+
+  if (await tapNamed(device, ["Show roots"], 4_000)) {
+    steps.push("documents-show-roots");
+  } else {
+    steps.push("documents-show-roots-miss");
+  }
+}
+
+export async function runAndroidFileProviderJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG["file-provider"];
+  const pathStr = entry?.path ?? "examples/file-provider";
+  const steps: string[] = [];
+
+  try {
+    if (!entry) throw new Error("file-provider: missing catalog entry");
+    const pkg = hostLaunchId(entry, "android");
+
+    steps.push("android-launch-host");
+    await device.launchApp(pkg, { terminateRunning: true });
+    await dismissSystemAlerts(device);
+    await waitForId(device, hostReadyTestId(entry.testIds), 15_000);
+    steps.push("host-ready");
+
+    try {
+      await tapId(device, entry.testIds.clearPayload, 3_000);
+      steps.push("clear-payload");
+    } catch {
+      steps.push("clear-payload-skip");
+    }
+
+    await tapId(device, "btn-seed-android-docs", 5_000);
+    steps.push("seed-android-docs");
+    await assertPayloadContains(
+      device,
+      entry.testIds.lastPayload,
+      "android-docs",
+      8_000,
+    );
+    steps.push("host-marker-ok");
+
+    steps.push("documents-surface");
+    await openDocumentsSurface(device, steps);
+
+    let listed = await waitForRootListed(device, 10_000);
+    if (!listed) {
+      await tapNamed(device, ["Show roots"], 3_000);
+      listed = await waitForRootListed(device, 8_000);
+    }
+    if (!listed) {
+      const labels = flattenLabels(await device.accessibilityTree());
+      throw new Error(
+        `DocumentsUI missing Expo Targets root; labels=${labels.slice(0, 80).join(", ")}`,
+      );
+    }
+    steps.push("documents-root-listed");
+
+    const opened = await tryOpenRoot(device);
+    steps.push(opened ? "documents-root-opened" : "documents-root-open-miss");
+    let sawSeed = false;
+    if (opened) {
+      sawSeed = await seedVisible(device);
+      steps.push(sawSeed ? "documents-seed-visible" : "documents-seed-miss");
+    }
+
+    await device.pressButton({ button: "HOME" });
+    await sleep(400);
+    await device.launchApp(pkg, { terminateRunning: false });
+    await waitForId(device, hostReadyTestId(entry.testIds), 12_000);
+    if (entry.testIds.refresh) {
+      try {
+        await tapId(device, entry.testIds.refresh, 3_000);
+      } catch {
+        // optional
+      }
+    }
+    await assertPayloadContains(
+      device,
+      entry.testIds.lastPayload,
+      "android-docs",
+      8_000,
+    );
+    steps.push("host-marker-reassert");
+
+    return {
+      id: "file-provider",
+      path: pathStr,
+      phase: 5,
+      ok: true,
+      status: "green",
+      steps: [
+        ...steps,
+        sawSeed ? "fp-android-deepen-ok" : "fp-android-root-list-ok",
+      ],
+    };
+  } catch (e) {
+    const msg = String(e);
+    const failureKind =
+      /not installed|Launch failed|device offline|no devices|openUrl|pressButton/i.test(
+        msg,
+      )
+        ? "operator"
+        : "product";
+    return {
+      id: "file-provider",
+      path: pathStr,
+      phase: 5,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/journeys/file-provider.ts
+++ b/examples/.devicewright/journeys/file-provider.ts
@@ -20,6 +20,7 @@ import {
   waitForNamed,
 } from "./helpers";
 import { tapLabelInTree } from "./settings-nav";
+import { runAndroidFileProviderJourney } from "./file-provider.android";
 
 const FILES_BUNDLE = "com.apple.DocumentsApp";
 const DOMAIN_MARKERS = ["ET FileProv", "FileProv"];
@@ -198,6 +199,9 @@ async function openDomainAndAssertSeed(
 export async function runFileProviderJourney(
   device: DeviceSession,
 ): Promise<TargetJourneyResult> {
+  if (device.platform === "android") {
+    return runAndroidFileProviderJourney(device);
+  }
   const entry = TARGET_CATALOG["file-provider"];
   const pathStr = entry?.path ?? "examples/file-provider";
   const steps: string[] = [];

--- a/examples/.devicewright/journeys/keyboard.android.ts
+++ b/examples/.devicewright/journeys/keyboard.android.ts
@@ -1,0 +1,202 @@
+/**
+ * Android dual of keyboard — Language & input must list ET Keyboard IME.
+ * Enabling + typing "ET" is preferred deepen; Settings enable toggles may leftover.
+ * DeviceSession only.
+ */
+import type { DeviceSession } from "@csark0812/devicewright";
+import { hostLaunchId, TARGET_CATALOG } from "../catalog";
+import type { TargetJourneyResult } from "../types";
+import {
+  assertPayloadContains,
+  dismissSystemAlerts,
+  findNamedViaPointProbe,
+  flattenLabels,
+  hostReadyTestId,
+  sleep,
+  tapCenter,
+  tapId,
+  tapProbeHit,
+  waitForId,
+  waitForNamed,
+} from "./helpers";
+
+const ET_IME_MARKERS = ["ET Keyboard", "ET Keyboard Target"] as const;
+
+function labelsHit(labels: string[], needles: readonly string[]): boolean {
+  const lower = labels.map((l) => l.toLowerCase());
+  return needles.some((n) =>
+    lower.some((l) => l === n.toLowerCase() || l.includes(n.toLowerCase())),
+  );
+}
+
+async function tapNamed(
+  device: DeviceSession,
+  names: string[],
+  timeoutMs = 4_000,
+): Promise<boolean> {
+  try {
+    await tapCenter(device, await waitForNamed(device, names, timeoutMs));
+    await sleep(700);
+    return true;
+  } catch {
+    try {
+      const hit = await findNamedViaPointProbe(device, names, {
+        timeoutMs: Math.min(timeoutMs, 3_500),
+        match: "includes",
+        yStartRatio: 0.05,
+        yEndRatio: 0.95,
+      });
+      await tapProbeHit(device, hit);
+      await sleep(700);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function waitForImeListed(
+  device: DeviceSession,
+  timeoutMs = 12_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const labels = flattenLabels(await device.accessibilityTree());
+    // Prefer ET-prefixed markers; bare "Keyboard" is too noisy alone.
+    if (
+      labelsHit(labels, ET_IME_MARKERS) ||
+      labels.some((l) => /et keyboard/i.test(l))
+    ) {
+      return true;
+    }
+    await sleep(400);
+  }
+  return false;
+}
+
+export async function runAndroidKeyboardJourney(
+  device: DeviceSession,
+): Promise<TargetJourneyResult> {
+  const entry = TARGET_CATALOG.keyboard;
+  const pathStr = entry?.path ?? "examples/keyboard";
+  const steps: string[] = [];
+
+  try {
+    if (!entry) throw new Error("keyboard: missing catalog entry");
+    const pkg = hostLaunchId(entry, "android");
+
+    steps.push("android-launch-host");
+    await device.launchApp(pkg, { terminateRunning: true });
+    await dismissSystemAlerts(device);
+    await waitForId(device, hostReadyTestId(entry.testIds), 15_000);
+    steps.push("host-ready");
+
+    await tapId(device, "btn-open-ime-settings", 8_000);
+    steps.push("open-ime-settings");
+    await sleep(1_200);
+    await dismissSystemAlerts(device);
+
+    // Drill into Managed keyboards / Virtual keyboard if present.
+    for (const label of [
+      "On-screen keyboard",
+      "Virtual keyboard",
+      "Manage on-screen keyboards",
+      "Managed keyboards",
+      "Keyboards",
+    ]) {
+      if (await tapNamed(device, [label], 2_500)) {
+        steps.push(`settings-drill:${label}`);
+      }
+    }
+
+    let listed = await waitForImeListed(device, 10_000);
+    if (!listed) {
+      // Scroll settings list.
+      for (let i = 0; i < 4 && !listed; i++) {
+        await device.swipe({
+          xStart: 540,
+          yStart: 1600,
+          xEnd: 540,
+          yEnd: 600,
+          duration: 0.35,
+        });
+        await sleep(500);
+        listed = await waitForImeListed(device, 3_000);
+      }
+    }
+
+    if (!listed) {
+      const labels = flattenLabels(await device.accessibilityTree());
+      throw new Error(
+        `IME settings missing ET Keyboard; labels=${labels.slice(0, 80).join(", ")}`,
+      );
+    }
+    steps.push("ime-listed");
+
+    // Best-effort enable + type ET (Settings leftover if toggles opaque).
+    let typed = false;
+    if (await tapNamed(device, ["ET Keyboard", "ET Keyboard Target"], 3_000)) {
+      steps.push("ime-row-opened");
+      for (const en of ["Use ET Keyboard", "Enable", "OK", "Allow"]) {
+        if (await tapNamed(device, [en], 1_500)) {
+          steps.push(`ime-enable:${en}`);
+        }
+      }
+    }
+
+    await device.pressButton({ button: "HOME" });
+    await sleep(400);
+    await device.launchApp(pkg, { terminateRunning: false });
+    await waitForId(device, hostReadyTestId(entry.testIds), 12_000);
+    try {
+      await tapId(device, "input-type-field", 5_000);
+      await sleep(600);
+      // If our IME is active, tap ET key via AX; else soft-skip typing deepen.
+      if (await tapNamed(device, ["ET"], 3_000)) {
+        steps.push("ime-et-key");
+        await assertPayloadContains(
+          device,
+          entry.testIds.lastPayload,
+          "typed:ET",
+          6_000,
+        );
+        typed = true;
+        steps.push("typed-et-ok");
+      } else {
+        steps.push("ime-et-key-miss");
+      }
+    } catch {
+      steps.push("type-deepen-skip");
+    }
+
+    return {
+      id: "keyboard",
+      path: pathStr,
+      phase: 5,
+      ok: true,
+      status: "green",
+      steps: [
+        ...steps,
+        typed ? "keyboard-android-deepen-ok" : "keyboard-android-ime-list-ok",
+      ],
+    };
+  } catch (e) {
+    const msg = String(e);
+    const failureKind =
+      /not installed|Launch failed|device offline|no devices|pressButton/i.test(
+        msg,
+      )
+        ? "operator"
+        : "product";
+    return {
+      id: "keyboard",
+      path: pathStr,
+      phase: 5,
+      ok: false,
+      status: failureKind === "operator" ? "operator" : "red",
+      steps,
+      error: msg,
+      failureKind,
+    };
+  }
+}

--- a/examples/.devicewright/journeys/keyboard.ts
+++ b/examples/.devicewright/journeys/keyboard.ts
@@ -26,6 +26,7 @@ import {
   tapProbeHit,
   waitForNamed,
 } from "./helpers";
+import { runAndroidKeyboardJourney } from "./keyboard.android";
 import {
   navigatePath,
   scrollUntilVisible,
@@ -390,6 +391,9 @@ async function ensureFullAccessOn(
 export async function runKeyboardJourney(
   device: DeviceSession,
 ): Promise<TargetJourneyResult> {
+  if (device.platform === "android") {
+    return runAndroidKeyboardJourney(device);
+  }
   const entry = TARGET_CATALOG.keyboard;
   const path = entry?.path ?? "examples/keyboard";
   const steps: string[] = [];

--- a/examples/.devicewright/journeys/share.ts
+++ b/examples/.devicewright/journeys/share.ts
@@ -18,6 +18,7 @@ import {
   waitForId,
 } from "./helpers";
 import { runAndroidShareJourney } from "./share.android";
+import { runAndroidActionJourney } from "./action.android";
 
 async function dismissShareSheet(device: DeviceSession): Promise<void> {
   for (const label of ["Close", "Cancel"]) {
@@ -220,6 +221,9 @@ export async function runShareActionJourney(
   id: keyof typeof TARGET_CATALOG,
 ): Promise<TargetJourneyResult> {
   if (device.platform === "android") {
+    if (id === "action") {
+      return runAndroidActionJourney(device, id);
+    }
     return runAndroidShareJourney(device, id);
   }
 

--- a/examples/.devicewright/touchpoints.ts
+++ b/examples/.devicewright/touchpoints.ts
@@ -216,7 +216,7 @@ export const TOUCHPOINTS: readonly TouchpointDef[] = [
     id: "file-provider",
     tranche: "T6",
     touchpoint:
-      "Replicated File Provider + Files Browse ET FileProv; open→App Group fp:* (seed file AX leftover)",
+      "iOS: Files Browse ET FileProv + App Group fp:*; Android: DocumentsUI lists Expo Targets root + host android-docs marker",
     status: "concrete",
   },
   {

--- a/examples/call-directory/app.json
+++ b/examples/call-directory/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.call-directory"
+      "package": "com.expotargets.example.calldirectory"
     }
   }
 }

--- a/examples/call-directory/targets/call-directory/android/com/expotargets/example/calldirectory/target/calldirectory/CallDirectoryCallScreeningService.kt
+++ b/examples/call-directory/targets/call-directory/android/com/expotargets/example/calldirectory/target/calldirectory/CallDirectoryCallScreeningService.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.call-directory.target.calldirectory
+package com.expotargets.example.calldirectory.target.calldirectory
 
 import expo.modules.targets.system.ExpoTargetsCallScreeningService
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.call-directory.target.calldirectory.CallDirectoryCallScreeningService
+ * com.expotargets.example.calldirectory.target.calldirectory.CallDirectoryCallScreeningService
  */
 class CallDirectoryCallScreeningService : ExpoTargetsCallScreeningService()

--- a/examples/credentials-provider/app.json
+++ b/examples/credentials-provider/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.credentials-provider"
+      "package": "com.expotargets.example.credentialsprovider"
     }
   }
 }

--- a/examples/credentials-provider/targets/credentials-provider/android/com/expotargets/example/credentialsprovider/target/credentialsprovider/CredentialsProviderAutofillService.kt
+++ b/examples/credentials-provider/targets/credentials-provider/android/com/expotargets/example/credentialsprovider/target/credentialsprovider/CredentialsProviderAutofillService.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.credentials-provider.target.credentialsprovider
+package com.expotargets.example.credentialsprovider.target.credentialsprovider
 
 import expo.modules.targets.system.ExpoTargetsAutofillService
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.credentials-provider.target.credentialsprovider.CredentialsProviderAutofillService
+ * com.expotargets.example.credentialsprovider.target.credentialsprovider.CredentialsProviderAutofillService
  */
 class CredentialsProviderAutofillService : ExpoTargetsAutofillService()

--- a/examples/file-provider-ui/app.json
+++ b/examples/file-provider-ui/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.file-provider-ui"
+      "package": "com.expotargets.example.fileproviderui"
     }
   }
 }

--- a/examples/file-provider-ui/targets/file-provider-ui/android/com/expotargets/example/fileproviderui/target/fileproviderui/FileProviderUiFileProviderUiActivity.kt
+++ b/examples/file-provider-ui/targets/file-provider-ui/android/com/expotargets/example/fileproviderui/target/fileproviderui/FileProviderUiFileProviderUiActivity.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.file-provider-ui.target.fileproviderui
+package com.expotargets.example.fileproviderui.target.fileproviderui
 
 import expo.modules.targets.system.ExpoTargetsFileProviderUiActivity
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.file-provider-ui.target.fileproviderui.FileProviderUiFileProviderUiActivity
+ * com.expotargets.example.fileproviderui.target.fileproviderui.FileProviderUiFileProviderUiActivity
  */
 class FileProviderUiFileProviderUiActivity : ExpoTargetsFileProviderUiActivity()

--- a/examples/file-provider/App.tsx
+++ b/examples/file-provider/App.tsx
@@ -12,7 +12,7 @@ import {
 
 const APP_GROUP = 'group.com.expotargets.example.file-provider';
 const AUTHORITY =
-  'com.expotargets.example.file-provider.expo_targets.documents.fileprovider';
+  'com.expotargets.example.fileprovider.expo_targets.documents.fileprovider';
 const storage = new AppGroupStorage(APP_GROUP);
 
 function readPayload(): string {

--- a/examples/file-provider/app.json
+++ b/examples/file-provider/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.file-provider"
+      "package": "com.expotargets.example.fileprovider"
     }
   }
 }

--- a/examples/file-provider/targets/file-provider/android/com/expotargets/example/fileprovider/target/fileprovider/FileProviderDocumentsProvider.kt
+++ b/examples/file-provider/targets/file-provider/android/com/expotargets/example/fileprovider/target/fileprovider/FileProviderDocumentsProvider.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.file-provider.target.fileprovider
+package com.expotargets.example.fileprovider.target.fileprovider
 
 import expo.modules.targets.system.ExpoTargetsDocumentsProvider
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.file-provider.target.fileprovider.FileProviderDocumentsProvider
+ * com.expotargets.example.fileprovider.target.fileprovider.FileProviderDocumentsProvider
  */
 class FileProviderDocumentsProvider : ExpoTargetsDocumentsProvider()

--- a/examples/file-provider/targets/file-provider/expo-target.config.json
+++ b/examples/file-provider/targets/file-provider/expo-target.config.json
@@ -19,6 +19,6 @@
     }
   },
   "android": {
-    "authority": "com.expotargets.example.file-provider.expo_targets.documents.fileprovider"
+    "authority": "com.expotargets.example.fileprovider.expo_targets.documents.fileprovider"
   }
 }

--- a/examples/network-packet-tunnel/app.json
+++ b/examples/network-packet-tunnel/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.network-packet-tunnel"
+      "package": "com.expotargets.example.networkpackettunnel"
     }
   }
 }

--- a/examples/network-packet-tunnel/targets/network-packet-tunnel/android/com/expotargets/example/networkpackettunnel/target/networkpackettunnel/NetworkPacketTunnelVpnService.kt
+++ b/examples/network-packet-tunnel/targets/network-packet-tunnel/android/com/expotargets/example/networkpackettunnel/target/networkpackettunnel/NetworkPacketTunnelVpnService.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.network-packet-tunnel.target.networkpackettunnel
+package com.expotargets.example.networkpackettunnel.target.networkpackettunnel
 
 import expo.modules.targets.system.ExpoTargetsVpnService
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.network-packet-tunnel.target.networkpackettunnel.NetworkPacketTunnelVpnService
+ * com.expotargets.example.networkpackettunnel.target.networkpackettunnel.NetworkPacketTunnelVpnService
  */
 class NetworkPacketTunnelVpnService : ExpoTargetsVpnService()

--- a/examples/print-service/app.json
+++ b/examples/print-service/app.json
@@ -40,7 +40,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.expotargets.example.print-service"
+      "package": "com.expotargets.example.printservice"
     }
   }
 }

--- a/examples/print-service/targets/print-service/android/com/expotargets/example/printservice/target/printservice/PrintServicePrintService.kt
+++ b/examples/print-service/targets/print-service/android/com/expotargets/example/printservice/target/printservice/PrintServicePrintService.kt
@@ -1,9 +1,9 @@
-package com.expotargets.example.print-service.target.printservice
+package com.expotargets.example.printservice.target.printservice
 
 import expo.modules.targets.system.ExpoTargetsPrintService
 
 /**
  * User deepen — FQCN must match the Android config plugin:
- * com.expotargets.example.print-service.target.printservice.PrintServicePrintService
+ * com.expotargets.example.printservice.target.printservice.PrintServicePrintService
  */
 class PrintServicePrintService : ExpoTargetsPrintService()

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "examples:devicewright:clip": "bun examples/.devicewright/cli.ts matrix --ids=clip",
     "examples:devicewright:widgets": "bun examples/.devicewright/cli.ts matrix --ids=widgets",
     "examples:devicewright:widgets:android": "bun examples/.devicewright/cli.ts matrix --ids=widgets --platform=android --device=emulator-5554 --live-through=3",
-    "examples:devicewright:file-provider:android": "bun examples/.devicewright/cli.ts matrix --ids=file-provider --platform=android --device=emulator-5554 --live-through=5"
+    "examples:devicewright:file-provider:android": "bun examples/.devicewright/cli.ts matrix --ids=file-provider --platform=android --device=emulator-5554 --live-through=5",
+    "examples:devicewright:keyboard:android": "bun examples/.devicewright/cli.ts matrix --ids=keyboard --platform=android --device=emulator-5554 --live-through=5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "examples:devicewright:share": "bun examples/.devicewright/cli.ts matrix --ids=share",
     "examples:devicewright:share:android": "bun examples/.devicewright/cli.ts matrix --ids=share --platform=android --device=emulator-5554 --live-through=1",
     "examples:devicewright:action": "bun examples/.devicewright/cli.ts matrix --ids=action",
+    "examples:devicewright:action:android": "bun examples/.devicewright/cli.ts matrix --ids=action --platform=android --device=emulator-5554 --live-through=1",
     "examples:devicewright:messages": "bun examples/.devicewright/cli.ts matrix --ids=messages",
     "examples:devicewright:stickers": "bun examples/.devicewright/cli.ts matrix --ids=stickers",
     "examples:devicewright:clip": "bun examples/.devicewright/cli.ts matrix --ids=clip",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "examples:devicewright:stickers": "bun examples/.devicewright/cli.ts matrix --ids=stickers",
     "examples:devicewright:clip": "bun examples/.devicewright/cli.ts matrix --ids=clip",
     "examples:devicewright:widgets": "bun examples/.devicewright/cli.ts matrix --ids=widgets",
-    "examples:devicewright:widgets:android": "bun examples/.devicewright/cli.ts matrix --ids=widgets --platform=android --device=emulator-5554 --live-through=3"
+    "examples:devicewright:widgets:android": "bun examples/.devicewright/cli.ts matrix --ids=widgets --platform=android --device=emulator-5554 --live-through=3",
+    "examples:devicewright:file-provider:android": "bun examples/.devicewright/cli.ts matrix --ids=file-provider --platform=android --device=emulator-5554 --live-through=5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/packages/expo-targets/android/src/main/java/expo/modules/targets/system/ExpoTargetsDocumentsProvider.kt
+++ b/packages/expo-targets/android/src/main/java/expo/modules/targets/system/ExpoTargetsDocumentsProvider.kt
@@ -17,12 +17,23 @@ open class ExpoTargetsDocumentsProvider : DocumentsProvider() {
   private val rootId = "expo_targets_root"
   private val docRoot = "root"
 
-  override fun onCreate(): Boolean = true
+  override fun onCreate(): Boolean {
+    ensureSeedFile()
+    return true
+  }
 
   private fun docsDir(): File {
     val dir = File(context!!.filesDir, "expo_targets_docs")
     if (!dir.exists()) dir.mkdirs()
     return dir
+  }
+
+  /** Seed a visible file so DocumentsUI / Files can prove the root is live. */
+  private fun ensureSeedFile() {
+    val seed = File(docsDir(), "et-fp-seed.txt")
+    if (!seed.exists()) {
+      seed.writeText("expo-targets file-provider seed\n")
+    }
   }
 
   override fun queryRoots(projection: Array<out String>?): Cursor {

--- a/scripts/scaffold-examples.ts
+++ b/scripts/scaffold-examples.ts
@@ -662,7 +662,8 @@ function scaffoldHost(
           foregroundImage: "./assets/adaptive-icon.png",
           backgroundColor: "#ffffff",
         },
-        package: bundleId,
+        // Android applicationId cannot contain hyphens (iOS bundle IDs can).
+        package: bundleId.replace(/-/g, ""),
       },
     },
   };


### PR DESCRIPTION
## Summary
- Android `action` host-sheet journey via DeviceSession (no raw adb).
- Fix hyphenated `android.package` on W3 dual examples (prebuild-blocking) + scaffold sanitization.
- Android `file-provider`: DocumentsUI Show roots → **Expo Targets** + host `android-docs`; DocumentsProvider seeds `et-fp-seed.txt`.
- Android `keyboard`: Language & input lists **ET Keyboard** (typing deepen soft / Settings leftover).

## Test plan
- [x] `bun run examples:devicewright:action:android` green on `emulator-5554`
- [x] `bun run examples:devicewright:share:android` green on `emulator-5554`
- [x] `bun run examples:devicewright:file-provider:android` green on `emulator-5554`
- [x] `bun run examples:devicewright:keyboard:android` green on `emulator-5554`
- [ ] CI green