### PR TITLE
feat(widgets): put Live Activity on ios.liveActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - One `widget` target can list many iOS WidgetKit picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`.
-- Live Activity attributes live on an `ios.kinds` `{ "type": "live-activity" }` row (at most one). Top-level `liveActivity` config is removed.
+- Live Activity config lives on `ios.liveActivity` (`attributesName`, `static`, `contentState`, `pushType`). `ios.kinds` is gallery WidgetKit only. A `{ "type": "live-activity" }` kinds row fails.
 
 ## [1.0.3] - 2026-08-10
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -460,7 +460,7 @@ await ContentBlocker.reload({ targetName: "MyBlocker" });
 
 ## LiveActivity
 
-Start, update, or end Live Activities. `attributesName` must match a `{ "type": "live-activity" }` row in `ios.kinds`. Unknown names throw with the configured list. Prefer `LiveActivity.create(name)`. This is a widgets-like factory. Also exported as `createLiveActivity(name)`.
+Start, update, or end Live Activities. `attributesName` must match `ios.liveActivity.attributesName` on a `type: widget` target. Unknown names throw with the configured list. Prefer `LiveActivity.create(name)`. This is a widgets-like factory. Also exported as `createLiveActivity(name)`.
 
 - **iOS:** ActivityKit (16.2+). Attributes and the host bridge are CNG into `ios/*/ExpoTargetsGenerated/` (gitignored). Activity UI stays under `targets/<widget>/ios/`.
 - **Android:** Ongoing `NotificationCompat` helper with the same JS surface. No Dynamic Island, StandBy, or ActivityKit push-to-start.
@@ -610,7 +610,7 @@ npx expo-targets add --no-wire   # scaffold only
 2. **Name:** Target name in kebab-case (e.g., `my-widget`)
 3. **Platforms:** iOS (Android widgets bridge-grade)
 4. **Use React Native?** (share/action/clip/messages/notification-content/safari when applicable)
-5. **Live Activity?** (widget only) — Emits an `ios.kinds` live-activity row + one-shot UI bootstrap
+5. **Live Activity?** (widget only) — Emits `ios.liveActivity` + one-shot UI bootstrap
 
 Wires the host by default (plugin, App Groups, Metro). Dynamic `app.config.ts` or `app.config.js` gets a snippet warning instead of a hard fail. Finish with `npx expo-targets doctor`. After scaffold, `generate` writes `.expo/types/expo-targets.d.ts`.
 
@@ -776,7 +776,7 @@ interface NonExtensionTarget extends BaseTarget {
 | -------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `Target "X" not found`     | Target name doesn't match config   | Check `createTarget('X')` matches `"name"` in config exactly |
 | `App Group not configured` | Missing `appGroup` in config       | Add `appGroup` to `expo-target.config.json` or `app.json`    |
-| `Unknown Live Activity attributesName` | Name not in `ios.kinds` live-activity row | Use a configured `attributesName` / `LiveActivity.create` |
+| `Unknown Live Activity attributesName` | Name not in `ios.liveActivity` | Use a configured `attributesName` / `LiveActivity.create` |
 | `fileProviderDomain` missing | FP target lacks domain config      | Add `ios.fileProviderDomain` to the file-provider config     |
 | `No targets config found`  | Running in wrong context           | Run from the app or extension, not a unit test               |
 | `close is not a function`  | Calling `close()` on non-extension | Only share/action/clip targets have `close()`                |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -516,14 +516,13 @@ widget.setData(
   "ios": {
     "deploymentTarget": "14.0",
     "kinds": [
-      { "name": "WeatherWidget", "displayName": "Weather" },
-      {
-        "type": "live-activity",
-        "attributesName": "WeatherAttributes",
-        "static": { "location": "string" },
-        "contentState": { "temp": "double", "summary": "string" }
-      }
+      { "name": "WeatherWidget", "displayName": "Weather" }
     ],
+    "liveActivity": {
+      "attributesName": "WeatherAttributes",
+      "static": { "location": "string" },
+      "contentState": { "temp": "double", "summary": "string" }
+    },
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" }
     }
@@ -531,7 +530,7 @@ widget.setData(
 }
 ```
 
-`ios.kinds` lists WidgetKit picker products (`name` matches `createTarget`). `supportedFamilies` on a kind is sizes of that one picker row, not extra products. A `{ "type": "live-activity" }` row holds `attributesName` / `static` / `contentState` / `pushType` (at most one). That row drives sealed CNG for native widgets and `WidgetLiveActivity()` on expo-ui Bundles. Ambient TypeScript payload types still land in `.expo/types/expo-targets.d.ts`. Host JS: `LiveActivity.create('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
+`ios.kinds` lists WidgetKit picker products (`name` matches `createTarget`). `supportedFamilies` on a kind is sizes of that one picker row, not extra products. `ios.liveActivity` holds `attributesName` / `static` / `contentState` / `pushType` (at most one per widget target). That object drives sealed CNG for native widgets and `WidgetLiveActivity()` on expo-ui Bundles. Ambient TypeScript payload types still land in `.expo/types/expo-targets.d.ts`. Host JS: `LiveActivity.create('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
 
 ### File Provider domain (iOS)
 
@@ -917,7 +916,7 @@ export default function (config: ExpoConfig) {
       // Inherit deployment target from main app
       deploymentTarget: config.ios?.deploymentTarget || "14.0",
     },
-  };
+  } satisfies import("expo-targets").TargetConfig;
 }
 ```
 
@@ -935,7 +934,7 @@ export default function (config: ExpoConfig) {
 - `config.android?.package` — Your app's Android package name
 - Any other fields from your Expo config
 
-**Note:** Dynamic configs (`.ts` or `.js`) are processed by expo-targets during prebuild. TypeScript is supported without extra configuration. The plugin handles transpilation.
+**Note:** Dynamic configs (`.ts` or `.js`) are processed by expo-targets during prebuild. TypeScript is supported without extra configuration. The plugin handles transpilation. Use `satisfies TargetConfig` (or a typed function return) for editor checks. `expo-target.config.json` is plain JSON. It has no types unless you add a JSON Schema. This package does not ship a schema yet.
 
 ---
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,7 +10,7 @@ Native WidgetKit and ActivityKit are **first-class** in expo-targets (not soft-d
 
 | Stage               | Behavior                                                                                    |
 | ------------------- | ------------------------------------------------------------------------------------------- |
-| **Now**             | Widget and Live Activity scaffolds and examples are supported                               |
+| **Now**             | Widget and Live Activity scaffolds and examples are supported. Put Live Activity on `ios.liveActivity`. `ios.kinds` is gallery WidgetKit only. A `{ "type": "live-activity" }` kinds row fails (doctor + resolver). |
 | **Dual engines**    | Unsupported: do not run expo-widgets and expo-targets WidgetKit generators in one app       |
 | **Android widgets** | **First-class** Glance/Compose or RemoteViews deepen (not bridge-grade). Same DoD as iOS: registry + scaffold + example + Devicewright (or leftover). One generator per app if official `expo-widgets` Android lands. |
 | **Android dual**    | API-ceiling program (~40% of types). Ledger in `TYPE_CHARACTERISTICS` (`androidBucket` / `androidComponent`). W0–W3 shipped (through system services). Ceiling includes W4-in-1.0 partials + Wear strong — no separate W5 Wear wave. No orphan Android stubs outside the ceiling. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,7 +134,7 @@ module.exports = withTargets(getDefaultConfig(__dirname));
 
 ### Typed target names + Live Activity payloads
 
-After prebuild (or `npx expo-targets generate`), ambient types are written to `.expo/types/expo-targets.d.ts` (gitignored, same layout as Expo Router typed routes). That narrows `createTarget('…')` / `LiveActivity.create('…')` string literals — **no import from `.expo/`**. When a live-activity kind sets `static` / `contentState`, `start` / `update` pick up those field types via module augmentation.
+After prebuild (or `npx expo-targets generate`), ambient types are written to `.expo/types/expo-targets.d.ts` (gitignored, same layout as Expo Router typed routes). That narrows `createTarget('…')` / `LiveActivity.create('…')` string literals — **no import from `.expo/`**. When `ios.liveActivity` sets `static` / `contentState`, `start` / `update` pick up those field types via module augmentation.
 
 ```typescript
 import { createTarget, LiveActivity, type TargetName } from "expo-targets";

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -57,14 +57,13 @@ Host CNG deletes only root-level `*.swift` under `ExpoTargetsGenerated/`. It nev
   "name": "OrderWidget",
   "ios": {
     "kinds": [
-      { "name": "OrderWidget" },
-      {
-        "type": "live-activity",
-        "attributesName": "OrderAttributes",
-        "static": { "orderId": "string" },
-        "contentState": { "status": "string", "progress": "double" }
-      }
-    ]
+      { "name": "OrderWidget" }
+    ],
+    "liveActivity": {
+      "attributesName": "OrderAttributes",
+      "static": { "orderId": "string" },
+      "contentState": { "status": "string", "progress": "double" }
+    }
   }
 }
 ```
@@ -99,7 +98,7 @@ npx expo-targets add
 - **native (default)** — SwiftUI / Glance deepen under `targets/<name>/ios|android/`.
 - **expo-ui** — writes `entry` + `createTarget(name, Layout)` with the `'widget'` directive; CNG emits `ExpoUiWidget` (+ optional AppIntentConfiguration / `WidgetLiveActivity`).
 - **Configurable (Edit Widget)** — native scaffolds `AppIntentConfiguration` under user deepen; expo-ui uses `ios.configuration` → sealed AppIntent + `environment.configuration` in Layout.
-- **Live Activity** — writes a `{ "type": "live-activity" }` row in `ios.kinds`. Native: `LiveActivity.swift` deepen + typed CNG attributes. Expo-ui: same entry registers `createLiveActivityLayout` + Bundle includes `WidgetLiveActivity()` (blob attrs; skip typed CNG).
+- **Live Activity** — writes `ios.liveActivity`. Native: `LiveActivity.swift` deepen + typed CNG attributes. Expo-ui: same entry registers `createLiveActivityLayout` + Bundle includes `WidgetLiveActivity()` (blob attrs; skip typed CNG).
 
 See [`examples/trick`](../examples/trick) for a full host + widget pairing and
 [`examples/widgets`](../examples/widgets) for static, expo-ui, and RemoteViews examples.
@@ -174,7 +173,7 @@ Use the same `appGroup` as `expo-target.config.json`.
 
 - `addUserInteractionListener` — widget Button presses (iOS AppIntent → host; Android Glance/RemoteViews Bump → `ExpoTargetsStorage` `onUserInteraction` with the same event shape).
 - `createLiveActivityLayout(name, slots)` — multi-slot LA UI in the same entry as the home Layout; `LiveActivity.create(attributesName)` still starts/updates/ends.
-- `ios.kinds` `{ type: "live-activity", pushType: "token" }` — native CNG requests ActivityKit push tokens; `addPushToStartTokenListener` for push-to-start. Simulator cannot prove APNs — Devicewright CLAIMS for DI / push / StandBy.
+- `ios.liveActivity.pushType: "token"` — native CNG requests ActivityKit push tokens; `addPushToStartTokenListener` for push-to-start. Simulator cannot prove APNs — Devicewright CLAIMS for DI / push / StandBy.
 
 ## Android widgets
 
@@ -186,7 +185,7 @@ Android home-screen widgets (Glance / RemoteViews) are **first-class** in expo-t
 - Seeded `message` + `taps` from host `setData`
 - `Bump` button → increments taps, refreshes the tile, emits `addUserInteractionListener` (`source` / `target`)
 
-See `examples/widgets` (`HelloExpoUi` has two expo-ui kinds plus a live-activity row; `HelloRemoteViewsBundle` has two Android providers). Scaffolded Glance targets get the same chrome + Bump stub.
+See `examples/widgets` (`HelloExpoUi` has two expo-ui kinds plus `ios.liveActivity`; `HelloRemoteViewsBundle` has two Android providers). Scaffolded Glance targets get the same chrome + Bump stub.
 
 One `type: widget` folder can list many iOS picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`. `supportedFamilies` on a kind is sizes of that row, not extra products.
 
@@ -195,7 +194,7 @@ One generator per app if official `expo-widgets` Android lands. ActivityKit / Dy
 ## Related
 
 - [api.md](./api.md) — `LiveActivity` runtime
-- [configuration.md](./configuration.md) — `ios.kinds` schema
+- [configuration.md](./configuration.md) — `ios.kinds` and `ios.liveActivity` schema
 - [limits.md](./limits.md) — lib floor vs Apple gates
 - [deprecations.md](./deprecations.md) — roadmap policy
 - [getting-started.md](./getting-started.md)

--- a/examples/trick/targets/trick-widgets/expo-target.config.json
+++ b/examples/trick/targets/trick-widgets/expo-target.config.json
@@ -8,14 +8,11 @@
     "bundleIdentifier": "com.expotargets.example.trick.widgets",
     "displayName": "ET Trick Widget",
     "deploymentTarget": "18.0",
-    "kinds": [
-      {
-        "type": "live-activity",
-        "attributesName": "TrickActivityAttributes",
-        "static": { "title": "string" },
-        "contentState": { "status": "string" }
-      }
-    ],
+    "liveActivity": {
+      "attributesName": "TrickActivityAttributes",
+      "static": { "title": "string" },
+      "contentState": { "status": "string" }
+    },
     "colors": {
       "AccentColor": { "light": "#2F6BFF", "dark": "#5B8CFF" },
       "BackgroundColor": { "light": "#0B1220", "dark": "#0B1220" },

--- a/examples/widgets/README.md
+++ b/examples/widgets/README.md
@@ -1,6 +1,6 @@
 # Widgets
 
-WidgetKit and Android widget example. Four targets: native Glance (`HelloWidget`), expo-ui Glance (`HelloExpoUi` — two iOS picker rows plus a live-activity kind), RemoteViews (`HelloRemoteViews`), and a RemoteViews bundle (`HelloRemoteViewsBundle` — two Android picker rows). The host seeds payloads, pins widgets on Android, and controls Live Activities.
+WidgetKit and Android widget example. Four targets: native Glance (`HelloWidget`), expo-ui Glance (`HelloExpoUi` — two iOS picker rows plus `ios.liveActivity`), RemoteViews (`HelloRemoteViews`), and a RemoteViews bundle (`HelloRemoteViewsBundle` — two Android picker rows). The host seeds payloads, pins widgets on Android, and controls Live Activities.
 
 Full widget docs: [../../docs/widgets.md](../../docs/widgets.md). Suite how-to: [../README.md](../README.md). Type maturity: [../../docs/configuration.md](../../docs/configuration.md).
 

--- a/examples/widgets/targets/hello-expo-ui/expo-target.config.json
+++ b/examples/widgets/targets/hello-expo-ui/expo-target.config.json
@@ -28,15 +28,14 @@
         "displayName": "Hello Expo UI Compact",
         "description": "Compact picker row (not a second size of Hello Expo UI)",
         "supportedFamilies": ["systemSmall"]
-      },
-      {
-        "type": "live-activity",
-        "attributesName": "HelloExpoUiAttributes",
-        "static": { "title": "string" },
-        "contentState": { "status": "string" },
-        "pushType": "token"
       }
     ],
+    "liveActivity": {
+      "attributesName": "HelloExpoUiAttributes",
+      "static": { "title": "string" },
+      "contentState": { "status": "string" },
+      "pushType": "token"
+    },
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" },
       "BackgroundColor": { "light": "#F2F2F7", "dark": "#1C1C1E" },

--- a/examples/widgets/targets/hello-widget/expo-target.config.json
+++ b/examples/widgets/targets/hello-widget/expo-target.config.json
@@ -7,14 +7,11 @@
   "ios": {
     "bundleIdentifier": "com.expotargets.example.widgets.hello",
     "displayName": "Hello Widget",
-    "kinds": [
-      {
-        "type": "live-activity",
-        "attributesName": "HelloWidgetAttributes",
-        "static": { "title": "string" },
-        "contentState": { "status": "string" }
-      }
-    ],
+    "liveActivity": {
+      "attributesName": "HelloWidgetAttributes",
+      "static": { "title": "string" },
+      "contentState": { "status": "string" }
+    },
     "colors": {
       "AccentColor": { "light": "#007AFF", "dark": "#0A84FF" },
       "BackgroundColor": { "light": "#F2F2F7", "dark": "#1C1C1E" },

--- a/packages/expo-targets/cli/src/checks/liveActivityKind.ts
+++ b/packages/expo-targets/cli/src/checks/liveActivityKind.ts
@@ -1,0 +1,26 @@
+import type { CheckResult, ProjectContext } from '../types';
+
+function hasLiveActivityKind(kinds: { type?: string }[] | undefined): boolean {
+  return Boolean(kinds?.some((kind) => kind.type === 'live-activity'));
+}
+
+/** Fail when a widget still lists Live Activity inside ios.kinds. */
+export function checkLiveActivityKind(ctx: ProjectContext): CheckResult[] {
+  const errors: CheckResult[] = [];
+  for (const target of ctx.targets) {
+    if (target.config.type !== 'widget') {
+      continue;
+    }
+    if (!hasLiveActivityKind(target.config.ios?.kinds)) {
+      continue;
+    }
+    errors.push({
+      ok: false,
+      level: 'error',
+      title: 'Live Activity kinds row',
+      message: `targets/${target.dirName}: ios.kinds cannot contain { "type": "live-activity" }. Set ios.liveActivity instead.`,
+      fix: 'Keep ios.kinds as gallery WidgetKit products only. Put attributesName, static, contentState, and pushType on ios.liveActivity.',
+    });
+  }
+  return errors;
+}

