### PR TITLE
feat(widgets): colocate iOS kinds and Android providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- One `widget` target can list many iOS WidgetKit picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`.
+- Live Activity attributes live on an `ios.kinds` `{ "type": "live-activity" }` row (at most one). Top-level `liveActivity` config is removed.
+
 ## [1.0.3] - 2026-08-10
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -460,7 +460,7 @@ await ContentBlocker.reload({ targetName: "MyBlocker" });
 
 ## LiveActivity
 
-Start, update, or end Live Activities. `attributesName` must match `liveActivity.attributesName` on a widget target. Unknown names throw with the configured list. Prefer `LiveActivity.create(name)`. This is a widgets-like factory. Also exported as `createLiveActivity(name)`.
+Start, update, or end Live Activities. `attributesName` must match a `{ "type": "live-activity" }` row in `ios.kinds`. Unknown names throw with the configured list. Prefer `LiveActivity.create(name)`. This is a widgets-like factory. Also exported as `createLiveActivity(name)`.
 
 - **iOS:** ActivityKit (16.2+). Attributes and the host bridge are CNG into `ios/*/ExpoTargetsGenerated/` (gitignored). Activity UI stays under `targets/<widget>/ios/`.
 - **Android:** Ongoing `NotificationCompat` helper with the same JS surface. No Dynamic Island, StandBy, or ActivityKit push-to-start.
@@ -610,7 +610,7 @@ npx expo-targets add --no-wire   # scaffold only
 2. **Name:** Target name in kebab-case (e.g., `my-widget`)
 3. **Platforms:** iOS (Android widgets bridge-grade)
 4. **Use React Native?** (share/action/clip/messages/notification-content/safari when applicable)
-5. **Live Activity?** (widget only) — Emits `liveActivity` config + one-shot UI bootstrap
+5. **Live Activity?** (widget only) — Emits an `ios.kinds` live-activity row + one-shot UI bootstrap
 
 Wires the host by default (plugin, App Groups, Metro). Dynamic `app.config.ts` or `app.config.js` gets a snippet warning instead of a hard fail. Finish with `npx expo-targets doctor`. After scaffold, `generate` writes `.expo/types/expo-targets.d.ts`.
 
@@ -776,7 +776,7 @@ interface NonExtensionTarget extends BaseTarget {
 | -------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `Target "X" not found`     | Target name doesn't match config   | Check `createTarget('X')` matches `"name"` in config exactly |
 | `App Group not configured` | Missing `appGroup` in config       | Add `appGroup` to `expo-target.config.json` or `app.json`    |
-| `Unknown Live Activity attributesName` | Name not in widget `liveActivity` | Use a configured `attributesName` / `LiveActivity.create` |
+| `Unknown Live Activity attributesName` | Name not in `ios.kinds` live-activity row | Use a configured `attributesName` / `LiveActivity.create` |
 | `fileProviderDomain` missing | FP target lacks domain config      | Add `ios.fileProviderDomain` to the file-provider config     |
 | `No targets config found`  | Running in wrong context           | Run from the app or extension, not a unit test               |
 | `close is not a function`  | Calling `close()` on non-extension | Only share/action/clip targets have `close()`                |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 **Source of truth for** `expo-target.config` options and extension types.
 
-<!-- doc-meta: owner=eng | last-reviewed=2026-08-10 -->
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-14 -->
 
 > **Orphan-stub freeze:** do not add new `ExtensionType` values without registry, scaffold, example, and Devicewright row. See [deprecations.md](./deprecations.md). Widgets policy: [widgets.md](./widgets.md).
 
@@ -64,7 +64,6 @@ targets/my-widget/
 | ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `displayName`      | `name`      | Human-readable name (`CFBundleDisplayName` or `CFBundleName` on iOS; widget picker label)                                                                          |
 | `appGroup`         | _inherited_ | App Group ID. When omitted, inherits from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
-| `liveActivity`     | —           | Widget-only ActivityKit schema (`attributesName`, `static`, `contentState`). CNG into `ExpoTargetsGenerated/` (see [widgets.md](./widgets.md))                  |
 | `entry`            | —           | React Native entry point for share, action, clip, and messages (see [Entry Field](#entry-field) below)                                                                  |
 | `excludedPackages` | auto for RN `entry` | Extra packages to omit from the nested `ExpoModulesProvider` (`post_integrate`). `expo-updates` and `expo-dev-client` are always merged for RN-native `entry` targets. List only extras (for example reanimated) |
 
@@ -342,7 +341,21 @@ Android widgets are supported with **Glance** (Jetpack Compose) or **RemoteViews
 | `description`        | —                        | Widget description in picker                                        |
 | `targetCellWidth`    | —                        | Target cell width (Material You widgets)                            |
 | `targetCellHeight`   | —                        | Target cell height (Material You widgets)                           |
+| `initialLayout`      | `widget_<name>`          | RemoteViews layout resource (no `@layout/` prefix)                  |
+| `providers`          | —                        | Opt-in list of AppWidgetProvider rows. Empty or omitted = 1:1 path  |
 | `colors`             | `{}`                     | Named colors for Android resources                                  |
+
+When `android.providers` is omitted or empty, the plugin registers one receiver from the scalar fields. The RemoteViews class name stays `{package}.widget.{sanitizedName}.{Pascal}Provider`. The Glance class name stays `{package}.widget.{sanitizedName}.{Pascal}WidgetReceiver`.
+
+When `android.providers` has one or more rows, each row is a widget picker entry with its own FQCN and `widgetprovider_<name>.xml`. This is the Android dual of iOS `supportedFamilies` / WidgetBundle. Each row can set `name`, `displayName`, `className`, `initialLayout`, cell size, preview, and description. Omitted layout fields inherit from the scalar `android.*` object.
+
+Set `className` to a full FQCN when an existing app already bound placed widgets to that class. A simple class name resolves under `{package}.widget.{sanitizedTarget}`. Do not change a shipped FQCN.
+
+The plugin writes each `widgetprovider_*.xml` from the row fields. If the file already exists, the plugin updates those fields and keeps extra attributes that you added.
+
+RemoteViews can use `providers` today. Glance can register more than one receiver the same way. You do not need to rewrite a RemoteViews target as Glance.
+
+See `examples/widgets/targets/hello-remoteviews-bundle` (two layouts, not one layout at two sizes). Hello RemoteViews stays the 1:1 scalar path.
 
 ### Widget Types
 
@@ -500,13 +513,17 @@ widget.setData(
   "displayName": "Weather",
   "platforms": ["ios"],
   "appGroup": "group.com.yourapp",
-  "liveActivity": {
-    "attributesName": "WeatherAttributes",
-    "static": { "location": "string" },
-    "contentState": { "temp": "double", "summary": "string" }
-  },
   "ios": {
     "deploymentTarget": "14.0",
+    "kinds": [
+      { "name": "WeatherWidget", "displayName": "Weather" },
+      {
+        "type": "live-activity",
+        "attributesName": "WeatherAttributes",
+        "static": { "location": "string" },
+        "contentState": { "temp": "double", "summary": "string" }
+      }
+    ],
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" }
     }
@@ -514,7 +531,7 @@ widget.setData(
 }
 ```
 
-`liveActivity` drives sealed CNG (`ActivityAttributes` and host bridge) under `ios/<App>/ExpoTargetsGenerated/`. It also drives ambient TypeScript payload types in `.expo/types/expo-targets.d.ts` (`static` and `contentState` map to `LiveActivity.create().start`). Keep `ActivityConfiguration` UI in `targets/<widget>/ios/`. Host JS: `LiveActivity.create('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
+`ios.kinds` lists WidgetKit picker products (`name` matches `createTarget`). `supportedFamilies` on a kind is sizes of that one picker row, not extra products. A `{ "type": "live-activity" }` row holds `attributesName` / `static` / `contentState` / `pushType` (at most one). That row drives sealed CNG for native widgets and `WidgetLiveActivity()` on expo-ui Bundles. Ambient TypeScript payload types still land in `.expo/types/expo-targets.d.ts`. Host JS: `LiveActivity.create('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
 
 ### File Provider domain (iOS)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,7 +134,7 @@ module.exports = withTargets(getDefaultConfig(__dirname));
 
 ### Typed target names + Live Activity payloads
 
-After prebuild (or `npx expo-targets generate`), ambient types are written to `.expo/types/expo-targets.d.ts` (gitignored, same layout as Expo Router typed routes). That narrows `createTarget('…')` / `LiveActivity.create('…')` string literals — **no import from `.expo/`**. When `liveActivity.static` / `contentState` are set, `start` / `update` pick up those field types via module augmentation.
+After prebuild (or `npx expo-targets generate`), ambient types are written to `.expo/types/expo-targets.d.ts` (gitignored, same layout as Expo Router typed routes). That narrows `createTarget('…')` / `LiveActivity.create('…')` string literals — **no import from `.expo/`**. When a live-activity kind sets `static` / `contentState`, `start` / `update` pick up those field types via module augmentation.
 
 ```typescript
 import { createTarget, LiveActivity, type TargetName } from "expo-targets";

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2,7 +2,7 @@
 
 **Source of truth for** WidgetKit / ActivityKit ownership in expo-targets.
 
-<!-- doc-meta: owner=eng | last-reviewed=2026-08-10 -->
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-14 -->
 
 ## Ownership
 
@@ -55,10 +55,16 @@ Host CNG deletes only root-level `*.swift` under `ExpoTargetsGenerated/`. It nev
 {
   "type": "widget",
   "name": "OrderWidget",
-  "liveActivity": {
-    "attributesName": "OrderAttributes",
-    "static": { "orderId": "string" },
-    "contentState": { "status": "string", "progress": "double" }
+  "ios": {
+    "kinds": [
+      { "name": "OrderWidget" },
+      {
+        "type": "live-activity",
+        "attributesName": "OrderAttributes",
+        "static": { "orderId": "string" },
+        "contentState": { "status": "string", "progress": "double" }
+      }
+    ]
   }
 }
 ```
@@ -93,7 +99,7 @@ npx expo-targets add
 - **native (default)** — SwiftUI / Glance deepen under `targets/<name>/ios|android/`.
 - **expo-ui** — writes `entry` + `createTarget(name, Layout)` with the `'widget'` directive; CNG emits `ExpoUiWidget` (+ optional AppIntentConfiguration / `WidgetLiveActivity`).
 - **Configurable (Edit Widget)** — native scaffolds `AppIntentConfiguration` under user deepen; expo-ui uses `ios.configuration` → sealed AppIntent + `environment.configuration` in Layout.
-- **Live Activity** — writes `liveActivity` into config. Native: `LiveActivity.swift` deepen + typed CNG attributes. Expo-ui: same entry registers `createLiveActivityLayout` + Bundle includes `WidgetLiveActivity()` (blob attrs; skip typed CNG).
+- **Live Activity** — writes a `{ "type": "live-activity" }` row in `ios.kinds`. Native: `LiveActivity.swift` deepen + typed CNG attributes. Expo-ui: same entry registers `createLiveActivityLayout` + Bundle includes `WidgetLiveActivity()` (blob attrs; skip typed CNG).
 
 See [`examples/trick`](../examples/trick) for a full host + widget pairing and
 [`examples/widgets`](../examples/widgets) for static, expo-ui, and RemoteViews examples.
@@ -168,7 +174,7 @@ Use the same `appGroup` as `expo-target.config.json`.
 
 - `addUserInteractionListener` — widget Button presses (iOS AppIntent → host; Android Glance/RemoteViews Bump → `ExpoTargetsStorage` `onUserInteraction` with the same event shape).
 - `createLiveActivityLayout(name, slots)` — multi-slot LA UI in the same entry as the home Layout; `LiveActivity.create(attributesName)` still starts/updates/ends.
-- `liveActivity.pushType: 'token'` — native CNG requests ActivityKit push tokens; `addPushToStartTokenListener` for push-to-start. Simulator cannot prove APNs — Devicewright CLAIMS for DI / push / StandBy.
+- `ios.kinds` `{ type: "live-activity", pushType: "token" }` — native CNG requests ActivityKit push tokens; `addPushToStartTokenListener` for push-to-start. Simulator cannot prove APNs — Devicewright CLAIMS for DI / push / StandBy.
 
 ## Android widgets
 
@@ -180,14 +186,16 @@ Android home-screen widgets (Glance / RemoteViews) are **first-class** in expo-t
 - Seeded `message` + `taps` from host `setData`
 - `Bump` button → increments taps, refreshes the tile, emits `addUserInteractionListener` (`source` / `target`)
 
-See `examples/widgets` (`HelloExpoUi`, `HelloWidget`, `HelloRemoteViews`). Scaffolded Glance targets get the same chrome + Bump stub.
+See `examples/widgets` (`HelloExpoUi` has two expo-ui kinds plus a live-activity row; `HelloRemoteViewsBundle` has two Android providers). Scaffolded Glance targets get the same chrome + Bump stub.
+
+One `type: widget` folder can list many iOS picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`. `supportedFamilies` on a kind is sizes of that row, not extra products.
 
 One generator per app if official `expo-widgets` Android lands. ActivityKit / Dynamic Island / StandBy remain iOS-only; `LiveActivity.*` on Android maps to an **ongoing-notification helper** (same JS API; see `examples/widgets`). See [limits.md](./limits.md) and [configuration.md](./configuration.md) Android matrix.
 
 ## Related
 
 - [api.md](./api.md) — `LiveActivity` runtime
-- [configuration.md](./configuration.md) — `liveActivity` schema
+- [configuration.md](./configuration.md) — `ios.kinds` schema
 - [limits.md](./limits.md) — lib floor vs Apple gates
 - [deprecations.md](./deprecations.md) — roadmap policy
 - [getting-started.md](./getting-started.md)

--- a/examples/.devicewright/journeys/helpers.ts
+++ b/examples/.devicewright/journeys/helpers.ts
@@ -254,6 +254,103 @@ export async function dismissSystemAlerts(
   }
 }
 
+function isSpringBoardSpotlight(labels: string[]): boolean {
+  const joined = labels.join(" | ");
+  // iOS 26 home still exposes dewey-search-field for the Search pill — that is
+  // not Spotlight. Real Spotlight has Siri Suggestions / a Spotlight title.
+  return (
+    /Siri Suggestions/i.test(joined) ||
+    /(^|\|)\s*Spotlight\s*(\||$)/i.test(joined)
+  );
+}
+
+/**
+ * iOS 26: HOME from an app can land on Spotlight instead of the icon grid.
+ * The home Search pill is not Spotlight — do not swipe it away.
+ */
+export async function dismissSpringBoardSpotlight(
+  device: DeviceSession,
+): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    if (!isSpringBoardSpotlight(flattenLabels(await device.accessibilityTree()))) {
+      return;
+    }
+    await device.pressButton({ button: "HOME" }).catch(() => undefined);
+    await sleep(400);
+    if (!isSpringBoardSpotlight(flattenLabels(await device.accessibilityTree()))) {
+      return;
+    }
+    try {
+      const cancel = await waitForNamed(device, ["Cancel"], { timeoutMs: 800 });
+      await tapCenter(device, cancel);
+      await sleep(400);
+      continue;
+    } catch {
+      /* swipe up to close Spotlight, not down (down opens search) */
+    }
+    await device.swipe({
+      xStart: 200,
+      yStart: 720,
+      xEnd: 200,
+      yEnd: 140,
+      duration: 0.28,
+    });
+    await sleep(400);
+  }
+}
+
+/**
+ * SpringBoard app icons are often missing from the AX tree on iOS 26 (only the
+ * Search pill is listed). Probe the grid + dock and synthesize a tap frame.
+ */
+export async function findSpringBoardHostIcon(
+  device: DeviceSession,
+  names: string[],
+): Promise<AccessibilityNode> {
+  await dismissSpringBoardSpotlight(device);
+  for (let page = 0; page < 4; page++) {
+    try {
+      const hit = await findNamedViaPointProbe(device, names, {
+        timeoutMs: 3_500,
+        match: "includes",
+        yStartRatio: 0.05,
+        yEndRatio: 0.99,
+        hotspots: [
+          { x: 48, y: 820 },
+          { x: 72, y: 860 },
+          { x: 96, y: 880 },
+          { x: 120, y: 840 },
+          { x: 200, y: 420 },
+        ],
+      });
+      const node = hit.node;
+      const frame = node.frame;
+      if (!frame || frame.width < 8 || frame.height < 8) {
+        node.frame = {
+          x: hit.probeX - 22,
+          y: hit.probeY - 22,
+          width: 44,
+          height: 44,
+        };
+      }
+      return node;
+    } catch {
+      await device.swipe({
+        xStart: 360,
+        yStart: 400,
+        xEnd: 60,
+        yEnd: 400,
+        duration: 0.3,
+      });
+      await sleep(500);
+    }
+  }
+  const tree = await device.accessibilityTree();
+  throw new Error(
+    `host icon not on SpringBoard; labels=${flattenLabels(tree).slice(0, 60).join(", ")}`,
+  );
+}
+
 /**
  * Visible text for an a11y node. On Android, long JSON in `text=` often leaves
  * `label`/`value` empty while the uiautomator `raw` still carries `text='...'`.

--- a/examples/.devicewright/journeys/widgets-expo-ui.ts
+++ b/examples/.devicewright/journeys/widgets-expo-ui.ts
@@ -5,6 +5,7 @@ import {
   dismissSystemAlerts,
   findNamedViaPointProbe,
   flattenLabels,
+  findSpringBoardHostIcon,
   hostReadyTestId,
   sleep,
   tapCenter,
@@ -30,24 +31,7 @@ async function findSpringBoardHost(
   device: DeviceSession,
   names: string[],
 ): Promise<AccessibilityNode> {
-  for (let page = 0; page < 4; page++) {
-    try {
-      return await waitForNamed(device, names, { timeoutMs: 2_500 });
-    } catch {
-      await device.swipe({
-        xStart: 360,
-        yStart: 400,
-        xEnd: 60,
-        yEnd: 400,
-        duration: 0.3,
-      });
-      await sleep(500);
-    }
-  }
-  const tree = await device.accessibilityTree();
-  throw new Error(
-    `host icon not on SpringBoard; labels=${flattenLabels(tree).slice(0, 60).join(", ")}`,
-  );
+  return findSpringBoardHostIcon(device, names);
 }
 
 /**

--- a/examples/.devicewright/journeys/widgets.ts
+++ b/examples/.devicewright/journeys/widgets.ts
@@ -6,6 +6,7 @@ import {
   dismissSystemAlerts,
   findNamedViaPointProbe,
   flattenLabels,
+  findSpringBoardHostIcon,
   hostReadyTestId,
   sleep,
   tapCenter,
@@ -31,24 +32,7 @@ async function findSpringBoardHost(
   device: DeviceSession,
   names: string[],
 ): Promise<AccessibilityNode> {
-  for (let page = 0; page < 4; page++) {
-    try {
-      return await waitForNamed(device, names, { timeoutMs: 2_500 });
-    } catch {
-      await device.swipe({
-        xStart: 360,
-        yStart: 400,
-        xEnd: 60,
-        yEnd: 400,
-        duration: 0.3,
-      });
-      await sleep(500);
-    }
-  }
-  const tree = await device.accessibilityTree();
-  throw new Error(
-    `host icon not on SpringBoard; labels=${flattenLabels(tree).slice(0, 60).join(", ")}`,
-  );
+  return findSpringBoardHostIcon(device, names);
 }
 
 /**

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ Do not commit generated `ios/` or `android/` folders from example prebuilds. Nev
 | [`messages`](./messages) | React Native messages extension |
 | [`clip`](./clip) | React Native App Clip |
 | [`stickers`](./stickers) | Asset-only sticker pack |
-| [`widgets`](./widgets) | WidgetKit + Glance/RemoteViews — [widgets.md](../docs/widgets.md) |
+| [`widgets`](./widgets) | WidgetKit + Glance/RemoteViews (incl. `android.providers[]`) — [widgets.md](../docs/widgets.md) |
 | [`trick`](./trick) | Live Activity showcase (`live-activity` Devicewright id) |
 | [`kitchen-sink`](./kitchen-sink) | Multi-target host (optional aggregate) |
 | [`native/share`](./native/share) | Swift share + RN host |

--- a/examples/trick/targets/trick-widgets/expo-target.config.json
+++ b/examples/trick/targets/trick-widgets/expo-target.config.json
@@ -4,15 +4,18 @@
   "displayName": "ET Trick Widget",
   "platforms": ["ios"],
   "appGroup": "group.com.expotargets.example.trick",
-  "liveActivity": {
-    "attributesName": "TrickActivityAttributes",
-    "static": { "title": "string" },
-    "contentState": { "status": "string" }
-  },
   "ios": {
     "bundleIdentifier": "com.expotargets.example.trick.widgets",
     "displayName": "ET Trick Widget",
     "deploymentTarget": "18.0",
+    "kinds": [
+      {
+        "type": "live-activity",
+        "attributesName": "TrickActivityAttributes",
+        "static": { "title": "string" },
+        "contentState": { "status": "string" }
+      }
+    ],
     "colors": {
       "AccentColor": { "light": "#2F6BFF", "dark": "#5B8CFF" },
       "BackgroundColor": { "light": "#0B1220", "dark": "#0B1220" },

--- a/examples/widgets/App.tsx
+++ b/examples/widgets/App.tsx
@@ -16,6 +16,7 @@ import {
 import {
   getExpoUiMessage,
   helloExpoUi,
+  helloExpoUiCompact,
   helloExpoUiLiveActivity,
   updateExpoUiMessage,
 } from './targets/hello-expo-ui';
@@ -24,10 +25,12 @@ import {
   helloRemoteViews,
   updateRemoteViewsMessage,
 } from './targets/hello-remoteviews';
+import { helloRemoteViewsBundle } from './targets/hello-remoteviews-bundle';
 import { getMessage, helloWidget, updateMessage } from './targets/hello-widget';
 
 // Keep layout registration reachable (tree-shake guard).
 void helloExpoUiLiveActivity;
+void helloExpoUiCompact;
 
 /** Seeded host markers for Devicewright (avoid `|` — can confuse AX splits). */
 export const UITEST_WIDGET_SEED = 'Hello from host · family:systemSmall';
