### PR TITLE
docs(readme): clarify RN share/action support on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Showcase subset (common adoption path). **Full type set and maturity (~47 types)
 
 ## How It Works
 
-expo-targets uses **App Groups** to share data between your app and extensions. For RN extensions, Metro plus a native host loads your React tree inside the extension process.
+expo-targets uses **App Groups** to share data between your app and extensions. For RN extensions, Metro plus a native host loads your React tree (iOS `.appex` process; Android dedicated Activity).
 
 ```
 ┌─────────────────┐        ┌─────────────────┐

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Showcase subset (common adoption path). **Full type set and maturity (~47 types)
 
 | Type       | iOS  | Android | Description                          |
 | ---------- | ---- | ------- | ------------------------------------ |
-| `share`    | ✅   | ✅‡     | Share extensions (RN on iOS; Android dedicated Activity) |
-| `action`   | ✅   | ✅‡     | Action extensions (RN on iOS; Android dedicated Activity) |
+| `share`    | ✅   | ✅‡     | Share extensions (RN with `entry` on both; iOS `.appex`, Android dedicated Activity) |
+| `action`   | ✅   | ✅‡     | Action extensions (RN with `entry` on both; iOS `.appex`, Android dedicated Activity) |
 | `clip`     | ✅   | —       | App Clips (RN UI supported)          |
 | `messages` | ✅   | —       | iMessage apps (RN UI supported)      |
 | `stickers` | ✅   | —       | iMessage sticker packs (asset-only)  |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes misleading README copy that implied React Native share/action UI was iOS-only. Both platforms use RN when `entry` is set; Android hosts it in a dedicated Activity instead of an `.appex`.

## Changes

- Update showcase table descriptions for `share` and `action`
- Clarify "How It Works" RN host sentence to mention both iOS and Android containers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdde-f364-75fd-af77-520c2076152e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdde-f364-75fd-af77-520c2076152e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