--- a/packages/expo-targets/cli/src/doctor.test.ts
+++ b/packages/expo-targets/cli/src/doctor.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 
 import { checkAppGroups } from './checks/appGroups';
 import { checkEntries } from './checks/entries';
+import { checkLiveActivityKind } from './checks/liveActivityKind';
 import { checkMetro } from './checks/metro';
 import { checkNameSync } from './checks/nameSync';
 import { checkPlugin } from './checks/plugin';
@@ -288,5 +289,42 @@ describe('warnUnusedWidgetBundle', () => {
       'targets/widget/ios/HomeBundle.swift': 'struct HomeBundle {}\n',
     });
     expect(warnUnusedWidgetBundle(loadProject(root))).toHaveLength(0);
+  });
+});
+
+describe('checkLiveActivityKind', () => {
+  test('fails leftover live-activity kinds', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        ios: {
+          kinds: [{ type: 'live-activity', attributesName: 'HomeAttributes' }],
+        },
+      }),
+    });
+    const errors = checkLiveActivityKind(loadProject(root));
+    expect(errors[0]?.level).toBe('error');
+    expect(errors[0]?.message).toContain('ios.liveActivity');
+  });
+
+  test('skips when Live Activity is only on ios.liveActivity', () => {
+    const root = makeProject({
+      'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+      'targets/widget/expo-target.config.json': JSON.stringify({
+        type: 'widget',
+        name: 'Home',
+        platforms: ['ios'],
+        ios: {
+          liveActivity: {
+            attributesName: 'HomeAttributes',
+            contentState: { status: 'string' },
+          },
+        },
+      }),
+    });
+    expect(checkLiveActivityKind(loadProject(root))).toHaveLength(0);
   });
 });