@@ -136,6 +139,8 @@ function seedAllPayloads(refresh: () => void) {
   updateMessage(UITEST_WIDGET_SEED);
   updateExpoUiMessage(UITEST_EXPO_UI_SEED);
   updateRemoteViewsMessage(UITEST_REMOTEVIEWS_SEED);
+  helloRemoteViewsBundle.setData({ message: UITEST_REMOTEVIEWS_SEED });
+  helloRemoteViewsBundle.refresh();
   refresh();
 }
 
@@ -145,6 +150,8 @@ function clearAllPayloads(refresh: () => void) {
   helloExpoUi.setData({ message: '' }, { refresh: true });
   helloRemoteViews.setData({ message: '' });
   helloRemoteViews.refresh();
+  helloRemoteViewsBundle.setData({ message: '' });
+  helloRemoteViewsBundle.refresh();
   refresh();
 }
 
@@ -343,6 +350,33 @@ function AndroidPinButton({
   );
 }
 
+function RemoteViewsBundlePins({
+  setPinStatus,
+}: {
+  setPinStatus: (status: string) => void;
+}) {
+  return (
+    <Section
+      eyebrow="RemoteViews · providers[]"
+      title="Hello RV Bundle"
+      body="One target, two AppWidgetProvider picker rows (Status layout and Agenda layout)."
+    >
+      <AndroidPinButton
+        testID="btn-pin-hello-status"
+        label="Pin Hello Status"
+        targetName="Status"
+        setPinStatus={setPinStatus}
+      />
+      <AndroidPinButton
+        testID="btn-pin-hello-agenda"
+        label="Pin Hello Agenda"
+        targetName="Agenda"
+        setPinStatus={setPinStatus}
+      />
+    </Section>
+  );
+}
+
 function PinSections({
   setPinStatus,
 }: {
@@ -386,6 +420,7 @@ function PinSections({
           setPinStatus={setPinStatus}
         />
       </Section>
+      <RemoteViewsBundlePins setPinStatus={setPinStatus} />
     </>
   );
 }

--- a/examples/widgets/README.md
+++ b/examples/widgets/README.md
@@ -1,6 +1,6 @@
 # Widgets
 
-WidgetKit and Android widget example. Three targets: native Glance (`HelloWidget`), expo-ui Glance (`HelloExpoUi`), and RemoteViews (`HelloRemoteViews`). The host seeds payloads, pins widgets on Android, and controls Live Activities.
+WidgetKit and Android widget example. Four targets: native Glance (`HelloWidget`), expo-ui Glance (`HelloExpoUi` — two iOS picker rows plus a live-activity kind), RemoteViews (`HelloRemoteViews`), and a RemoteViews bundle (`HelloRemoteViewsBundle` — two Android picker rows). The host seeds payloads, pins widgets on Android, and controls Live Activities.
 
 Full widget docs: [../../docs/widgets.md](../../docs/widgets.md). Suite how-to: [../README.md](../README.md). Type maturity: [../../docs/configuration.md](../../docs/configuration.md).
 

--- a/examples/widgets/targets/hello-expo-ui/expo-target.config.json
+++ b/examples/widgets/targets/hello-expo-ui/expo-target.config.json
@@ -5,25 +5,38 @@
   "platforms": ["ios", "android"],
   "appGroup": "group.com.expotargets.example.widgets",
   "entry": "./targets/hello-expo-ui/index.tsx",
-  "liveActivity": {
-    "attributesName": "HelloExpoUiAttributes",
-    "static": { "title": "string" },
-    "contentState": { "status": "string" },
-    "pushType": "token"
-  },
   "ios": {
     "bundleIdentifier": "com.expotargets.example.widgets.helloexpoui",
     "displayName": "Hello Expo UI",
-    "configuration": {
-      "title": "Hello Expo UI Configuration",
-      "parameters": {
-        "listId": {
-          "title": "List",
-          "type": "string",
-          "default": "default"
+    "kinds": [
+      {
+        "name": "HelloExpoUi",
+        "displayName": "Hello Expo UI",
+        "configuration": {
+          "title": "Hello Expo UI Configuration",
+          "parameters": {
+            "listId": {
+              "title": "List",
+              "type": "string",
+              "default": "default"
+            }
+          }
         }
+      },
+      {
+        "name": "HelloExpoUiCompact",
+        "displayName": "Hello Expo UI Compact",
+        "description": "Compact picker row (not a second size of Hello Expo UI)",
+        "supportedFamilies": ["systemSmall"]
+      },
+      {
+        "type": "live-activity",
+        "attributesName": "HelloExpoUiAttributes",
+        "static": { "title": "string" },
+        "contentState": { "status": "string" },
+        "pushType": "token"
       }
-    },
+    ],
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" },
       "BackgroundColor": { "light": "#F2F2F7", "dark": "#1C1C1E" },

--- a/examples/widgets/targets/hello-expo-ui/index.tsx
+++ b/examples/widgets/targets/hello-expo-ui/index.tsx
@@ -92,6 +92,30 @@ function HelloExpoUiLiveActivity(
 
 export const helloExpoUi = createTarget('HelloExpoUi', HelloExpoUiLayout);
 
+function HelloExpoUiCompactLayout(props: HelloExpoUiProps) {
+  'widget';
+  return (
+    <VStack>
+      <Text
+        modifiers={[
+          font({ weight: 'bold', size: 13 }),
+          foregroundStyle('#000000'),
+        ]}
+      >
+        Compact
+      </Text>
+      <Text modifiers={[font({ size: 12 }), foregroundStyle('#3C3C43')]}>
+        {props.message ?? 'Hello Expo UI Compact'}
+      </Text>
+    </VStack>
+  );
+}
+
+export const helloExpoUiCompact = createTarget(
+  'HelloExpoUiCompact',
+  HelloExpoUiCompactLayout
+);
+
 /** Multi-slot expo-ui Live Activity (WidgetLiveActivity blob path). */
 export const helloExpoUiLiveActivity = createLiveActivityLayout(
   'HelloExpoUi',

--- a/examples/widgets/targets/hello-remoteviews-bundle/android/com/expotargets/example/widgets/widget/helloremoteviewsbundle/AgendaProvider.kt
+++ b/examples/widgets/targets/hello-remoteviews-bundle/android/com/expotargets/example/widgets/widget/helloremoteviewsbundle/AgendaProvider.kt
@@ -1,0 +1,33 @@
+package com.expotargets.example.widgets.widget.helloremoteviewsbundle
+
+import android.content.Context
+import android.widget.RemoteViews
+import com.expotargets.example.widgets.R
+import expo.modules.targets.ExpoTargetsRemoteViewsProvider
+
+/**
+ * RemoteViews picker row 2 — FQCN:
+ * com.expotargets.example.widgets.widget.helloremoteviewsbundle.AgendaProvider
+ */
+class AgendaProvider :
+  ExpoTargetsRemoteViewsProvider("group.com.expotargets.example.widgets") {
+  companion object {
+    private const val TARGET = "HelloRemoteViewsBundle"
+  }
+
+  override val layoutResId: Int = R.layout.widget_agenda
+
+  override fun updateWidget(
+    context: Context,
+    views: RemoteViews,
+    data: Map<String, *>,
+  ) {
+    val message =
+      (data["$TARGET:message"] as? String)
+        ?: (data["message"] as? String)
+        ?: "Ship widgets"
+    views.setTextViewText(R.id.widget_agenda_title, "Hello Agenda")
+    views.setTextViewText(R.id.widget_agenda_line1, "1. Morning standup")
+    views.setTextViewText(R.id.widget_agenda_line2, "2. $message")
+  }
+}

--- a/examples/widgets/targets/hello-remoteviews-bundle/android/com/expotargets/example/widgets/widget/helloremoteviewsbundle/StatusProvider.kt
+++ b/examples/widgets/targets/hello-remoteviews-bundle/android/com/expotargets/example/widgets/widget/helloremoteviewsbundle/StatusProvider.kt
@@ -1,0 +1,32 @@
+package com.expotargets.example.widgets.widget.helloremoteviewsbundle
+
+import android.content.Context
+import android.widget.RemoteViews
+import com.expotargets.example.widgets.R
+import expo.modules.targets.ExpoTargetsRemoteViewsProvider
+
+/**
+ * RemoteViews picker row 1 — FQCN:
+ * com.expotargets.example.widgets.widget.helloremoteviewsbundle.StatusProvider
+ */
+class StatusProvider :
+  ExpoTargetsRemoteViewsProvider("group.com.expotargets.example.widgets") {
+  companion object {
+    private const val TARGET = "HelloRemoteViewsBundle"
+  }
+
+  override val layoutResId: Int = R.layout.widget_status
+
+  override fun updateWidget(
+    context: Context,
+    views: RemoteViews,
+    data: Map<String, *>,
+  ) {
+    val message =
+      (data["$TARGET:message"] as? String)
+        ?: (data["message"] as? String)
+        ?: "Status ready"
+    views.setTextViewText(R.id.widget_status_title, "Hello Status")
+    views.setTextViewText(R.id.widget_status_message, message)
+  }
+}

--- a/examples/widgets/targets/hello-remoteviews-bundle/android/layouts/layout/widget_agenda.xml
+++ b/examples/widgets/targets/hello-remoteviews-bundle/android/layouts/layout/widget_agenda.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="#FFF1F8E9">
+    <TextView
+        android:id="@+id/widget_agenda_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Hello Agenda"
+        android:textStyle="bold"
+        android:textSize="15sp"
+        android:textColor="#FF33691E" />
+    <TextView
+        android:id="@+id/widget_agenda_line1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:text="1. Morning standup"
+        android:textSize="13sp"
+        android:textColor="#FF3C3C43" />
+    <TextView
+        android:id="@+id/widget_agenda_line2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:text="2. Ship widgets"
+        android:textSize="13sp"
+        android:textColor="#FF3C3C43" />
+</LinearLayout>

--- a/examples/widgets/targets/hello-remoteviews-bundle/android/layouts/layout/widget_status.xml
+++ b/examples/widgets/targets/hello-remoteviews-bundle/android/layouts/layout/widget_status.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="#FFE8F0FE">
+    <TextView
+        android:id="@+id/widget_status_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Hello Status"
+        android:textStyle="bold"
+        android:textSize="15sp"
+        android:textColor="#FF1A73E8" />
+    <TextView
+        android:id="@+id/widget_status_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="No status yet"
+        android:textSize="13sp"
+        android:textColor="#FF3C3C43" />
+</LinearLayout>

--- a/examples/widgets/targets/hello-remoteviews-bundle/expo-target.config.json
+++ b/examples/widgets/targets/hello-remoteviews-bundle/expo-target.config.json
@@ -1,0 +1,29 @@
+{
+  "type": "widget",
+  "name": "HelloRemoteViewsBundle",
+  "displayName": "Hello RV Bundle",
+  "platforms": ["android"],
+  "appGroup": "group.com.expotargets.example.widgets",
+  "android": {
+    "widgetType": "remoteviews",
+    "providers": [
+      {
+        "name": "Status",
+        "displayName": "Hello Status",
+        "initialLayout": "widget_status",
+        "targetCellWidth": 2,
+        "targetCellHeight": 2,
+        "description": "Status RemoteViews row (compact layout)"
+      },
+      {
+        "name": "Agenda",
+        "displayName": "Hello Agenda",
+        "initialLayout": "widget_agenda",
+        "minWidth": "250dp",
+        "targetCellWidth": 4,
+        "targetCellHeight": 2,
+        "description": "Agenda RemoteViews row (list layout)"
+      }
+    ]
+  }
+}

--- a/examples/widgets/targets/hello-remoteviews-bundle/index.ts
+++ b/examples/widgets/targets/hello-remoteviews-bundle/index.ts
@@ -1,0 +1,8 @@
+import { createTarget } from 'expo-targets';
+
+export const helloRemoteViewsBundle = createTarget('HelloRemoteViewsBundle');
+
+export const updateBundleMessage = (message: string) => {
+  helloRemoteViewsBundle.setData({ message });
+  helloRemoteViewsBundle.refresh();
+};

--- a/examples/widgets/targets/hello-widget/expo-target.config.json
+++ b/examples/widgets/targets/hello-widget/expo-target.config.json
@@ -4,14 +4,17 @@
   "displayName": "Hello Widget",
   "platforms": ["ios", "android"],
   "appGroup": "group.com.expotargets.example.widgets",
-  "liveActivity": {
-    "attributesName": "HelloWidgetAttributes",
-    "static": { "title": "string" },
-    "contentState": { "status": "string" }
-  },
   "ios": {
     "bundleIdentifier": "com.expotargets.example.widgets.hello",
     "displayName": "Hello Widget",
+    "kinds": [
+      {
+        "type": "live-activity",
+        "attributesName": "HelloWidgetAttributes",
+        "static": { "title": "string" },
+        "contentState": { "status": "string" }
+      }
+    ],
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" },
       "BackgroundColor": { "light": "#F2F2F7", "dark": "#1C1C1E" },

--- a/packages/expo-targets/android/src/main/java/expo/modules/targets/storage/ExpoTargetsStorageModule.kt
+++ b/packages/expo-targets/android/src/main/java/expo/modules/targets/storage/ExpoTargetsStorageModule.kt
@@ -251,13 +251,25 @@ class ExpoTargetsStorageModule : Module() {
   }
 
   /**
-   * Resolve AppWidget ComponentName for a target name.
+   * Resolve AppWidget ComponentName for a target name, provider name, or FQCN.
    * Matches withAndroidWidget FQCNs:
    * - Glance: `{package}.widget.{sanitized}.{Pascal}WidgetReceiver`
    * - RemoteViews: `{package}.widget.{sanitized}.{Pascal}Provider`
+   * - `android.providers[].className` override (full FQCN)
    */
   private fun resolveWidgetProvider(context: Context, targetName: String): ComponentName? {
     val pkg = context.packageName
+    val awm = AppWidgetManager.getInstance(context)
+
+    if (targetName.contains('.')) {
+      for (info in awm.installedProviders) {
+        if (info.provider.packageName == pkg && info.provider.className == targetName) {
+          return info.provider
+        }
+      }
+      return ComponentName(pkg, targetName)
+    }
+
     val segment = targetName.lowercase().replace(Regex("[^a-z0-9_]"), "_")
     val segmentAlt = targetName.replace(Regex("[^a-zA-Z0-9]"), "").lowercase()
     val pascal =
@@ -272,11 +284,16 @@ class ExpoTargetsStorageModule : Module() {
         "$pkg.widget.$segmentAlt.${pascal}Provider",
       )
 
-    val awm = AppWidgetManager.getInstance(context)
     for (info in awm.installedProviders) {
       if (info.provider.packageName != pkg) continue
       val className = info.provider.className
       if (candidates.contains(className)) return info.provider
+      val simple = className.substringAfterLast('.')
+      if (simple.equals("${pascal}Provider", ignoreCase = true) ||
+          simple.equals("${pascal}WidgetReceiver", ignoreCase = true)
+      ) {
+        return info.provider
+      }
       val lower = className.lowercase()
       if (
         lower.contains(".$segment.") ||

--- a/packages/expo-targets/cli/src/checks/nameSync.ts
+++ b/packages/expo-targets/cli/src/checks/nameSync.ts
@@ -45,14 +45,14 @@ function parseCreateTargetArg(arg: Expression): string | null {
   return null;
 }
 
-function parseCreateTargetName(filePath: string): string | null {
+function parseCreateTargetNames(filePath: string): string[] {
   const source = fs.readFileSync(filePath, 'utf8');
   const ast = parse(source, {
     sourceType: 'module',
     plugins: ['typescript', 'jsx'],
   });
 
-  let found: string | null = null;
+  const found: string[] = [];
   traverse(ast, {
     CallExpression(path) {
       const callee = path.node.callee;
@@ -65,7 +65,7 @@ function parseCreateTargetName(filePath: string): string | null {
       }
       const name = parseCreateTargetArg(arg);
       if (name) {
-        found = name;
+        found.push(name);
       }
     },
   });
@@ -83,51 +83,75 @@ function helperPath(targetDir: string): string | null {
   return null;
 }
 
+function galleryKindNames(target: {
+  config: {
+    ios?: { kinds?: { type?: string; name?: string }[] };
+    name?: string;
+  };
+}): string[] {
+  const kinds = (target.config.ios?.kinds ?? []).filter(
+    (kind) => kind.type !== 'live-activity' && kind.name
+  );
+  if (kinds.length > 0) {
+    return kinds.map((kind) => kind.name as string);
+  }
+  return target.config.name ? [target.config.name] : [];
+}
+
 export function checkNameSync(ctx: ProjectContext): CheckResult[] {
   const failures: CheckResult[] = [];
 
   for (const target of ctx.targets) {
-    const configName = target.config.name;
-    if (!configName) {
-      failures.push({
-        ok: false,
-        level: 'error',
-        title: 'Name sync',
-        message: `targets/${target.dirName}: missing "name" in expo-target.config`,
-        fix: 'Set "name" to match createTarget(\'...\') in the target index file',
-      });
-      continue;
+    const result = checkOneNameSync(target);
+    if (result) {
+      failures.push(result);
     }
-
-    const helper = helperPath(path.dirname(target.configPath));
-    if (!helper) {
-      continue;
-    }
-
-    const createName = parseCreateTargetName(helper);
-    if (!createName) {
-      failures.push({
-        ok: false,
-        level: 'error',
-        title: 'Name sync',
-        message: `targets/${target.dirName}: could not find createTarget('...') in ${path.basename(helper)}`,
-        fix: `Add: export const x = createTarget('${configName}');`,
-      });
-      continue;
-    }
-
-    if (createName === configName) {
-      continue;
-    }
-
-    failures.push({
-      ok: false,
-      level: 'error',
-      title: 'Name sync',
-      message: `targets/${target.dirName}: config name "${configName}" ≠ createTarget('${createName}')`,
-      fix: `Align expo-target.config "name" and createTarget('${configName}')`,
-    });
   }
 
   return failures;
+}
+
+function checkOneNameSync(
+  target: ProjectContext['targets'][number]
+): CheckResult | undefined {
+  const configName = target.config.name;
+  if (!configName) {
+    return {
+      ok: false,
+      level: 'error',
+      title: 'Name sync',
+      message: `targets/${target.dirName}: missing "name" in expo-target.config`,
+      fix: 'Set "name" to match createTarget(\'...\') in the target index file',
+    };
+  }
+
+  const helper = helperPath(path.dirname(target.configPath));
+  if (!helper) {
+    return;
+  }
+
+  const createNames = parseCreateTargetNames(helper);
+  if (createNames.length === 0) {
+    return {
+      ok: false,
+      level: 'error',
+      title: 'Name sync',
+      message: `targets/${target.dirName}: could not find createTarget('...') in ${path.basename(helper)}`,
+      fix: `Add: export const x = createTarget('${configName}');`,
+    };
+  }
+
+  const expected = galleryKindNames(target);
+  const missing = expected.filter((name) => !createNames.includes(name));
+  if (missing.length === 0) {
+    return;
+  }
+
+  return {
+    ok: false,
+    level: 'error',
+    title: 'Name sync',
+    message: `targets/${target.dirName}: ios.kinds / name ${JSON.stringify(missing)} missing createTarget(...) in ${path.basename(helper)} (found ${JSON.stringify(createNames)})`,
+    fix: `Add createTarget('${missing[0]}', Layout) for each gallery kind`,
+  };
 }

--- a/packages/expo-targets/cli/src/checks/unusedWidgetBundle.ts
+++ b/packages/expo-targets/cli/src/checks/unusedWidgetBundle.ts
@@ -1,0 +1,45 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { CheckResult, ProjectContext } from '../types';
+
+function hasGalleryKinds(
+  kinds: { type?: string; name?: string }[] | undefined
+): boolean {
+  return Boolean(
+    kinds?.some((kind) => kind.type !== 'live-activity' && kind.name)
+  );
+}
+
+/** Warn when expo-ui kinds generate a sealed Bundle and a user Bundle.swift is leftover. */
+export function warnUnusedWidgetBundle(ctx: ProjectContext): CheckResult[] {
+  const warnings: CheckResult[] = [];
+  for (const target of ctx.targets) {
+    if (target.config.type !== 'widget' || !target.config.entry) {
+      continue;
+    }
+    if (!hasGalleryKinds(target.config.ios?.kinds)) {
+      continue;
+    }
+    const name = target.config.name;
+    if (!name) {
+      continue;
+    }
+    const bundlePath = path.join(
+      path.dirname(target.configPath),
+      'ios',
+      `${name}Bundle.swift`
+    );
+    if (!fs.existsSync(bundlePath)) {
+      continue;
+    }
+    warnings.push({
+      ok: true,
+      level: 'warn',
+      title: 'Unused widget Bundle',
+      message: `targets/${target.dirName}/ios/${name}Bundle.swift is not compiled when ios.kinds lists gallery widgets. The sealed generated Bundle is used instead.`,
+      fix: `Delete targets/${target.dirName}/ios/${name}Bundle.swift after you confirm the generated Bundle.`,
+    });
+  }
+  return warnings;
+}

--- a/packages/expo-targets/cli/src/doctor.test.ts
+++ b/packages/expo-targets/cli/src/doctor.test.ts
@@ -8,6 +8,7 @@ import { checkEntries } from './checks/entries';
 import { checkMetro } from './checks/metro';
 import { checkNameSync } from './checks/nameSync';
 import { checkPlugin } from './checks/plugin';
+import { warnUnusedWidgetBundle } from './checks/unusedWidgetBundle';
 import { loadProject } from './project';
 
 const roots: string[] = [];
@@ -169,7 +170,9 @@ describe('checkNameSync', () => {
         "import { createTarget } from 'expo-targets';\n" +
         "export const share = createTarget('Wrong');\n",
     });
-    expect(checkNameSync(loadProject(root))[0]?.message).toContain('≠');
+    expect(checkNameSync(loadProject(root))[0]?.message).toContain(
+      'missing createTarget'
+    );
   });
 
   test('passes when names match', () => {
@@ -201,5 +204,89 @@ describe('checkNameSync', () => {
         'export const share = createTarget(Targets.Share);\n',
     });
     expect(checkNameSync(loadProject(root))).toHaveLength(0);
+  });
+});
+
+describe('checkNameSync gallery kinds', () => {
+  test('fails when a gallery kind has no createTarget', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        entry: './targets/widget/index.tsx',
+        ios: {
+          kinds: [
+            { name: 'Home' },
+            { name: 'Lock' },
+            { type: 'live-activity', attributesName: 'HomeAttributes' },
+          ],
+        },
+      }),
+      'targets/widget/index.tsx':
+        "import { createTarget } from 'expo-targets';\n" +
+        "export const home = createTarget('Home');\n",
+    });
+    expect(checkNameSync(loadProject(root))[0]?.message).toContain('Lock');
+  });
+
+  test('passes when every gallery kind has createTarget', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        entry: './targets/widget/index.tsx',
+        ios: {
+          kinds: [
+            { name: 'Home' },
+            { name: 'Lock' },
+            { type: 'live-activity', attributesName: 'HomeAttributes' },
+          ],
+        },
+      }),
+      'targets/widget/index.tsx':
+        "import { createTarget } from 'expo-targets';\n" +
+        "export const home = createTarget('Home');\n" +
+        "export const lock = createTarget('Lock');\n",
+    });
+    expect(checkNameSync(loadProject(root))).toHaveLength(0);
+  });
+});
+
+describe('warnUnusedWidgetBundle', () => {
+  test('warns leftover Bundle.swift when expo-ui lists gallery kinds', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        entry: './targets/widget/index.tsx',
+        ios: { kinds: [{ name: 'Home' }, { name: 'Lock' }] },
+      }),
+      'targets/widget/ios/HomeBundle.swift':
+        'import WidgetKit\nstruct HomeBundle: WidgetBundle { var body: some Widget { Home() } }\n',
+    });
+    const warnings = warnUnusedWidgetBundle(loadProject(root));
+    expect(warnings[0]?.message).toContain('HomeBundle.swift');
+  });
+
+  test('skips live-activity-only kinds', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        ios: {
+          kinds: [{ type: 'live-activity', attributesName: 'HomeAttributes' }],
+        },
+      }),
+      'targets/widget/ios/HomeBundle.swift': 'struct HomeBundle {}\n',
+    });
+    expect(warnUnusedWidgetBundle(loadProject(root))).toHaveLength(0);
   });
 });

