### PR TITLE
fix(ios): stop excluded-packages Podfile markers from breaking CocoaPods

### DIFF
--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { normalizePodfile } from '../../../../test-utils/normalizePodfile';
+import { Logger } from '../../../logger';
+import { applyPodfilePlan } from './applyPodfilePlan';
 import {
   ensureExcludedPackagesPostIntegrate,
   ensureExpoWidgetsPostInstall,
@@ -66,7 +68,7 @@ describe('generateReactNativeTargetBlock', () => {
       extensionType: 'share',
     });
     expect(block).toContain('inherit! :search_paths');
-    expect(block).not.toContain('[expo-targets-excluded-packages]');
+    expect(block).not.toContain('expo-targets-excluded-packages');
   });
 
   test('clip also inherits search_paths (host copies frameworks into AppClips)', () => {
@@ -86,7 +88,7 @@ describe('generateReactNativeTargetBlock', () => {
       excludedPackages: ['expo-updates', 'expo-dev-client'],
     });
     expect(block).toContain(
-      '# [expo-targets-excluded-packages] expo-updates,expo-dev-client'
+      '# [expo-targets-excluded-packages-list] expo-updates,expo-dev-client'
     );
   });
 });
@@ -99,7 +101,8 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
         packages: ['expo-updates', 'expo-dev-client'],
       },
     ]);
-    expect(once).toContain('# [expo-targets-excluded-packages-start]');
+    expect(once).toContain('# [expo-targets-excluded-packages-begin]');
+    expect(once).toContain('# [expo-targets-excluded-packages-done]');
     expect(once).toContain('post_integrate do |installer|');
     expect(once).toContain(
       "'ExampleMessagesTarget' => ['expo-updates', 'expo-dev-client']"
@@ -114,7 +117,7 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
         packages: ['expo-updates', 'expo-dev-client'],
       },
     ]);
-    expect(twice.split('# [expo-targets-excluded-packages-start]').length).toBe(
+    expect(twice.split('# [expo-targets-excluded-packages-begin]').length).toBe(
       2
     );
   });
@@ -124,7 +127,7 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
       { targetName: 'ExampleMessagesTarget', packages: ['expo-updates'] },
     ]);
     const cleared = ensureExcludedPackagesPostIntegrate(withHook, []);
-    expect(cleared).not.toContain('# [expo-targets-excluded-packages-start]');
+    expect(cleared).not.toContain('# [expo-targets-excluded-packages-begin]');
     expect(cleared).not.toContain('post_integrate do |installer|');
   });
 });