--- a/packages/expo-targets/cli/src/doctor.ts
+++ b/packages/expo-targets/cli/src/doctor.ts
@@ -8,6 +8,7 @@ import {
 } from './checks/easCredentials';
 import { checkEntries } from './checks/entries';
 import { warnHeavyExclusions } from './checks/heavyExclusions';
+import { checkLiveActivityKind } from './checks/liveActivityKind';
 import { checkMetro } from './checks/metro';
 import { checkNameSync } from './checks/nameSync';
 import { checkPlugin } from './checks/plugin';
@@ -37,6 +38,7 @@ function collectFailures(ctx: ReturnType<typeof loadProject>): CheckResult[] {
   results.push(...checkAppGroups(ctx));
   results.push(...checkEntries(ctx));
   results.push(...checkNameSync(ctx));
+  results.push(...checkLiveActivityKind(ctx));
   results.push(...checkEasCredentialErrors(ctx));
   return results;
 }

--- a/packages/expo-targets/cli/src/scaffold/expoUiWidgetTemplate.test.ts
+++ b/packages/expo-targets/cli/src/scaffold/expoUiWidgetTemplate.test.ts
@@ -44,8 +44,8 @@ describe('generateConfig expo-ui widget', () => {
   });
 });
 
-describe('generateConfig live-activity kinds', () => {
-  test('live-activity writes kinds and moves expo-ui configuration onto the widget row', () => {
+describe('generateConfig live-activity sibling', () => {
+  test('expo-ui live-activity writes ios.liveActivity and keeps configuration off kinds', () => {
     const json = JSON.parse(
       generateConfig({
         type: 'widget',
@@ -58,34 +58,18 @@ describe('generateConfig live-activity kinds', () => {
         appGroup: 'group.test',
       })
     );
-    expect(json.ios.configuration).toBeUndefined();
-    expect(json.ios.kinds).toEqual([
-      {
-        name: 'MyWidget',
-        displayName: 'My Widget',
-        configuration: {
-          title: 'My Widget Configuration',
-          parameters: {
-            listId: {
-              title: 'List',
-              type: 'string',
-              default: 'default',
-            },
-          },
-        },
-      },
-      {
-        type: 'live-activity',
-        attributesName: 'MyWidgetAttributes',
-        static: { title: 'string' },
-        contentState: { status: 'string' },
-      },
-    ]);
+    expect(json.ios.kinds).toBeUndefined();
+    expect(json.ios.configuration.parameters.listId.type).toBe('string');
+    expect(json.ios.liveActivity).toEqual({
+      attributesName: 'MyWidgetAttributes',
+      static: { title: 'string' },
+      contentState: { status: 'string' },
+    });
   });
 });
 
 describe('generateConfig native live-activity', () => {
-  test('native live-activity kinds omit a gallery widget row', () => {
+  test('native live-activity writes ios.liveActivity without kinds', () => {
     const json = JSON.parse(
       generateConfig({
         type: 'widget',
@@ -97,13 +81,11 @@ describe('generateConfig native live-activity', () => {
         appGroup: 'group.test',
       })
     );
-    expect(json.ios.kinds).toEqual([
-      {
-        type: 'live-activity',
-        attributesName: 'MyWidgetAttributes',
-        static: { title: 'string' },
-        contentState: { status: 'string' },
-      },
-    ]);
+    expect(json.ios.kinds).toBeUndefined();
+    expect(json.ios.liveActivity).toEqual({
+      attributesName: 'MyWidgetAttributes',
+      static: { title: 'string' },
+      contentState: { status: 'string' },
+    });
   });
 });

--- a/packages/expo-targets/cli/src/scaffold/generateConfig.ts
+++ b/packages/expo-targets/cli/src/scaffold/generateConfig.ts
@@ -105,23 +105,11 @@ function applyLiveActivityConfig(
     typeof config.ios === 'object' && config.ios
       ? (config.ios as Record<string, unknown>)
       : {};
-  const kinds = Array.isArray(ios.kinds) ? [...ios.kinds] : [];
-  if (options.widgetUi === 'expo-ui') {
-    const configuration = ios.configuration;
-    delete ios.configuration;
-    kinds.unshift({
-      name: options.pascalName,
-      displayName: formatDisplayName(options.kebabName),
-      ...(configuration ? { configuration } : {}),
-    });
-  }
-  kinds.push({
-    type: 'live-activity',
+  ios.liveActivity = {
     attributesName,
     static: { title: 'string' },
     contentState: { status: 'string' },
-  });
-  ios.kinds = kinds;
+  };
   config.ios = ios;
 }
 

--- a/packages/expo-targets/cli/src/types.ts
+++ b/packages/expo-targets/cli/src/types.ts
@@ -19,6 +19,7 @@ export interface TargetConfig {
   excludedPackages?: string[];
   ios?: {
     kinds?: { type?: string; name?: string }[];
+    liveActivity?: { attributesName?: string };
     intents?: { ui?: boolean | { name?: string } };
     wallet?: { ui?: boolean | { name?: string } };
   };

--- a/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.test.ts
+++ b/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.test.ts
@@ -32,4 +32,25 @@ describe('collectRuntimeConfigs', () => {
     );
     expect(configs[0]?.appGroup).toBe('group.com.example.app');
   });
+
+  test('copies ios.liveActivity onto the runtime row', () => {
+    const configs = collectRuntimeConfigs(
+      [
+        {
+          config: {
+            name: 'WeatherWidget',
+            type: 'widget',
+            ios: {
+              liveActivity: {
+                attributesName: 'WeatherAttributes',
+                contentState: { temp: 'double' },
+              },
+            },
+          },
+        },
+      ],
+      {}
+    );
+    expect(configs[0]?.liveActivity?.attributesName).toBe('WeatherAttributes');
+  });
 });

--- a/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.ts
+++ b/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.ts
@@ -15,6 +15,7 @@ export interface RuntimeTargetConfig {
   };
   ios?: {
     kinds?: import('../config').IosKindConfig[];
+    liveActivity?: import('../config').LiveActivityConfig;
     intents?: { ui?: boolean | { name?: string } };
     wallet?: { ui?: boolean | { name?: string } };
   };

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -343,10 +343,17 @@ interface BaseIosTargetConfig {
   /** Disable default WidgetKit content margins (expo-ui). */
   contentMarginsDisabled?: boolean;
   /**
-   * WidgetKit picker products plus at most one live-activity row.
+   * WidgetKit picker products (`name` matches `createTarget` / Swift `kind:`).
    * When omitted or empty, one widget uses `name` + scalar ios fields.
+   * Live Activity belongs on `liveActivity`, not in this list.
    */
-  kinds?: IosKindConfig[];
+  kinds?: IosWidgetKindConfig[];
+  /**
+   * ActivityKit Live Activity in the same widget `.appex`. At most one.
+   * Native CNG uses `attributesName` / `static` / `contentState` / `pushType`.
+   * Expo-ui Bundles add `WidgetLiveActivity()`.
+   */
+  liveActivity?: LiveActivityConfig;
 }
 
 /** WidgetKit family names (expo-ui supportedFamilies). */
@@ -416,12 +423,16 @@ export interface IosWidgetKindConfig {
   configuration?: WidgetConfiguration;
 }
 
-/** ActivityKit row. Adds `WidgetLiveActivity()` on expo-ui Bundles. At most one. */
+/**
+ * Leftover kinds row shape. Author Live Activity on `ios.liveActivity`.
+ * A `{ type: "live-activity" }` kinds row throws.
+ */
 export type IosLiveActivityKindConfig = LiveActivityConfig & {
   type: 'live-activity';
 };
 
-export type IosKindConfig = IosWidgetKindConfig | IosLiveActivityKindConfig;
+/** Gallery WidgetKit picker product. Not a Live Activity. */
+export type IosKindConfig = IosWidgetKindConfig;
 
 export interface AppIntentHostConfig {
   className: string;

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
@@ -33,11 +33,6 @@ describe('resolveGalleryWidgetKinds list', () => {
             displayName: 'Lock QR',
             supportedFamilies: ['accessoryCircular', 'accessoryRectangular'],
           },
-          {
-            type: 'live-activity',
-            attributesName: 'DynamicIslandAttributes',
-            contentState: { views: 'string' },
-          },
         ],
       },
     });
@@ -46,6 +41,24 @@ describe('resolveGalleryWidgetKinds list', () => {
       'LockScreenWidgets',
     ]);
     expect(kinds[1]?.displayName).toBe('Lock QR');
+  });
+
+  test('a live-activity kinds row throws', () => {
+    expect(() =>
+      resolveGalleryWidgetKinds({
+        targetName: 'HomescreenWidgets',
+        ios: {
+          kinds: [
+            { name: 'Home' },
+            {
+              type: 'live-activity',
+              attributesName: 'DynamicIslandAttributes',
+              contentState: { views: 'string' },
+            },
+          ],
+        },
+      })
+    ).toThrow(/ios\.liveActivity/);
   });
 
   test('duplicate widget names throw', () => {
@@ -59,47 +72,62 @@ describe('resolveGalleryWidgetKinds list', () => {
 });
 
 describe('resolveLiveActivityConfig', () => {
-  test('reads attributes from a live-activity kind', () => {
+  test('reads ios.liveActivity', () => {
     const la = resolveLiveActivityConfig({
       ios: {
-        kinds: [
-          { name: 'Home' },
-          {
-            type: 'live-activity',
-            attributesName: 'HelloExpoUiAttributes',
-            static: { title: 'string' },
-            contentState: { status: 'string' },
-            pushType: 'token',
-          },
-        ],
+        kinds: [{ name: 'Home' }],
+        liveActivity: {
+          attributesName: 'HelloExpoUiAttributes',
+          static: { title: 'string' },
+          contentState: { status: 'string' },
+          pushType: 'token',
+        },
       },
     });
     expect(la?.attributesName).toBe('HelloExpoUiAttributes');
     expect(la?.pushType).toBe('token');
   });
 
-  test('two live-activity kinds throw', () => {
+  test('a live-activity kinds row throws even when ios.liveActivity is set', () => {
     expect(() =>
       resolveLiveActivityConfig({
         ios: {
+          liveActivity: {
+            attributesName: 'SiblingAttributes',
+            contentState: { status: 'string' },
+          },
           kinds: [
             {
               type: 'live-activity',
-              attributesName: 'A',
-              contentState: { s: 'string' },
-            },
-            {
-              type: 'live-activity',
-              attributesName: 'B',
-              contentState: { s: 'string' },
+              attributesName: 'KindAttributes',
+              contentState: { status: 'string' },
             },
           ],
         },
       })
-    ).toThrow(/at most one/);
+    ).toThrow(/ios\.liveActivity/);
   });
 
-  test('omitted kinds has no live activity', () => {
+  test('a leftover live-activity kind throws', () => {
+    expect(() =>
+      resolveLiveActivityConfig({
+        ios: {
+          kinds: [
+            { name: 'Home' },
+            {
+              type: 'live-activity',
+              attributesName: 'HelloExpoUiAttributes',
+              static: { title: 'string' },
+              contentState: { status: 'string' },
+              pushType: 'token',
+            },
+          ],
+        },
+      })
+    ).toThrow(/ios\.liveActivity/);
+  });
+
+  test('omitted liveActivity and kinds has no live activity', () => {
     expect(resolveLiveActivityConfig({ ios: {} })).toBeUndefined();
   });
 });

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
@@ -1,5 +1,4 @@
 import type {
-  IosKindConfig,
   IosLiveActivityKindConfig,
   IosWidgetKindConfig,
   LiveActivityConfig,
@@ -7,18 +6,21 @@ import type {
   WidgetFamily,
 } from '../../config';
 
+type KindRow = IosWidgetKindConfig | IosLiveActivityKindConfig;
+
 export function isLiveActivityKind(
-  kind: IosKindConfig
+  kind: KindRow
 ): kind is IosLiveActivityKindConfig {
   return kind.type === 'live-activity';
 }
 
-export function isWidgetKind(kind: IosKindConfig): kind is IosWidgetKindConfig {
+export function isWidgetKind(kind: KindRow): kind is IosWidgetKindConfig {
   return kind.type !== 'live-activity';
 }
 
 type IosKindSource = {
-  kinds?: IosKindConfig[];
+  kinds?: KindRow[];
+  liveActivity?: LiveActivityConfig;
   displayName?: string;
   supportedFamilies?: WidgetFamily[];
   contentMarginsDisabled?: boolean;
@@ -40,7 +42,7 @@ export type ResolvedIosWidgetKind = {
   configuration?: WidgetConfiguration;
 };
 
-function explicitKinds(ios?: IosKindSource): IosKindConfig[] | undefined {
+function explicitKinds(ios?: IosKindSource): KindRow[] | undefined {
   const listed = ios?.kinds;
   if (!listed || listed.length === 0) {
     return;
@@ -48,34 +50,27 @@ function explicitKinds(ios?: IosKindSource): IosKindConfig[] | undefined {
   return listed;
 }
 
+function assertNoLiveActivityKinds(ios?: IosKindSource): void {
+  if ((explicitKinds(ios) ?? []).some(isLiveActivityKind)) {
+    throw new Error(
+      'ios.kinds cannot contain { "type": "live-activity" }. Set ios.liveActivity instead.'
+    );
+  }
+}
+
 export function resolveLiveActivityConfig(input: {
   ios?: IosKindSource;
 }): LiveActivityConfig | undefined {
-  const listed = explicitKinds(input.ios);
-  if (!listed) {
-    return;
+  assertNoLiveActivityKinds(input.ios);
+  const sibling = input.ios?.liveActivity;
+  if (sibling?.attributesName) {
+    return sibling;
   }
-  const live = listed.filter(isLiveActivityKind);
-  if (live.length > 1) {
-    throw new Error(
-      'ios.kinds may contain at most one { "type": "live-activity" } row'
-    );
-  }
-  const row = live[0];
-  if (!row) {
-    return;
-  }
-  return {
-    attributesName: row.attributesName,
-    static: row.static,
-    contentState: row.contentState,
-    pushType: row.pushType,
-  };
 }
 
 function widgetRowsForTarget(
   input: ResolveIosKindsInput,
-  listed: IosKindConfig[] | undefined
+  listed: KindRow[] | undefined
 ): IosWidgetKindConfig[] {
   if (listed) {
     return listed.filter(isWidgetKind);
@@ -92,7 +87,7 @@ function resolveOneGalleryKind(opts: {
   row: IosWidgetKindConfig;
   ios: IosKindSource;
   input: ResolveIosKindsInput;
-  listed: IosKindConfig[] | undefined;
+  listed: KindRow[] | undefined;
 }): ResolvedIosWidgetKind {
   const { row, ios, input, listed } = opts;
   return {
@@ -113,6 +108,7 @@ export function resolveGalleryWidgetKinds(
   input: ResolveIosKindsInput
 ): ResolvedIosWidgetKind[] {
   const ios = input.ios || {};
+  assertNoLiveActivityKinds(ios);
   const listed = explicitKinds(ios);
   const widgetRows = widgetRowsForTarget(input, listed);
   const seen = new Set<string>();

--- a/packages/expo-targets/src/modules/liveActivity/index.ts
+++ b/packages/expo-targets/src/modules/liveActivity/index.ts
@@ -78,7 +78,7 @@ function resolveMatch(attributesName: string): {
     throw new Error(
       `[expo-targets] Unknown Live Activity attributesName "${attributesName}". ` +
         `Configured: ${names || '(none)'}. ` +
-        `Add a { "type": "live-activity", "attributesName": "..." } row to ios.kinds.`
+        `Set ios.liveActivity.attributesName in expo-target.config.json.`
     );
   }
   return matches[0];


### PR DESCRIPTION
## Summary
- Move Live Activity off `ios.kinds` onto sibling `ios.liveActivity` (`attributesName`, `static`, `contentState`, `pushType`).
- `ios.kinds` is gallery WidgetKit only. A leftover `{ "type": "live-activity" }` row fails at doctor and in the kinds resolver.
- Scaffold, examples, and docs match. Typed JSON is still `expo-target.config.ts` + `satisfies TargetConfig` (no shipped JSON Schema).

## Test plan
- [x] Resolver tests: sibling reads; leftover kinds row throws
- [x] Doctor fails leftover kinds; skips `ios.liveActivity`
- [x] Scaffold `--live-activity` writes `ios.liveActivity` without a kinds row
- [ ] Popl switches consumer JSON after this minor lands