--- a/packages/expo-targets/cli/src/doctor.ts
+++ b/packages/expo-targets/cli/src/doctor.ts
@@ -13,6 +13,7 @@ import { checkNameSync } from './checks/nameSync';
 import { checkPlugin } from './checks/plugin';
 import { warnSealedZone } from './checks/sealedZone';
 import { checkUiMode } from './checks/uiMode';
+import { warnUnusedWidgetBundle } from './checks/unusedWidgetBundle';
 import { warnExtensionBundleExport } from './checks/updateScript';
 import { loadProject } from './project';
 import type { CheckResult } from './types';
@@ -42,6 +43,7 @@ function collectFailures(ctx: ReturnType<typeof loadProject>): CheckResult[] {
 
 function collectWarnings(ctx: ReturnType<typeof loadProject>): CheckResult[] {
   return [
+    ...warnUnusedWidgetBundle(ctx),
     ...warnSealedZone(ctx),
     ...warnDualWidgets(ctx),
     ...checkUiMode(ctx),

--- a/packages/expo-targets/cli/src/scaffold/expoUiWidgetTemplate.test.ts
+++ b/packages/expo-targets/cli/src/scaffold/expoUiWidgetTemplate.test.ts
@@ -43,3 +43,67 @@ describe('generateConfig expo-ui widget', () => {
     expect(json.entry).toBeUndefined();
   });
 });
+
+describe('generateConfig live-activity kinds', () => {
+  test('live-activity writes kinds and moves expo-ui configuration onto the widget row', () => {
+    const json = JSON.parse(
+      generateConfig({
+        type: 'widget',
+        kebabName: 'my-widget',
+        pascalName: 'MyWidget',
+        platforms: ['ios'],
+        widgetUi: 'expo-ui',
+        configurableWidget: true,
+        includeLiveActivity: true,
+        appGroup: 'group.test',
+      })
+    );
+    expect(json.ios.configuration).toBeUndefined();
+    expect(json.ios.kinds).toEqual([
+      {
+        name: 'MyWidget',
+        displayName: 'My Widget',
+        configuration: {
+          title: 'My Widget Configuration',
+          parameters: {
+            listId: {
+              title: 'List',
+              type: 'string',
+              default: 'default',
+            },
+          },
+        },
+      },
+      {
+        type: 'live-activity',
+        attributesName: 'MyWidgetAttributes',
+        static: { title: 'string' },
+        contentState: { status: 'string' },
+      },
+    ]);
+  });
+});
+
+describe('generateConfig native live-activity', () => {
+  test('native live-activity kinds omit a gallery widget row', () => {
+    const json = JSON.parse(
+      generateConfig({
+        type: 'widget',
+        kebabName: 'my-widget',
+        pascalName: 'MyWidget',
+        platforms: ['ios'],
+        widgetUi: 'native',
+        includeLiveActivity: true,
+        appGroup: 'group.test',
+      })
+    );
+    expect(json.ios.kinds).toEqual([
+      {
+        type: 'live-activity',
+        attributesName: 'MyWidgetAttributes',
+        static: { title: 'string' },
+        contentState: { status: 'string' },
+      },
+    ]);
+  });
+});

--- a/packages/expo-targets/cli/src/scaffold/generateConfig.ts
+++ b/packages/expo-targets/cli/src/scaffold/generateConfig.ts
@@ -101,11 +101,28 @@ function applyLiveActivityConfig(
   }
   const attributesName =
     options.liveActivityAttributesName ?? `${options.pascalName}Attributes`;
-  config.liveActivity = {
+  const ios =
+    typeof config.ios === 'object' && config.ios
+      ? (config.ios as Record<string, unknown>)
+      : {};
+  const kinds = Array.isArray(ios.kinds) ? [...ios.kinds] : [];
+  if (options.widgetUi === 'expo-ui') {
+    const configuration = ios.configuration;
+    delete ios.configuration;
+    kinds.unshift({
+      name: options.pascalName,
+      displayName: formatDisplayName(options.kebabName),
+      ...(configuration ? { configuration } : {}),
+    });
+  }
+  kinds.push({
+    type: 'live-activity',
     attributesName,
     static: { title: 'string' },
     contentState: { status: 'string' },
-  };
+  });
+  ios.kinds = kinds;
+  config.ios = ios;
 }
 
 function applyAppIntentIosConfig(

--- a/packages/expo-targets/cli/src/types.ts
+++ b/packages/expo-targets/cli/src/types.ts
@@ -17,8 +17,8 @@ export interface TargetConfig {
   ui?: 'native' | 'expo-ui' | 'react-native';
   appGroup?: string;
   excludedPackages?: string[];
-  liveActivity?: { attributesName?: string };
   ios?: {
+    kinds?: { type?: string; name?: string }[];
     intents?: { ui?: boolean | { name?: string } };
     wallet?: { ui?: boolean | { name?: string } };
   };

--- a/packages/expo-targets/plugin/src/android/resolveAndroidWidgetProviders.test.ts
+++ b/packages/expo-targets/plugin/src/android/resolveAndroidWidgetProviders.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildAppWidgetProviderXml,
+  mergeAppWidgetProviderXml,
+  resolveAndroidWidgetProviders,
+} from './resolveAndroidWidgetProviders';
+
+const pkg = 'com.expotargets.example.widgets';
+
+describe('resolveAndroidWidgetProviders 1:1', () => {
+  test('omitted providers keeps 1:1 RemoteViews FQCN and xml name', () => {
+    const [provider] = resolveAndroidWidgetProviders({
+      packageName: pkg,
+      targetName: 'HelloRemoteViews',
+      displayName: 'Hello RemoteViews',
+      android: { widgetType: 'remoteviews' },
+    });
+
+    expect(provider.className).toBe(
+      `${pkg}.widget.helloremoteviews.HelloRemoteViewsProvider`
+    );
+    expect(provider.xmlName).toBe('widgetprovider_helloremoteviews');
+    expect(provider.displayName).toBe('Hello RemoteViews');
+    expect(provider.initialLayout).toBe('widget_helloremoteviews');
+  });
+
+  test('omitted providers keeps 1:1 Glance receiver FQCN', () => {
+    const [provider] = resolveAndroidWidgetProviders({
+      packageName: pkg,
+      targetName: 'HelloWidget',
+      android: { widgetType: 'glance' },
+    });
+
+    expect(provider.className).toBe(
+      `${pkg}.widget.hellowidget.HelloWidgetWidgetReceiver`
+    );
+    expect(provider.xmlName).toBe('widgetprovider_hellowidget');
+  });
+
+  test('empty providers array is the scalar 1:1 path', () => {
+    const providers = resolveAndroidWidgetProviders({
+      packageName: pkg,
+      targetName: 'HelloRemoteViews',
+      android: { widgetType: 'remoteviews', providers: [] },
+    });
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.className).toBe(
+      `${pkg}.widget.helloremoteviews.HelloRemoteViewsProvider`
+    );
+  });
+});
+
+const poplProviders = [
+  {
+    name: 'homescreen',
+    displayName: 'Popl Card',
+    className: `${pkg}.widget.homescreenwidget.HomescreenWidgetProvider`,
+    initialLayout: 'widget_homescreen',
+    targetCellWidth: 4,
+    targetCellHeight: 2,
+  },
+  {
+    name: 'medium-qr',
+    displayName: 'Medium QR',
+    className: 'MediumQrWidgetProvider',
+    initialLayout: 'widget_medium_qr',
+    minWidth: '250dp',
+  },
+];
+
+describe('resolveAndroidWidgetProviders list', () => {
+  test('providers list registers N FQCNs and xml resources', () => {
+    const providers = resolveAndroidWidgetProviders({
+      packageName: pkg,
+      targetName: 'HomescreenWidget',
+      displayName: 'Popl',
+      android: {
+        widgetType: 'remoteviews',
+        minWidth: '180dp',
+        providers: poplProviders,
+      },
+    });
+
+    expect(providers).toHaveLength(2);
+    expect(providers[0]?.className).toBe(
+      `${pkg}.widget.homescreenwidget.HomescreenWidgetProvider`
+    );
+    expect(providers[0]?.xmlName).toBe('widgetprovider_homescreen');
+    expect(providers[0]?.displayName).toBe('Popl Card');
+    expect(providers[0]?.minWidth).toBe('180dp');
+    expect(providers[0]?.targetCellWidth).toBe(4);
+    expect(providers[1]?.className).toBe(
+      `${pkg}.widget.homescreenwidget.MediumQrWidgetProvider`
+    );
+    expect(providers[1]?.xmlName).toBe('widgetprovider_medium_qr');
+    expect(providers[1]?.minWidth).toBe('250dp');
+  });
+});
+
+describe('resolveAndroidWidgetProviders duplicates', () => {
+  test('duplicate provider names throw', () => {
+    expect(() =>
+      resolveAndroidWidgetProviders({
+        packageName: pkg,
+        targetName: 'Bundle',
+        android: {
+          widgetType: 'remoteviews',
+          providers: [{ name: 'status' }, { name: 'status' }],
+        },
+      })
+    ).toThrow(/status/);
+  });
+});
+
+describe('mergeAppWidgetProviderXml', () => {
+  test('writes a full provider xml when the file is missing', () => {
+    const xml = mergeAppWidgetProviderXml(
+      null,
+      buildAppWidgetProviderXml({
+        minWidth: '180dp',
+        minHeight: '110dp',
+        resizeMode: 'horizontal|vertical',
+        updatePeriodMillis: 0,
+        widgetCategory: 'home_screen',
+        initialLayout: 'widget_status',
+      })
+    );
+
+    expect(xml).toContain('android:initialLayout="@layout/widget_status"');
+    expect(xml).toContain('android:minWidth="180dp"');
+  });
+
+  test('keeps extra user attributes when the file already exists', () => {
+    const existing = `<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:widgetFeatures="reconfigurable"
+    android:initialLayout="@layout/widget_status">
+</appwidget-provider>
+`;
+    const xml = mergeAppWidgetProviderXml(
+      existing,
+      buildAppWidgetProviderXml({
+        minWidth: '180dp',
+        minHeight: '110dp',
+        resizeMode: 'none',
+        updatePeriodMillis: 0,
+        widgetCategory: 'home_screen',
+        initialLayout: 'widget_status',
+      })
+    );
+
+    expect(xml).toContain('android:minWidth="180dp"');
+    expect(xml).toContain('android:widgetFeatures="reconfigurable"');
+    expect(xml).toContain('android:initialLayout="@layout/widget_status"');
+  });
+});