@@ -161,6 +164,63 @@ describe('insertTargetBlock + removeTargetBlock', () => {
   test('removeTargetBlock is a no-op when the target does not exist', () => {
     const result = removeTargetBlock(plainPodfile, 'DoesNotExist');
     expect(result).toBe(plainPodfile);
+  });
+
+  test('standalone insert does not splice into the excluded-packages fence', () => {
+    const withHook = ensureExcludedPackagesPostIntegrate(plainPodfile, [
+      { targetName: 'MessagesTarget', packages: ['expo-updates'] },
+    ]);
+    const clip = generateStandaloneTargetBlock({
+      targetName: 'ClipTarget',
+      deploymentTarget: '16.4',
+      useFrameworks: true,
+    });
+    const result = insertTargetBlock(withHook, clip, { standalone: true });
+
+    expect(result).toContain('# [expo-targets-excluded-packages-begin]');
+    expect(result).toContain('# [expo-targets-excluded-packages-done]');
+    expect(result).not.toMatch(/excluded-packages-\w+\n/);
+    expect(result).not.toMatch(/^\s+end\]/m);
+    expect(result.indexOf("target 'ClipTarget'")).toBeLessThan(
+      result.indexOf('# [expo-targets-excluded-packages-begin]')
+    );
+  });
+});
+
+describe('applyPodfilePlan messages then clip', () => {
+  test('keeps fence markers intact after a later standalone target', () => {
+    const logger = new Logger();
+    const afterMessages = applyPodfilePlan(
+      plainPodfile,
+      {
+        targetName: 'MessagesTarget',
+        deploymentTarget: '16.4',
+        extensionType: 'messages',
+        standalone: false,
+        excludedPackages: ['expo-updates', 'expo-dev-client'],
+      },
+      { mainTargetName: 'App', logger }
+    );
+    const afterClip = applyPodfilePlan(
+      afterMessages,
+      {
+        targetName: 'ClipTarget',
+        deploymentTarget: '16.4',
+        extensionType: 'clip',
+        standalone: true,
+      },
+      { mainTargetName: 'App', logger }
+    );
+
+    expect(afterClip).toContain('# [expo-targets-excluded-packages-list]');
+    expect(afterClip).toContain('# [expo-targets-excluded-packages-begin]');
+    expect(afterClip).toContain('# [expo-targets-excluded-packages-done]');
+    expect(afterClip).not.toMatch(/excluded-packages-\w+\n/);
+    expect(afterClip).not.toMatch(/^\s+end\]/m);
+    expect(afterClip).toContain("target 'ClipTarget' do");
+    expect(afterClip.indexOf("target 'ClipTarget'")).toBeLessThan(
+      afterClip.indexOf('# [expo-targets-excluded-packages-begin]')
+    );
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -154,8 +154,17 @@ function indentCustomPods(podsRbContent?: string): string {
   return `\n${indented}\n`;
 }
 
-/** Parseable marker: packages to strip from this nested target's ExpoModulesProvider. */
-export const EXCLUDED_PACKAGES_MARKER = '# [expo-targets-excluded-packages]';
+/**
+ * Parseable marker: packages to strip from this nested target's ExpoModulesProvider.
+ * Must not be a prefix of the post_integrate fence markers, and those fences
+ * must not contain a Ruby `\bend\b` (standalone insert used to splice there).
+ */
+export const EXCLUDED_PACKAGES_MARKER =
+  '# [expo-targets-excluded-packages-list]';
+const EXCLUDED_PACKAGES_POST_INTEGRATE_START =
+  '# [expo-targets-excluded-packages-begin]';
+const EXCLUDED_PACKAGES_POST_INTEGRATE_END =
+  '# [expo-targets-excluded-packages-done]';
 
 /**
  * Generate a Podfile target block for a React Native extension.
@@ -334,6 +343,23 @@ end
 }
 
 /**
+ * Last `end` that opens a line (optional indent). Ignores `end` inside comments
+ * such as `# [expo-targets-*-end]`.
+ */
+function findLastLineLevelEndIndex(podfileContent: string): number {
+  const lineEnd = /^[ \t]*end\b/gm;
+  let match: RegExpExecArray | null;
+  let last: RegExpExecArray | null = null;
+  while ((match = lineEnd.exec(podfileContent)) !== null) {
+    last = match;
+  }
+  if (!last) {
+    throw new Error('Could not find any end keyword in Podfile');
+  }
+  return last.index + last[0].length;
+}
+
+/**
  * Standalone targets are inserted as siblings AFTER the main target's closing
  * `end`, which prevents CocoaPods from auto-generating Expo module providers.
  */
@@ -342,24 +368,26 @@ function insertStandaloneTargetBlock(
   targetBlock: string,
   logger?: { log: (message: string) => void }
 ): string {
-  // The main target is the outermost block in a standard Expo Podfile, so its
-  // closing 'end' is the last one in the file.
-  const lastEndMatch = podfileContent.match(/\bend\b(?!.*\bend\b)/s);
-
-  if (!lastEndMatch) {
-    throw new Error('Could not find any end keyword in Podfile');
+  const insertion = `\n\n${targetBlock.trim()}`;
+  const hookStart = podfileContent.indexOf(
+    EXCLUDED_PACKAGES_POST_INTEGRATE_START
+  );
+  if (hookStart !== -1) {
+    logger?.log(
+      'Inserting standalone target before excluded-packages post_integrate hook'
+    );
+    return `${podfileContent.slice(0, hookStart).trimEnd()}${insertion}\n\n${podfileContent.slice(hookStart)}`;
   }
 
-  const mainTargetEndIndex = lastEndMatch.index! + lastEndMatch[0].length;
+  const mainTargetEndIndex = findLastLineLevelEndIndex(podfileContent);
 
   logger?.log(
-    `Inserting standalone target after main target's closing 'end' at position ${mainTargetEndIndex}`
+    `Inserting standalone target after last line-level 'end' at position ${mainTargetEndIndex}`
   );
 
   return (
     podfileContent.slice(0, mainTargetEndIndex) +
-    '\n\n' +
-    targetBlock.trim() +
+    insertion +
     podfileContent.slice(mainTargetEndIndex)
   );
 }
@@ -789,11 +817,6 @@ export function ensureReactNativeExtensionFrameworkPaths(
     afterInsert
   );
 }
-
-const EXCLUDED_PACKAGES_POST_INTEGRATE_START =
-  '# [expo-targets-excluded-packages-start]';
-const EXCLUDED_PACKAGES_POST_INTEGRATE_END =
-  '# [expo-targets-excluded-packages-end]';
 
 function rubySingleQuoted(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
@@ -21,7 +21,8 @@ const PLATFORM_LINE = /platform\s+:ios,\s+'([^']+)'/;
 const STANDALONE_TARGET =
   /target\s+'([^']+)'\s+do\s+platform\s+:ios,\s+'([^']+)'/g;
 /** Keep in sync with EXCLUDED_PACKAGES_MARKER in podfile.ts */
-const EXCLUDED_PACKAGES_LINE = /# \[expo-targets-excluded-packages\]\s*(.+)/;
+const EXCLUDED_PACKAGES_LINE =
+  /# \[expo-targets-excluded-packages-list\]\s*(.+)/;
 
 /**
  * The main target's block, up to the `post_install` hook when there is one.

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -44,7 +44,13 @@ describe('resolveExcludedPackages user extras', () => {
         entry: './targets/action/index.tsx',
         excludedPackages: ['expo-updates', 'expo-font'],
       })
-    ).toEqual(['expo-updates', 'expo-dev-client', 'expo-font']);
+    ).toEqual([
+      'expo-updates',
+      'expo-dev-client',
+      'expo-dev-launcher',
+      'expo-dev-menu',
+      'expo-font',
+    ]);
   });
 });
 

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
@@ -5,6 +5,8 @@ import { REACT_NATIVE_NATIVE_TYPES } from './domain';
 export const HOST_ONLY_EXCLUDED_PACKAGES = [
   'expo-updates',
   'expo-dev-client',
+  'expo-dev-launcher',
+  'expo-dev-menu',
 ] as const;
 
 export type ResolveExcludedPackagesInput = {


### PR DESCRIPTION
## Summary
- Rename excluded-packages list/fence markers so the short list comment is not a prefix of `-start`/`-end`, and the fence does not contain a Ruby `\bend\b`.
- Insert standalone targets before the post_integrate fence (line-level `end` only).
- Also exclude `expo-dev-launcher` and `expo-dev-menu` so messages ExpoModulesProvider does not import `EXDevLauncher`.

## Test plan
- [x] `bun test` on podfile + resolveExcludedPackages
- [x] Popl CNG worktree: `expo prebuild --clean --no-install` → `pod install` → unsigned Debug simulator `xcodebuild` **BUILD SUCCEEDED**