--- a/packages/expo-targets/plugin/src/android/resolveAndroidWidgetProviders.ts
+++ b/packages/expo-targets/plugin/src/android/resolveAndroidWidgetProviders.ts
@@ -1,0 +1,282 @@
+import type {
+  AndroidTargetConfig,
+  AndroidWidgetProviderConfig,
+} from '../config';
+
+export function sanitizeWidgetResourceName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+}
+
+export function toWidgetNamePascal(name: string): string {
+  return (
+    name.charAt(0).toUpperCase() +
+    name.slice(1).replace(/[-_]([a-z])/g, (_, letter) => letter.toUpperCase())
+  );
+}
+
+export interface ResolveAndroidWidgetProvidersInput {
+  packageName: string;
+  targetName: string;
+  displayName?: string;
+  android?: AndroidTargetConfig;
+}
+
+export interface ResolvedAndroidWidgetProvider {
+  name: string;
+  resourceName: string;
+  displayName: string;
+  className: string;
+  xmlName: string;
+  descriptionStringName: string | null;
+  initialLayout: string;
+  minWidth: string;
+  minHeight: string;
+  resizeMode: string;
+  updatePeriodMillis: number;
+  widgetCategory: string;
+  previewImage?: string;
+  description?: string;
+  maxResizeWidth?: string;
+  maxResizeHeight?: string;
+  targetCellWidth?: number;
+  targetCellHeight?: number;
+  hasExplicitLayout: boolean;
+}
+
+export interface WidgetProviderXmlFields {
+  minWidth: string;
+  minHeight: string;
+  resizeMode: string;
+  updatePeriodMillis: number;
+  widgetCategory: string;
+  initialLayout: string;
+  previewImage?: string;
+  descriptionStringName?: string | null;
+  maxResizeWidth?: string;
+  maxResizeHeight?: string;
+  targetCellWidth?: number;
+  targetCellHeight?: number;
+}
+
+function layoutSizes(
+  provider: AndroidWidgetProviderConfig,
+  android: AndroidTargetConfig
+) {
+  return {
+    minWidth: provider.minWidth ?? android.minWidth ?? '180dp',
+    minHeight: provider.minHeight ?? android.minHeight ?? '110dp',
+    resizeMode:
+      provider.resizeMode ?? android.resizeMode ?? 'horizontal|vertical',
+    updatePeriodMillis:
+      provider.updatePeriodMillis ?? android.updatePeriodMillis ?? 0,
+    widgetCategory:
+      provider.widgetCategory ?? android.widgetCategory ?? 'home_screen',
+  };
+}
+
+function layoutOptional(
+  provider: AndroidWidgetProviderConfig,
+  android: AndroidTargetConfig
+) {
+  return {
+    description: provider.description ?? android.description,
+    previewImage: provider.previewImage ?? android.previewImage,
+    maxResizeWidth: provider.maxResizeWidth ?? android.maxResizeWidth,
+    maxResizeHeight: provider.maxResizeHeight ?? android.maxResizeHeight,
+    targetCellWidth: provider.targetCellWidth ?? android.targetCellWidth,
+    targetCellHeight: provider.targetCellHeight ?? android.targetCellHeight,
+  };
+}
+
+function layoutFields(
+  provider: AndroidWidgetProviderConfig,
+  android: AndroidTargetConfig,
+  resourceName: string
+) {
+  const explicitLayout = provider.initialLayout ?? android.initialLayout;
+  return {
+    ...layoutSizes(provider, android),
+    ...layoutOptional(provider, android),
+    initialLayout: explicitLayout || `widget_${resourceName}`,
+    hasExplicitLayout: Boolean(explicitLayout),
+  };
+}
+
+function resolveClassName(opts: {
+  packageName: string;
+  targetSegment: string;
+  providerName: string;
+  widgetType: 'glance' | 'remoteviews';
+  className?: string;
+}): string {
+  const packagePrefix = `${opts.packageName}.widget.${opts.targetSegment}`;
+  if (opts.className) {
+    if (opts.className.includes('.')) {
+      return opts.className;
+    }
+    return `${packagePrefix}.${opts.className}`;
+  }
+  const pascal = toWidgetNamePascal(opts.providerName);
+  const suffix = opts.widgetType === 'glance' ? 'WidgetReceiver' : 'Provider';
+  return `${packagePrefix}.${pascal}${suffix}`;
+}
+
+function toResolvedProvider(
+  input: ResolveAndroidWidgetProvidersInput,
+  provider: AndroidWidgetProviderConfig
+): ResolvedAndroidWidgetProvider {
+  const android = input.android || {};
+  const resourceName = sanitizeWidgetResourceName(provider.name);
+  const layout = layoutFields(provider, android, resourceName);
+  return {
+    name: provider.name,
+    resourceName,
+    displayName:
+      provider.displayName ||
+      input.displayName ||
+      provider.name ||
+      input.targetName,
+    className: resolveClassName({
+      packageName: input.packageName,
+      targetSegment: sanitizeWidgetResourceName(input.targetName),
+      providerName: provider.name,
+      widgetType: android.widgetType || 'glance',
+      className: provider.className,
+    }),
+    xmlName: `widgetprovider_${resourceName}`,
+    descriptionStringName: layout.description
+      ? `widget_${resourceName}_description`
+      : null,
+    ...layout,
+  };
+}
+
+export function resolveAndroidWidgetProviders(
+  input: ResolveAndroidWidgetProvidersInput
+): ResolvedAndroidWidgetProvider[] {
+  const android = input.android || {};
+  const listed = android.providers;
+  const configs: AndroidWidgetProviderConfig[] =
+    listed && listed.length > 0
+      ? listed
+      : [{ name: input.targetName, displayName: input.displayName }];
+
+  const seenNames = new Set<string>();
+  const seenClassNames = new Set<string>();
+  const resolved: ResolvedAndroidWidgetProvider[] = [];
+
+  for (const config of configs) {
+    const next = toResolvedProvider(input, config);
+    if (seenNames.has(next.resourceName)) {
+      throw new Error(
+        `Duplicate android.providers name "${config.name}" (resource "${next.resourceName}") on target "${input.targetName}"`
+      );
+    }
+    if (seenClassNames.has(next.className)) {
+      throw new Error(
+        `Duplicate AppWidgetProvider className "${next.className}" on target "${input.targetName}"`
+      );
+    }
+    seenNames.add(next.resourceName);
+    seenClassNames.add(next.className);
+    resolved.push(next);
+  }
+
+  return resolved;
+}
+
+export function buildAppWidgetProviderXml(
+  fields: WidgetProviderXmlFields
+): Record<string, string> {
+  const attrs: Record<string, string> = {
+    'xmlns:android': 'http://schemas.android.com/apk/res/android',
+    'android:minWidth': fields.minWidth,
+    'android:minHeight': fields.minHeight,
+    'android:resizeMode': fields.resizeMode,
+    'android:updatePeriodMillis': String(fields.updatePeriodMillis),
+    'android:widgetCategory': fields.widgetCategory,
+    'android:initialLayout': `@layout/${fields.initialLayout}`,
+  };
+
+  if (fields.previewImage) {
+    const preview =
+      fields.previewImage.startsWith('@') || fields.previewImage.includes('/')
+        ? fields.previewImage
+        : `@drawable/${fields.previewImage}`;
+    attrs['android:previewImage'] = preview;
+  }
+  if (fields.descriptionStringName) {
+    attrs['android:description'] = `@string/${fields.descriptionStringName}`;
+  }
+  if (fields.maxResizeWidth) {
+    attrs['android:maxResizeWidth'] = fields.maxResizeWidth;
+  }
+  if (fields.maxResizeHeight) {
+    attrs['android:maxResizeHeight'] = fields.maxResizeHeight;
+  }
+  if (fields.targetCellWidth) {
+    attrs['android:targetCellWidth'] = String(fields.targetCellWidth);
+  }
+  if (fields.targetCellHeight) {
+    attrs['android:targetCellHeight'] = String(fields.targetCellHeight);
+  }
+
+  return attrs;
+}
+
+const ATTR_RE = /([A-Za-z_:][A-Za-z0-9_:]*)="([^"]*)"/g;
+
+function parseAppWidgetProviderAttributes(xml: string): Record<string, string> {
+  const match = xml.match(/<appwidget-provider\b([^>]*)\/?>/s);
+  if (!match) {
+    return {};
+  }
+  const attrs: Record<string, string> = {};
+  const body = match[1] ?? '';
+  for (const part of body.matchAll(ATTR_RE)) {
+    const name = part[1];
+    const value = part[2];
+    if (name && value !== undefined) {
+      attrs[name] = value;
+    }
+  }
+  return attrs;
+}
+
+function formatAppWidgetProviderXml(attrs: Record<string, string>): string {
+  const lines = Object.entries(attrs).map(
+    ([name, value]) => `    ${name}="${value}"`
+  );
+  return `<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+${lines.join('\n')}>
+</appwidget-provider>
+`;
+}
+
+export function mergeAppWidgetProviderXml(
+  existing: string | null,
+  generated: Record<string, string>
+): string {
+  const current = existing ? parseAppWidgetProviderAttributes(existing) : {};
+  return formatAppWidgetProviderXml({ ...current, ...generated });
+}
+
+export function xmlFieldsFromProvider(
+  provider: ResolvedAndroidWidgetProvider
+): WidgetProviderXmlFields {
+  return {
+    minWidth: provider.minWidth,
+    minHeight: provider.minHeight,
+    resizeMode: provider.resizeMode,
+    updatePeriodMillis: provider.updatePeriodMillis,
+    widgetCategory: provider.widgetCategory,
+    initialLayout: provider.initialLayout,
+    previewImage: provider.previewImage,
+    descriptionStringName: provider.descriptionStringName,
+    maxResizeWidth: provider.maxResizeWidth,
+    maxResizeHeight: provider.maxResizeHeight,
+    targetCellWidth: provider.targetCellWidth,
+    targetCellHeight: provider.targetCellHeight,
+  };
+}

--- a/packages/expo-targets/plugin/src/android/withAndroidWidget.ts
+++ b/packages/expo-targets/plugin/src/android/withAndroidWidget.ts
@@ -10,21 +10,19 @@ import {
   withStringsXml,
 } from '@expo/config-plugins';
 import type { AndroidTargetConfig, Color } from '../config';
+import {
+  buildAppWidgetProviderXml,
+  mergeAppWidgetProviderXml,
+  type ResolvedAndroidWidgetProvider,
+  resolveAndroidWidgetProviders,
+  sanitizeWidgetResourceName,
+  toWidgetNamePascal,
+  xmlFieldsFromProvider,
+} from './resolveAndroidWidgetProviders';
 import { addWidgetSourceSets } from './widgetSourceSets';
 
-/**
- * Sanitize widget name for Android resource names.
- * Android resource names can only contain lowercase a-z, 0-9, or underscore.
- */
 function sanitizeResourceName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9_]/g, '_');
-}
-
-function toWidgetNamePascal(name: string): string {
-  return (
-    name.charAt(0).toUpperCase() +
-    name.slice(1).replace(/[-_]([a-z])/g, (_, letter) => letter.toUpperCase())
-  );
+  return sanitizeWidgetResourceName(name);
 }
 
 interface WidgetProps {
@@ -34,14 +32,6 @@ interface WidgetProps {
   platforms: string[];
   android?: AndroidTargetConfig;
   directory: string;
-}
-
-interface WidgetReceiverContext {
-  mainApplication: any;
-  packageName: string;
-  props: WidgetProps;
-  widgetNameLower: string;
-  widgetNamePascal: string;
 }
 
 function configureGlanceBuild(config: any, props: WidgetProps) {
@@ -82,20 +72,27 @@ function configureWidgetManifest(config: any, props: WidgetProps) {
 
 function configureWidgetDescription(
   config: any,
-  props: WidgetProps,
-  description: string
+  providers: ResolvedAndroidWidgetProvider[]
 ) {
+  const items = providers
+    .filter(
+      (provider) => provider.description && provider.descriptionStringName
+    )
+    .map((provider) => ({
+      $: {
+        name: provider.descriptionStringName as string,
+        translatable: 'false' as const,
+      },
+      _: (provider.description as string).replace(/'/g, "\\'"),
+    }));
+
+  if (items.length === 0) {
+    return config;
+  }
+
   return withStringsXml(config, (stringsConfig) => {
     stringsConfig.modResults = AndroidConfig.Strings.setStringItem(
-      [
-        {
-          $: {
-            name: `widget_${sanitizeResourceName(props.name)}_description`,
-            translatable: 'false',
-          },
-          _: description.replace(/'/g, "\\'"),
-        },
-      ],
+      items,
       stringsConfig.modResults
     );
     return stringsConfig;
@@ -124,6 +121,15 @@ function configureWidgetResources(
 export const withAndroidWidget: ConfigPlugin<WidgetProps> = (config, props) => {
   const androidConfig = props.android || {};
   const widgetType = androidConfig.widgetType || 'glance';
+  const packageName = config.android?.package;
+  const providers = packageName
+    ? resolveAndroidWidgetProviders({
+        packageName,
+        targetName: props.name,
+        displayName: props.displayName,
+        android: androidConfig,
+      })
+    : [];
 
   if (widgetType === 'glance') {
     config = configureGlanceBuild(config, props);
@@ -133,13 +139,7 @@ export const withAndroidWidget: ConfigPlugin<WidgetProps> = (config, props) => {
 
   config = configureWidgetManifest(config, props);
 
-  if (androidConfig?.description) {
-    config = configureWidgetDescription(
-      config,
-      props,
-      androidConfig.description
-    );
-  }
+  config = configureWidgetDescription(config, providers);
 
   config = configureWidgetResources(config, props, androidConfig);
 
@@ -344,40 +344,34 @@ function addWidgetReceiver(
   }
 
   const widgetType = props.android?.widgetType || 'glance';
-  const widgetNameLower = sanitizeResourceName(props.name);
-  const widgetNamePascal = toWidgetNamePascal(props.name);
-  const receiverContext: WidgetReceiverContext = {
-    mainApplication,
+  const providers = resolveAndroidWidgetProviders({
     packageName,
-    props,
-    widgetNameLower,
-    widgetNamePascal,
-  };
+    targetName: props.name,
+    displayName: props.displayName,
+    android: props.android,
+  });
 
   if (widgetType === 'remoteviews') {
-    const providerClassName = `${packageName}.widget.${widgetNameLower}.${widgetNamePascal}Provider`;
-    registerAppWidgetProvider(mainApplication, providerClassName, props);
+    for (const provider of providers) {
+      registerAppWidgetProvider(mainApplication, provider);
+    }
     return;
   }
 
-  registerGlanceReceiver(receiverContext);
-  registerUpdateReceiver(receiverContext);
+  for (const provider of providers) {
+    registerGlanceReceiver(mainApplication, provider);
+  }
+  registerUpdateReceiver(mainApplication, packageName, props);
 }
 
-function registerGlanceReceiver(context: WidgetReceiverContext) {
-  const {
-    mainApplication,
-    packageName,
-    props,
-    widgetNameLower,
-    widgetNamePascal,
-  } = context;
+function registerGlanceReceiver(
+  mainApplication: any,
+  provider: ResolvedAndroidWidgetProvider
+) {
   mainApplication.receiver = mainApplication.receiver || [];
 
-  const widgetClassName = `${packageName}.widget.${widgetNameLower}.${widgetNamePascal}WidgetReceiver`;
-
   const alreadyAdded = mainApplication.receiver.some(
-    (r: any) => r.$['android:name'] === widgetClassName
+    (r: any) => r.$['android:name'] === provider.className
   );
 
   if (alreadyAdded) {
@@ -386,9 +380,9 @@ function registerGlanceReceiver(context: WidgetReceiverContext) {
 
   mainApplication.receiver.push({
     $: {
-      'android:name': widgetClassName,
+      'android:name': provider.className,
       'android:exported': 'true',
-      'android:label': props.displayName || props.name,
+      'android:label': provider.displayName,
     },
     'intent-filter': [
       {
@@ -403,18 +397,22 @@ function registerGlanceReceiver(context: WidgetReceiverContext) {
       {
         $: {
           'android:name': 'android.appwidget.provider',
-          'android:resource': `@xml/widgetprovider_${widgetNameLower}`,
+          'android:resource': `@xml/${provider.xmlName}`,
         },
       },
     ],
   });
 }
 
-function registerUpdateReceiver(context: WidgetReceiverContext) {
-  const { mainApplication, packageName, widgetNameLower, widgetNamePascal } =
-    context;
+function registerUpdateReceiver(
+  mainApplication: any,
+  packageName: string,
+  props: WidgetProps
+) {
   mainApplication.receiver = mainApplication.receiver || [];
 
+  const widgetNameLower = sanitizeResourceName(props.name);
+  const widgetNamePascal = toWidgetNamePascal(props.name);
   const updateReceiverClassName = `${packageName}.widget.${widgetNameLower}.${widgetNamePascal}UpdateReceiver`;
 
   const updateReceiverAdded = mainApplication.receiver.some(
@@ -442,14 +440,12 @@ function registerUpdateReceiver(context: WidgetReceiverContext) {
 
 function registerAppWidgetProvider(
   mainApplication: any,
-  providerClassName: string,
-  props: WidgetProps
+  provider: ResolvedAndroidWidgetProvider
 ) {
   mainApplication.receiver = mainApplication.receiver || [];
 
-  const widgetNameLower = sanitizeResourceName(props.name);
   const alreadyAdded = mainApplication.receiver.some(
-    (r: any) => r.$['android:name'] === providerClassName
+    (r: any) => r.$['android:name'] === provider.className
   );
 
   if (alreadyAdded) {
@@ -458,9 +454,9 @@ function registerAppWidgetProvider(
 
   mainApplication.receiver.push({
     $: {
-      'android:name': providerClassName,
+      'android:name': provider.className,
       'android:exported': 'true',
-      'android:label': props.displayName || props.name,
+      'android:label': provider.displayName,
     },
     'intent-filter': [
       {
@@ -478,104 +474,36 @@ function registerAppWidgetProvider(
       {
         $: {
           'android:name': 'android.appwidget.provider',
-          'android:resource': `@xml/widgetprovider_${widgetNameLower}`,
+          'android:resource': `@xml/${provider.xmlName}`,
         },
       },
     ],
   });
 }
 
-function getPreviewImageAttribute(
-  androidConfig: AndroidTargetConfig,
-  props: WidgetProps
-): string {
-  if (!androidConfig.previewImage) {
-    return '';
-  }
-  const previewImageName =
-    typeof androidConfig.previewImage === 'string'
-      ? androidConfig.previewImage
-      : `${sanitizeResourceName(props.name)}_preview`;
-  return `\n    android:previewImage="@drawable/${previewImageName}"`;
-}
-
-function getDescriptionAttribute(
-  androidConfig: AndroidTargetConfig,
-  props: WidgetProps
-): string {
-  if (!androidConfig.description) {
-    return '';
-  }
-  return `\n    android:description="@string/widget_${sanitizeResourceName(props.name)}_description"`;
-}
-
-function getResizeAttribute(
-  androidConfig: AndroidTargetConfig,
-  attribute: 'maxResizeWidth' | 'maxResizeHeight'
-): string {
-  const value = androidConfig[attribute];
-  if (!value) {
-    return '';
-  }
-  return `\n    android:${attribute}="${value}"`;
-}
-
-function getCellAttribute(
-  androidConfig: AndroidTargetConfig,
-  attribute: 'targetCellWidth' | 'targetCellHeight'
-): string {
-  const value = androidConfig[attribute];
-  if (!value) {
-    return '';
-  }
-  return `\n    android:${attribute}="${value}"`;
-}
-
-function buildWidgetInfoXml(
-  androidConfig: AndroidTargetConfig,
-  props: WidgetProps
-): string {
-  const minWidth = androidConfig.minWidth || '180dp';
-  const minHeight = androidConfig.minHeight || '110dp';
-  const resizeMode = androidConfig.resizeMode || 'horizontal|vertical';
-  const updatePeriodMillis = androidConfig.updatePeriodMillis || 0;
-  const widgetCategory = androidConfig.widgetCategory || 'home_screen';
-  const layoutName =
-    androidConfig.initialLayout || `widget_${sanitizeResourceName(props.name)}`;
-
-  const header = `<?xml version="1.0" encoding="utf-8"?>
-<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="${minWidth}"
-    android:minHeight="${minHeight}"
-    android:resizeMode="${resizeMode}"
-    android:updatePeriodMillis="${updatePeriodMillis}"
-    android:widgetCategory="${widgetCategory}"
-    android:initialLayout="@layout/${layoutName}"`;
-
-  const optionalAttributes = [
-    getPreviewImageAttribute(androidConfig, props),
-    getDescriptionAttribute(androidConfig, props),
-    getResizeAttribute(androidConfig, 'maxResizeWidth'),
-    getResizeAttribute(androidConfig, 'maxResizeHeight'),
-    getCellAttribute(androidConfig, 'targetCellWidth'),
-    getCellAttribute(androidConfig, 'targetCellHeight'),
-  ].join('');
-
-  return `${header}${optionalAttributes}>\n</appwidget-provider>`;
-}
-
 function generateWidgetResources(platformRoot: string, props: WidgetProps) {
-  const androidConfig = props.android || {};
   const projectRoot = platformRoot.replace(/\/android$/, '');
   const xmlDir = path.join(projectRoot, props.directory, 'android/res/xml');
   fs.mkdirSync(xmlDir, { recursive: true });
 
-  const widgetInfo = buildWidgetInfoXml(androidConfig, props);
+  const providers = resolveAndroidWidgetProviders({
+    packageName: 'placeholder',
+    targetName: props.name,
+    displayName: props.displayName,
+    android: props.android,
+  });
 
-  fs.writeFileSync(
-    path.join(xmlDir, `widgetprovider_${sanitizeResourceName(props.name)}.xml`),
-    widgetInfo
-  );
+  for (const provider of providers) {
+    const xmlPath = path.join(xmlDir, `${provider.xmlName}.xml`);
+    const existing = fs.existsSync(xmlPath)
+      ? fs.readFileSync(xmlPath, 'utf8')
+      : null;
+    const xml = mergeAppWidgetProviderXml(
+      existing,
+      buildAppWidgetProviderXml(xmlFieldsFromProvider(provider))
+    );
+    fs.writeFileSync(xmlPath, xml);
+  }
 }
 
 function removeConflictingLayout(
@@ -626,25 +554,34 @@ function generateDefaultLayoutIfNeeded(
   props: WidgetProps,
   androidConfig: AndroidTargetConfig
 ) {
-  if (androidConfig.initialLayout) {
-    return;
-  }
-
   const projectRoot = platformRoot.replace(/\/android$/, '');
-  const layoutName = `widget_${sanitizeResourceName(props.name)}`;
-  const userLayoutPath = path.join(
-    projectRoot,
-    props.directory,
-    'android/layouts/layout',
-    `${layoutName}.xml`
-  );
+  const providers = resolveAndroidWidgetProviders({
+    packageName: 'placeholder',
+    targetName: props.name,
+    displayName: props.displayName,
+    android: androidConfig,
+  });
 
-  if (fs.existsSync(userLayoutPath)) {
-    removeConflictingLayout(projectRoot, props, layoutName);
-    return;
+  for (const provider of providers) {
+    if (provider.hasExplicitLayout) {
+      continue;
+    }
+
+    const layoutName = provider.initialLayout;
+    const userLayoutPath = path.join(
+      projectRoot,
+      props.directory,
+      'android/layouts/layout',
+      `${layoutName}.xml`
+    );
+
+    if (fs.existsSync(userLayoutPath)) {
+      removeConflictingLayout(projectRoot, props, layoutName);
+      continue;
+    }
+
+    writeDefaultLayout(projectRoot, props, layoutName);
   }
-
-  writeDefaultLayout(projectRoot, props, layoutName);
 }
 
 interface ColorEntryResult {

--- a/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.ts
+++ b/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.ts
@@ -1,3 +1,5 @@
+import { resolveLiveActivityConfig } from '../ios/utils/resolveIosKinds';
+
 export type LiveActivityFieldType = 'string' | 'double' | 'int' | 'bool';
 
 export interface RuntimeTargetConfig {
@@ -12,6 +14,7 @@ export interface RuntimeTargetConfig {
     contentState?: Record<string, LiveActivityFieldType>;
   };
   ios?: {
+    kinds?: import('../config').IosKindConfig[];
     intents?: { ui?: boolean | { name?: string } };
     wallet?: { ui?: boolean | { name?: string } };
   };
@@ -68,7 +71,12 @@ export function collectRuntimeConfigs(
 
   for (const { config: evaluatedConfig } of targets) {
     const appGroup = resolveAppGroup(evaluatedConfig, expoConfig);
-    const withGroup = { ...evaluatedConfig, appGroup };
+    const liveActivity = resolveLiveActivityConfig(evaluatedConfig);
+    const withGroup = {
+      ...evaluatedConfig,
+      appGroup,
+      liveActivity: liveActivity ?? evaluatedConfig.liveActivity,
+    };
 
     if (evaluatedConfig.type === 'intent') {
       pushCompanionUi({

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -342,6 +342,11 @@ interface BaseIosTargetConfig {
   supportedFamilies?: WidgetFamily[];
   /** Disable default WidgetKit content margins (expo-ui). */
   contentMarginsDisabled?: boolean;
+  /**
+   * WidgetKit picker products plus at most one live-activity row.
+   * When omitted or empty, one widget uses `name` + scalar ios fields.
+   */
+  kinds?: IosKindConfig[];
 }
 
 /** WidgetKit family names (expo-ui supportedFamilies). */
@@ -400,6 +405,24 @@ export interface LiveActivityConfig {
   pushType?: 'token' | null;
 }
 
+/** Gallery WidgetKit picker product (`createTarget` name = Swift struct). */
+export interface IosWidgetKindConfig {
+  type?: 'widget';
+  name: string;
+  displayName?: string;
+  description?: string;
+  supportedFamilies?: WidgetFamily[];
+  contentMarginsDisabled?: boolean;
+  configuration?: WidgetConfiguration;
+}
+
+/** ActivityKit row. Adds `WidgetLiveActivity()` on expo-ui Bundles. At most one. */
+export type IosLiveActivityKindConfig = LiveActivityConfig & {
+  type: 'live-activity';
+};
+
+export type IosKindConfig = IosWidgetKindConfig | IosLiveActivityKindConfig;
+
 export interface AppIntentHostConfig {
   className: string;
   title: string;
@@ -438,6 +461,32 @@ export type IOSTargetConfig =
   | IOSTargetConfigWithReactNative
   | IOSTargetConfigNativeOnly;
 
+/** One AppWidgetProvider / picker row. Scalar `android.*` is the 1:1 default. */
+export interface AndroidWidgetProviderConfig {
+  /** Identity for xml (`widgetprovider_<sanitized>`) and default class names. */
+  name: string;
+  /** Widget picker label. */
+  displayName?: string;
+  /**
+   * AppWidgetProvider FQCN, or a simple class name under
+   * `{package}.widget.{sanitizedTarget}`. Placed widgets bind to FQCN — keep
+   * this stable when you colocate several providers in one target.
+   */
+  className?: string;
+  minWidth?: string;
+  minHeight?: string;
+  resizeMode?: string;
+  updatePeriodMillis?: number;
+  widgetCategory?: string;
+  previewImage?: string;
+  description?: string;
+  maxResizeWidth?: string;
+  maxResizeHeight?: string;
+  targetCellWidth?: number;
+  targetCellHeight?: number;
+  initialLayout?: string;
+}
+
 export interface AndroidTargetConfig {
   resourceName?: string;
   /**
@@ -446,6 +495,11 @@ export interface AndroidTargetConfig {
    * - 'remoteviews': Traditional XML layout-based widgets using RemoteViews
    */
   widgetType?: 'glance' | 'remoteviews';
+  /**
+   * Opt-in list of AppWidgetProvider rows (picker + FQCN). When omitted or
+   * empty, the plugin registers one provider from the scalar fields below.
+   */
+  providers?: AndroidWidgetProviderConfig[];
   // Widget-specific configuration
   minWidth?: string;
   minHeight?: string;
@@ -503,10 +557,6 @@ interface BaseTargetConfig {
   appGroup?: string;
   platforms: string[];
   android?: AndroidTargetConfig;
-  /**
-   * Live Activity schema (type='widget'). Drives CNG ActivityAttributes + host bridge.
-   */
-  liveActivity?: LiveActivityConfig;
   /**
    * UI authoring mode. Defaults: share-class + `entry` → `react-native`;
    * `widget`/`watch-widget` + `entry` → `expo-ui`; no `entry` → `native`.

--- a/packages/expo-targets/plugin/src/index.ts
+++ b/packages/expo-targets/plugin/src/index.ts
@@ -7,8 +7,10 @@ import { withTargetsDir } from './withTargetsDir';
 export type { ExpoConfig } from '@expo/config-types';
 // Export types for use in config files
 export type {
+  AndroidWidgetProviderConfig,
   AppIntentHostConfig,
   AppShortcutConfig,
+  IosKindConfig,
   LiveActivityConfig,
   TargetConfig,
   TargetConfigFunction,

--- a/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
+++ b/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
@@ -9,7 +9,6 @@ import {
 import type {
   AppIntentHostConfig,
   AppShortcutConfig,
-  LiveActivityConfig,
   TargetConfig,
 } from '../../config';
 import {
@@ -20,6 +19,7 @@ import {
   getProjectName,
 } from '../apply/pbx';
 import * as Paths from '../utils/paths';
+import { resolveLiveActivityConfig } from '../utils/resolveIosKinds';
 import {
   generateAppIntentShellSwift,
   generateAppShortcutsProviderSwift,
@@ -52,14 +52,17 @@ function pushLiveActivityPlans(
   plans: GeneratedFilePlan[],
   target: TargetConfig
 ): void {
-  if (!(target.type === 'widget' && target.liveActivity?.attributesName)) {
+  if (!(target.type === 'widget')) {
+    return;
+  }
+  const la = resolveLiveActivityConfig(target);
+  if (!la?.attributesName) {
     return;
   }
   // expo-ui widgets use WidgetLiveActivity blob attrs — skip typed CNG.
   if (target.entry) {
     return;
   }
-  const la = target.liveActivity as LiveActivityConfig;
   plans.push({
     fileName: `${la.attributesName}.swift`,
     contents: generateLiveActivityAttributesSwift(la),

--- a/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
@@ -2,6 +2,11 @@ import path from 'node:path';
 
 import { resolveUiMode } from '../../domain/uiMode';
 import type { TargetWorkspace } from '../observe/workspace';
+import {
+  hasExplicitGalleryKinds,
+  resolveGalleryWidgetKinds,
+  resolveLiveActivityConfig,
+} from '../utils/resolveIosKinds';
 import type {
   IOSTargetProps,
   SwiftFilePlan,
@@ -61,7 +66,15 @@ function ensureNamed(files: string[], name: string): void {
 
 function resolveEntryOnlySwiftFiles(props: IOSTargetProps): string[] {
   if (isExpoUiWidget(props)) {
-    return [`${props.name}.swift`, `${props.name}Bundle.swift`];
+    const kinds = resolveGalleryWidgetKinds({
+      targetName: props.name,
+      displayName: props.displayName,
+      ios: props,
+    });
+    return [
+      ...kinds.map((kind) => `${kind.name}.swift`),
+      `${props.name}Bundle.swift`,
+    ];
   }
   if (props.type === 'messages') {
     return [MESSAGES_VIEW_CONTROLLER, REACT_NATIVE_VIEW_CONTROLLER];
@@ -80,6 +93,13 @@ function resolveSwiftFileNames(
 
   if (props.type === 'safari') {
     ensureNamed(files, SAFARI_HANDLER);
+    return files;
+  }
+
+  if (isExpoUiWidget(props) && props.entry) {
+    for (const name of resolveEntryOnlySwiftFiles(props)) {
+      ensureNamed(files, name);
+    }
     return files;
   }
 
@@ -182,6 +202,64 @@ function planUserFile({
   return { file, sourcePath };
 }
 
+function planExpoUiKindFile(
+  file: string,
+  workspace: TargetWorkspace,
+  kind: ReturnType<typeof resolveGalleryWidgetKinds>[number]
+): UnresolvedSwiftFilePlan {
+  return planGeneratedFile({
+    file,
+    fileName: `${kind.name}.swift`,
+    hasUserFile: workspace.swiftFiles.some((f) =>
+      isNamed(f, `${kind.name}.swift`)
+    ),
+    workspace,
+    template: {
+      template: 'expoUiWidget',
+      options: {
+        name: kind.name,
+        displayName: kind.displayName,
+        description:
+          kind.description ??
+          (kind.displayName ? `${kind.displayName} (expo-ui)` : undefined),
+        supportedFamilies: kind.supportedFamilies,
+        contentMarginsDisabled: kind.contentMarginsDisabled,
+        configuration: kind.configuration,
+      },
+    },
+  });
+}
+
+function planExpoUiBundleFile(opts: {
+  file: string;
+  workspace: TargetWorkspace;
+  props: IOSTargetProps;
+  kinds: ReturnType<typeof resolveGalleryWidgetKinds>;
+}): UnresolvedSwiftFilePlan {
+  const { file, workspace, props, kinds } = opts;
+  const forceSealedBundle = hasExplicitGalleryKinds(props);
+  return planGeneratedFile({
+    file,
+    fileName: `${props.name}Bundle.swift`,
+    hasUserFile:
+      !forceSealedBundle &&
+      workspace.swiftFiles.some((f) => isNamed(f, `${props.name}Bundle.swift`)),
+    workspace,
+    template: {
+      template: 'expoUiWidgetBundle',
+      options: {
+        name: props.name,
+        widgets: kinds.map((row) => ({
+          name: row.name,
+          configurable: Boolean(row.configuration),
+        })),
+        includeLiveActivity: Boolean(resolveLiveActivityConfig({ ios: props })),
+        configurable: kinds.some((row) => Boolean(row.configuration)),
+      },
+    },
+  });
+}
+
 function planExpoUiWidgetSwiftFile({
   file,
   workspace,
@@ -195,47 +273,17 @@ function planExpoUiWidgetSwiftFile({
     return;
   }
 
-  if (isNamed(file, `${props.name}.swift`)) {
-    return planGeneratedFile({
-      file,
-      fileName: `${props.name}.swift`,
-      hasUserFile: workspace.swiftFiles.some((f) =>
-        isNamed(f, `${props.name}.swift`)
-      ),
-      workspace,
-      template: {
-        template: 'expoUiWidget',
-        options: {
-          name: props.name,
-          displayName: props.displayName,
-          description: props.displayName
-            ? `${props.displayName} (expo-ui)`
-            : undefined,
-          supportedFamilies: props.supportedFamilies,
-          contentMarginsDisabled: props.contentMarginsDisabled,
-          configuration: props.configuration,
-        },
-      },
-    });
+  const kinds = resolveGalleryWidgetKinds({
+    targetName: props.name,
+    displayName: props.displayName,
+    ios: props,
+  });
+  const kind = kinds.find((row) => isNamed(file, `${row.name}.swift`));
+  if (kind) {
+    return planExpoUiKindFile(file, workspace, kind);
   }
-
   if (isNamed(file, `${props.name}Bundle.swift`)) {
-    return planGeneratedFile({
-      file,
-      fileName: `${props.name}Bundle.swift`,
-      hasUserFile: workspace.swiftFiles.some((f) =>
-        isNamed(f, `${props.name}Bundle.swift`)
-      ),
-      workspace,
-      template: {
-        template: 'expoUiWidgetBundle',
-        options: {
-          name: props.name,
-          includeLiveActivity: Boolean(props.liveActivity),
-          configurable: Boolean(props.configuration),
-        },
-      },
-    });
+    return planExpoUiBundleFile({ file, workspace, props, kinds });
   }
 }
 

--- a/packages/expo-targets/plugin/src/ios/plan/types.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/types.ts
@@ -97,6 +97,7 @@ export type SwiftTemplatePlan =
         name: string;
         includeLiveActivity?: boolean;
         configurable?: boolean;
+        widgets?: { name: string; configurable?: boolean }[];
       };
     };
 

--- a/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 
-import { generateExpoUiWidgetSwift } from './expoUiWidgetSwift';
+import {
+  generateExpoUiWidgetBundleSwift,
+  generateExpoUiWidgetSwift,
+} from './expoUiWidgetSwift';
 
 describe('generateExpoUiWidgetSwift', () => {
   test('static configuration by default', () => {
@@ -28,5 +31,18 @@ describe('generateExpoUiWidgetSwift', () => {
     expect(src).toContain('HelloExpoUiConfigurationAppIntent');
     expect(src).toContain('env["configuration"]');
     expect(src).toContain('"listId"');
+  });
+});
+
+describe('generateExpoUiWidgetBundleSwift', () => {
+  test('lists every gallery kind plus WidgetLiveActivity', () => {
+    const src = generateExpoUiWidgetBundleSwift({
+      name: 'HomescreenWidgets',
+      widgets: [{ name: 'HomescreenWidgets' }, { name: 'LockScreenWidgets' }],
+      includeLiveActivity: true,
+    });
+    expect(src).toContain('HomescreenWidgets()');
+    expect(src).toContain('LockScreenWidgets()');
+    expect(src).toContain('WidgetLiveActivity()');
   });
 });

--- a/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.ts
@@ -266,34 +266,42 @@ struct ${options.name}: Widget {
 
 export function generateExpoUiWidgetBundleSwift(options: {
   name: string;
+  /** Gallery Widget structs to instantiate (kind names). */
+  widgets?: { name: string; configurable?: boolean }[];
   /** When true, include expo-widgets WidgetLiveActivity() for expo-ui LA slots. */
   includeLiveActivity?: boolean;
   /** Wrap home widget in iOS 17 availability (configurable AppIntent). */
   configurable?: boolean;
 }): string {
+  const widgets =
+    options.widgets && options.widgets.length > 0
+      ? options.widgets
+      : [{ name: options.name, configurable: Boolean(options.configurable) }];
+
+  const widgetLines = widgets
+    .map((widget) => {
+      if (widget.configurable) {
+        return `    if #available(iOS 17.0, *) {
+      ${widget.name}()
+    }`;
+      }
+      return `    ${widget.name}()`;
+    })
+    .join('\n');
+
   const liveLine = options.includeLiveActivity
     ? '\n    WidgetLiveActivity()'
     : '';
 
-  if (options.configurable) {
-    return `import WidgetKit
+  return `import WidgetKit
 import SwiftUI
 internal import ExpoWidgets
 
 @main
 struct ${options.name}Bundle: WidgetBundle {
   var body: some Widget {
-    if #available(iOS 17.0, *) {
-      ${options.name}()
-    }${liveLine}
+${widgetLines}${liveLine}
   }
 }
 `;
-  }
-
-  return loadTemplate('ExpoUiWidgetBundle.swift')
-    .split('{{NAME}}')
-    .join(options.name)
-    .split('{{LIVE_ACTIVITY}}')
-    .join(liveLine);
 }

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  hasExplicitGalleryKinds,
+  resolveGalleryWidgetKinds,
+  resolveLiveActivityConfig,
+} from './resolveIosKinds';
+
+describe('resolveGalleryWidgetKinds 1:1', () => {
+  test('omitted kinds uses the target name as one widget', () => {
+    const [kind] = resolveGalleryWidgetKinds({
+      targetName: 'HelloExpoUi',
+      displayName: 'Hello Expo UI',
+      ios: { supportedFamilies: ['systemSmall'] },
+    });
+    expect(kind.name).toBe('HelloExpoUi');
+    expect(kind.displayName).toBe('Hello Expo UI');
+    expect(kind.supportedFamilies).toEqual(['systemSmall']);
+  });
+});
+
+describe('resolveGalleryWidgetKinds list', () => {
+  test('kinds is the full gallery list', () => {
+    const kinds = resolveGalleryWidgetKinds({
+      targetName: 'HomescreenWidgets',
+      ios: {
+        kinds: [
+          {
+            name: 'HomescreenWidgets',
+            supportedFamilies: ['systemSmall', 'systemMedium', 'systemLarge'],
+          },
+          {
+            name: 'LockScreenWidgets',
+            displayName: 'Lock QR',
+            supportedFamilies: ['accessoryCircular', 'accessoryRectangular'],
+          },
+          {
+            type: 'live-activity',
+            attributesName: 'DynamicIslandAttributes',
+            contentState: { views: 'string' },
+          },
+        ],
+      },
+    });
+    expect(kinds.map((k) => k.name)).toEqual([
+      'HomescreenWidgets',
+      'LockScreenWidgets',
+    ]);
+    expect(kinds[1]?.displayName).toBe('Lock QR');
+  });
+
+  test('duplicate widget names throw', () => {
+    expect(() =>
+      resolveGalleryWidgetKinds({
+        targetName: 'W',
+        ios: { kinds: [{ name: 'A' }, { name: 'A' }] },
+      })
+    ).toThrow(/A/);
+  });
+});
+
+describe('resolveLiveActivityConfig', () => {
+  test('reads attributes from a live-activity kind', () => {
+    const la = resolveLiveActivityConfig({
+      ios: {
+        kinds: [
+          { name: 'Home' },
+          {
+            type: 'live-activity',
+            attributesName: 'HelloExpoUiAttributes',
+            static: { title: 'string' },
+            contentState: { status: 'string' },
+            pushType: 'token',
+          },
+        ],
+      },
+    });
+    expect(la?.attributesName).toBe('HelloExpoUiAttributes');
+    expect(la?.pushType).toBe('token');
+  });
+
+  test('two live-activity kinds throw', () => {
+    expect(() =>
+      resolveLiveActivityConfig({
+        ios: {
+          kinds: [
+            {
+              type: 'live-activity',
+              attributesName: 'A',
+              contentState: { s: 'string' },
+            },
+            {
+              type: 'live-activity',
+              attributesName: 'B',
+              contentState: { s: 'string' },
+            },
+          ],
+        },
+      })
+    ).toThrow(/at most one/);
+  });
+
+  test('omitted kinds has no live activity', () => {
+    expect(resolveLiveActivityConfig({ ios: {} })).toBeUndefined();
+  });
+});
+
+describe('hasExplicitGalleryKinds', () => {
+  test('true when a widget kind is listed', () => {
+    expect(hasExplicitGalleryKinds({ kinds: [{ name: 'Home' }] })).toBe(true);
+  });
+
+  test('false for live-activity-only kinds', () => {
+    expect(
+      hasExplicitGalleryKinds({
+        kinds: [
+          {
+            type: 'live-activity',
+            attributesName: 'A',
+            contentState: { s: 'string' },
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
@@ -1,0 +1,132 @@
+import type {
+  IosKindConfig,
+  IosLiveActivityKindConfig,
+  IosWidgetKindConfig,
+  LiveActivityConfig,
+  WidgetConfiguration,
+  WidgetFamily,
+} from '../../config';
+
+export function isLiveActivityKind(
+  kind: IosKindConfig
+): kind is IosLiveActivityKindConfig {
+  return kind.type === 'live-activity';
+}
+
+export function isWidgetKind(kind: IosKindConfig): kind is IosWidgetKindConfig {
+  return kind.type !== 'live-activity';
+}
+
+type IosKindSource = {
+  kinds?: IosKindConfig[];
+  displayName?: string;
+  supportedFamilies?: WidgetFamily[];
+  contentMarginsDisabled?: boolean;
+  configuration?: WidgetConfiguration;
+};
+
+export type ResolveIosKindsInput = {
+  targetName: string;
+  displayName?: string;
+  ios?: IosKindSource;
+};
+
+export type ResolvedIosWidgetKind = {
+  name: string;
+  displayName: string;
+  description?: string;
+  supportedFamilies?: WidgetFamily[];
+  contentMarginsDisabled?: boolean;
+  configuration?: WidgetConfiguration;
+};
+
+function explicitKinds(ios?: IosKindSource): IosKindConfig[] | undefined {
+  const listed = ios?.kinds;
+  if (!listed || listed.length === 0) {
+    return;
+  }
+  return listed;
+}
+
+export function resolveLiveActivityConfig(input: {
+  ios?: IosKindSource;
+}): LiveActivityConfig | undefined {
+  const listed = explicitKinds(input.ios);
+  if (!listed) {
+    return;
+  }
+  const live = listed.filter(isLiveActivityKind);
+  if (live.length > 1) {
+    throw new Error(
+      'ios.kinds may contain at most one { "type": "live-activity" } row'
+    );
+  }
+  const row = live[0];
+  if (!row) {
+    return;
+  }
+  return {
+    attributesName: row.attributesName,
+    static: row.static,
+    contentState: row.contentState,
+    pushType: row.pushType,
+  };
+}
+
+function widgetRowsForTarget(
+  input: ResolveIosKindsInput,
+  listed: IosKindConfig[] | undefined
+): IosWidgetKindConfig[] {
+  if (listed) {
+    return listed.filter(isWidgetKind);
+  }
+  return [
+    {
+      name: input.targetName,
+      displayName: input.displayName ?? input.ios?.displayName,
+    },
+  ];
+}
+
+function resolveOneGalleryKind(opts: {
+  row: IosWidgetKindConfig;
+  ios: IosKindSource;
+  input: ResolveIosKindsInput;
+  listed: IosKindConfig[] | undefined;
+}): ResolvedIosWidgetKind {
+  const { row, ios, input, listed } = opts;
+  return {
+    name: row.name,
+    displayName:
+      row.displayName || ios.displayName || input.displayName || row.name,
+    description: row.description,
+    supportedFamilies: row.supportedFamilies ?? ios.supportedFamilies,
+    contentMarginsDisabled:
+      row.contentMarginsDisabled ?? ios.contentMarginsDisabled,
+    configuration: listed
+      ? row.configuration
+      : (row.configuration ?? ios.configuration),
+  };
+}
+
+export function resolveGalleryWidgetKinds(
+  input: ResolveIosKindsInput
+): ResolvedIosWidgetKind[] {
+  const ios = input.ios || {};
+  const listed = explicitKinds(ios);
+  const widgetRows = widgetRowsForTarget(input, listed);
+  const seen = new Set<string>();
+  const resolved: ResolvedIosWidgetKind[] = [];
+  for (const row of widgetRows) {
+    if (seen.has(row.name)) {
+      throw new Error(`Duplicate ios.kinds widget name "${row.name}"`);
+    }
+    seen.add(row.name);
+    resolved.push(resolveOneGalleryKind({ row, ios, input, listed }));
+  }
+  return resolved;
+}
+
+export function hasExplicitGalleryKinds(ios?: IosKindSource): boolean {
+  return Boolean(explicitKinds(ios)?.some(isWidgetKind));
+}

--- a/packages/expo-targets/plugin/src/withTargetsDir.ts
+++ b/packages/expo-targets/plugin/src/withTargetsDir.ts
@@ -15,6 +15,7 @@ import {
   warnMissingMetroWrapper,
 } from './ensureHostAppGroups';
 import { withIOSTarget } from './ios/config-plugins/withIOSTarget';
+import { resolveLiveActivityConfig } from './ios/utils/resolveIosKinds';
 import { Logger } from './logger';
 import { resolveExcludedPackages } from './resolveExcludedPackages';
 
@@ -307,7 +308,7 @@ const withTargetIos: ConfigPlugin<{
     appGroup: evaluatedConfig.appGroup,
     entry: evaluatedConfig.entry,
     ui: evaluatedConfig.ui,
-    liveActivity: evaluatedConfig.liveActivity,
+    liveActivity: resolveLiveActivityConfig(evaluatedConfig),
     excludedPackages,
     runtimeVersion: runtimeVersion || undefined,
     directory: targetDirectory,
@@ -373,7 +374,11 @@ const withTarget: ConfigPlugin<{
   }
 
   // Store full config for runtime access (with resolved appGroup)
-  runtimeConfigs.push({ ...evaluatedConfig, appGroup });
+  runtimeConfigs.push({
+    ...evaluatedConfig,
+    appGroup,
+    liveActivity: resolveLiveActivityConfig(evaluatedConfig),
+  });
 
   return next;
 };

--- a/packages/expo-targets/src/index.ts
+++ b/packages/expo-targets/src/index.ts
@@ -3,9 +3,13 @@
 // Config types
 export type {
   AndroidTargetConfig,
+  AndroidWidgetProviderConfig,
   Color,
   ExtensionType,
   IOSTargetConfig,
+  IosKindConfig,
+  IosLiveActivityKindConfig,
+  IosWidgetKindConfig,
   ReactNativeCompatibleType,
   TargetConfig,
   UiMode,

--- a/packages/expo-targets/src/modules/liveActivity/index.ts
+++ b/packages/expo-targets/src/modules/liveActivity/index.ts
@@ -4,6 +4,7 @@ import type {
   LiveActivityConfig,
   TargetConfig,
 } from '../../../plugin/src/config';
+import { resolveLiveActivityConfig } from '../../../plugin/src/ios/utils/resolveIosKinds';
 import type {
   LiveActivityAttributesName,
   LiveActivityPayloadFor,
@@ -50,9 +51,17 @@ function liveActivityConfigs(): {
   target: TargetConfig;
   config: LiveActivityConfig;
 }[] {
-  return listTargets()
-    .filter((t) => t.type === 'widget' && t.liveActivity?.attributesName)
-    .map((t) => ({ target: t, config: t.liveActivity as LiveActivityConfig }));
+  const rows: { target: TargetConfig; config: LiveActivityConfig }[] = [];
+  for (const target of listTargets()) {
+    if (target.type !== 'widget') {
+      continue;
+    }
+    const config = resolveLiveActivityConfig(target);
+    if (config?.attributesName) {
+      rows.push({ target, config });
+    }
+  }
+  return rows;
 }
 
 function resolveMatch(attributesName: string): {
@@ -69,7 +78,7 @@ function resolveMatch(attributesName: string): {
     throw new Error(
       `[expo-targets] Unknown Live Activity attributesName "${attributesName}". ` +
         `Configured: ${names || '(none)'}. ` +
-        `Add liveActivity.attributesName to the widget expo-target.config.json.`
+        `Add a { "type": "live-activity", "attributesName": "..." } row to ios.kinds.`
     );
   }
   return matches[0];

--- a/packages/expo-targets/src/modules/storage/index.ts
+++ b/packages/expo-targets/src/modules/storage/index.ts
@@ -30,7 +30,7 @@ const ExpoTargetsStorageModule = requireNativeModule('ExpoTargetsStorage') as {
   isAppExtension?: () => boolean;
   /** Android: start VpnService.prepare consent UI when needed. */
   prepareVpn?: () => string;
-  /** Android: show system pin sheet for a Glance widget target. */
+  /** Android: show system pin sheet for a widget target, provider name, or FQCN. */
   requestPinWidget?: (targetName: string) => string;
   /** Android: count of live App Widget instances for a target. */
   getHostedWidgetCount?: (targetName: string) => number;


### PR DESCRIPTION
## Summary
- One `widget` target can list many iOS WidgetKit picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`.
- Live Activity config moves onto an `ios.kinds` `{ "type": "live-activity" }` row; top-level `liveActivity` is removed.
- Doctor name-syncs every gallery kind’s `createTarget`, and warns leftover expo-ui `*Bundle.swift` when kinds generate a sealed Bundle.

## Test plan
- [x] `bun run typecheck` and `bun test --cwd packages/expo-targets` (419 pass)
- [x] Android Devicewright widgets triad green (`widgets`, `widgets-expo-ui`, `widgets-remoteviews`)
- [ ] iOS widgets triad still blocked on SpringBoard AX (`dewey-search-field` only) — not a kinds/codegen miss
- [ ] After npm publish, Popl can colocate three iOS picker products in one target folder