### PR TITLE
feat: absorb Popl CNG workarounds into expo-targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `npx expo-targets doctor` fails when `.expo/types/expo-targets.d.ts` is missing or stale; `npx expo-targets generate` stays the no-prebuild fix.
+- Host App Groups union target `appGroup` / target entitlement groups into a non-empty host list.
+- App Clip compile phase copies host `CFBundleVersion` (EAS remote versioning).
+- Widget folder `setData` writes every kind. Live Activity `start({ replaceExisting })` defaults to true for that attributes name only.
+- RN `entry` targets infer unused heavy host packages (Sentry, reanimated, screens, netinfo) into `excludedPackages`.
+- Opt-in Android `android.qr` / `android.implementation` plus `ExpoTargetsQr.encode`.
+
 ### Changed
 
 - Android widget Kotlin lives at `targets/<name>/android/<File>.kt` (same layout as `ios/*.swift`). The `package` line still holds the FQCN.

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,8 +29,9 @@ hello.setData({ message: "Hi" }); // refresh implied on widgets
 
 // Multi-kind widget folder
 const popl = createTarget("PoplWidgets");
+popl.setData({ message: "Updated" }); // every kind
 const home = popl.widget("HomescreenWidgets");
-home.setData({ message: "Updated" });
+home.setData({ message: "Updated" }); // one kind
 const island = popl.liveActivity(); // single LA — or .liveActivity("DynamicIslandAttributes")
 const meeting = popl.liveActivity("MeetingLiveAttributes"); // when ios.liveActivities has 2+
 await island.start({ attributes: { … }, contentState: { … } });
@@ -52,7 +53,7 @@ export const share = createTarget("ShareExt", ShareExtension);
 | `name`      | `TargetName \| WidgetKindName` when generated | Folder `"name"`, or gallery kind / provider name on a multi-product widget |
 | `component` | `React.ComponentType` | _(Optional)_ For RN / expo-ui widgets. On multi-kind folders use `.widget('Kind', Layout)` instead |
 
-Multi-product widget folders (`ios.kinds` with more than one row, or a single kind whose name differs from the folder) return a **folder handle** with `.widget()` / `.liveActivity(name?)` only — not `setData`. Write data on the kind handle. When a folder declares multiple Live Activities (`ios.liveActivities`), pass `attributesName` to `.liveActivity(...)`.
+Multi-product widget folders (`ios.kinds` with more than one row, or a single kind whose name differs from the folder) return a **folder handle** with `.widget()` / `.liveActivity(name?)` / folder `.setData`. Folder `setData` writes the same payload to every kind. When a folder declares multiple Live Activities (`ios.liveActivities`), pass `attributesName` to `.liveActivity(...)`. `start` ends existing activities for that attributes name by default (`replaceExisting: false` to keep them).
 
 ### Error Handling
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ targets/my-widget/
 | `displayName`      | `name`      | Human-readable name (`CFBundleDisplayName` or `CFBundleName` on iOS; widget picker label)                                                                          |
 | `appGroup`         | _inherited_ | App Group ID. When omitted, inherits from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
 | `entry`            | —           | React Native entry point for share, action, clip, and messages (see [Entry Field](#entry-field) below)                                                                  |
-| `excludedPackages` | auto for RN `entry` | Extra packages to omit from the nested `ExpoModulesProvider` (`post_integrate`). `expo-updates` and `expo-dev-client` are always merged for RN-native `entry` targets. List only extras (for example reanimated) |
+| `excludedPackages` | auto for RN `entry` | Extra packages to omit from the nested `ExpoModulesProvider` (`post_integrate`). Crash-class packages (`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) are always merged for RN-native `entry` targets. Unused heavy host packages (Sentry, reanimated, screens, netinfo) are inferred when the entry does not import them. List only extras the infer pass misses |
 
 ### Entry Field
 
@@ -371,6 +371,8 @@ Android widgets are supported with **Glance** (Jetpack Compose) or **RemoteViews
 | `providers`          | —                        | Opt-in list of AppWidgetProvider rows. Empty or omitted = 1:1 path  |
 | `colors`             | `{}`                     | Named colors for Android resources                                  |
 | `images`             | `{}`                     | Named images copied into `android/res/drawable*`                    |
+| `implementation`     | `[]`                     | Extra Gradle `implementation("…")` coordinates on the host app      |
+| `qr`                 | `false`                  | Inject ZXing core + `ExpoTargetsQr.encode` helper                   |
 
 When `android.providers` is omitted or empty, the plugin registers one receiver from the scalar fields. The RemoteViews class name stays `{package}.widget.{sanitizedName}.{Pascal}Provider`. The Glance class name stays `{package}.widget.{sanitizedName}.{Pascal}WidgetReceiver`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ Add the plugin and App Groups to your `app.json`:
 
 Update the placeholder `appGroup` to match your `app.json`.
 
-For RN `entry` targets, the plugin **always** strips `expo-updates` and `expo-dev-client` from the nested `ExpoModulesProvider` (they crash appex processes). Add `excludedPackages` only for **extra** packages (for example reanimated). `npx expo-targets doctor` warns when heavy host deps look unused by the entry.
+For RN `entry` targets, the plugin **always** strips `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` from the nested `ExpoModulesProvider` (they crash appex processes). Unused heavy host packages (Sentry, reanimated) are inferred when the entry does not import them. Add `excludedPackages` only for extras the infer pass misses.
 
 Extension JS can still OTA without linking Updates in the appex: the host runs `eas update`, then sideloads Hermes bundles into the App Group. Set a string `expo.runtimeVersion`, run `npx expo-targets export-extension-bundles` before each update, and use a **Release** build to verify the share sheet. Full flow: [Extension bundle sideload](./react-native-extensions.md#extension-bundle-sideload-with-expo-updates).
 
@@ -154,7 +154,13 @@ await orderLive.start({
 
 Apps that only extend `expo/tsconfig.base` (no `include`) already load `.expo/types/*.d.ts` — `generate` does **not** invent an `include`. If `include` is already set (for example Expo Router), it appends `.expo/types/**/*.ts` when missing.
 
-Regenerate without a full prebuild: `npx expo-targets generate` (also runs with `npx expo-targets doctor --fix`).
+Regenerate without a full prebuild: `npx expo-targets generate` (also runs with `npx expo-targets doctor --fix`). Typecheck in CI:
+
+```bash
+npx expo-targets generate && npx tsc --noEmit
+```
+
+`npx expo-targets doctor` **fails** when `.expo/types/expo-targets.d.ts` is missing or stale versus `targets/`.
 
 ## Step 5: Build and run
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -362,9 +362,10 @@ Omit host-only Expo modules from the nested extension's `ExpoModulesProvider`. N
 strips the listed packages from `expo-configure-project.sh` in a `post_integrate`
 hook and regenerates the provider.
 
-For RN-native targets with `entry`, **`expo-updates` and `expo-dev-client` are always
+For RN-native targets with `entry`, **`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` are always
 union-merged** (no escape hatch). Updates asserts before the RN factory is ready and
-blanks the sheet. List only **additional** packages:
+blanks the sheet. Unused heavy host packages (Sentry, reanimated, screens, netinfo)
+are inferred when the entry does not import them. List only **additional** packages:
 
 ```json
 {
@@ -375,9 +376,8 @@ blanks the sheet. List only **additional** packages:
 }
 ```
 
-`npx expo-targets doctor` **warns** when heavy host dependencies (reanimated, Sentry,
-screens, netinfo, and others) are present but not imported from the extension entry and not yet
-excluded. This is advisory only. It never auto-strips.
+`npx expo-targets doctor` is quiet when unused heavies are already inferred into the exclude list.
+It still warns only if a heavy remains after that merge.
 
 **Auto-excluded (always):**
 
@@ -385,14 +385,19 @@ excluded. This is advisory only. It never auto-strips.
 | ----------------- | ---------------------- | ------- |
 | `expo-updates`    | Crashes appex process  | ~500KB  |
 | `expo-dev-client` | Host-only dev tooling  | ~800KB  |
+| `expo-dev-launcher` | Host-only dev tooling | — |
+| `expo-dev-menu`   | Host-only dev tooling  | — |
 
-**Common extra exclusions:**
+**Inferred when unused by the entry:**
 
 | Package                   | Reason                     | Savings |
 | ------------------------- | -------------------------- | ------- |
 | `react-native-reanimated` | Heavy animation library    | ~1.5MB  |
 | `@sentry/react-native`    | Error reporting not needed | ~1MB    |
 | `react-native-screens`    | Native nav not needed      | ~300KB  |
+| `@react-native-community/netinfo` | Host networking     | — |
+
+**Common extra exclusions:**
 
 ### Tips for Smaller Bundles
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -30,7 +30,7 @@ expo-targets can depend on `expo-widgets` **as a private library** for the layou
 | expo-widgets | expo-targets |
 | --- | --- |
 | `createWidget(name, Layout)` | `createTarget(name, Layout)` + `entry`, or `createTarget('Folder').widget('Kind', Layout)` |
-| `updateSnapshot(props)` | `setData(props)` on a widget **kind** handle (refresh implied) |
+| `updateSnapshot(props)` | `setData(props)` on a widget **kind** handle, or folder `setData` for every kind (refresh implied) |
 | `updateTimeline(entries)` | `setTimeline(entries)` — `{ date, props }` |
 | `getTimeline()` | `getTimeline()` |
 | `reload()` | `refresh()` |
@@ -88,6 +88,7 @@ if (!(await areLiveActivitiesEnabled())) {
 const id = await orderLive.start({
   attributes: { orderId: '12' },
   contentState: { status: 'preparing', progress: 0.1 },
+  // replaceExisting defaults to true (ends this attributesName only)
 });
 await orderLive.update(id, { status: 'ready', progress: 1 });
 await LiveActivity.endAll();
@@ -194,6 +195,8 @@ Android home-screen widgets (Glance / RemoteViews) are **first-class** in expo-t
 - `Bump` button → increments taps, refreshes the tile, emits `addUserInteractionListener` (`source` / `target`)
 
 See `examples/widgets` (`HelloExpoUi` has two expo-ui kinds plus `ios.liveActivity`; `HelloRemoteViewsBundle` has two Android providers). Scaffolded Glance targets get the same chrome + Bump stub.
+
+For QR tiles, set `android.qr: true` (injects ZXing) and call `ExpoTargetsQr.encode(text, sizePx)` from RemoteViews deepen. Or list extra Gradle coordinates in `android.implementation`.
 
 One `type: widget` folder can list many iOS picker products in `ios.kinds` (one `.appex`) and many Android `AppWidgetProvider` rows in `android.providers[]`. `supportedFamilies` on a kind is sizes of that row, not extra products.
 

--- a/examples/trick/App.tsx
+++ b/examples/trick/App.tsx
@@ -7,8 +7,6 @@ import { FileProviderDomain } from 'expo-targets';
 import { useCallback, useEffect, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
-import { trickLiveActivityActivity } from './targets/trick-widgets';
-
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,

--- a/examples/widgets/App.tsx
+++ b/examples/widgets/App.tsx
@@ -2,7 +2,6 @@ import { StatusBar } from 'expo-status-bar';
 import {
   addUserInteractionListener,
   areLiveActivitiesEnabled,
-  endLiveActivity,
   LiveActivity,
   requestPinWidget,
 } from 'expo-targets';
@@ -29,7 +28,12 @@ import {
   updateRemoteViewsMessage,
 } from './targets/hello-remoteviews';
 import { helloRemoteViewsBundle } from './targets/hello-remoteviews-bundle';
-import { getMessage, helloWidget, helloWidgetLiveActivity, updateMessage } from './targets/hello-widget';
+import {
+  getMessage,
+  helloWidget,
+  helloWidgetLiveActivity,
+  updateMessage,
+} from './targets/hello-widget';
 
 // Keep layout registration reachable (tree-shake guard).
 void helloExpoUiLiveActivity;
@@ -456,7 +460,7 @@ async function updateLiveActivity(
   setLiveStatus('updated:ready');
 }
 
-async function endLiveActivity(
+async function endDemoLiveActivity(
   liveId: string | null,
   setLiveId: (id: string | null) => void,
   setLiveStatus: (status: string) => void
@@ -530,7 +534,7 @@ function NativeLiveActivitySection({
         label="End Live Activity"
         tone="danger"
         onPress={() => {
-          void endLiveActivity(liveId, setLiveId, setLiveStatus);
+          void endDemoLiveActivity(liveId, setLiveId, setLiveStatus);
         }}
       />
       <Text testID="text-live-status" style={styles.mono}>
@@ -580,7 +584,7 @@ function ExpoUiLiveActivitySection({
         label="End Expo UI Live Activity"
         tone="danger"
         onPress={() => {
-          void endLiveActivity(
+          void endDemoLiveActivity(
             expoUiLiveId,
             setExpoUiLiveId,
             setExpoUiLiveStatus

--- a/packages/expo-targets/android/build.gradle
+++ b/packages/expo-targets/android/build.gradle
@@ -24,5 +24,6 @@ dependencies {
   compileOnly 'com.facebook.react:react-android'
   // FCM receive path — resolved from the app (expo-notifications / google-services)
   compileOnly 'com.google.firebase:firebase-messaging:24.1.0'
+  compileOnly 'com.google.zxing:core:3.4.1'
 }
 

--- a/packages/expo-targets/android/src/main/java/expo/modules/targets/ExpoTargetsQr.kt
+++ b/packages/expo-targets/android/src/main/java/expo/modules/targets/ExpoTargetsQr.kt
@@ -1,0 +1,25 @@
+package expo.modules.targets
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+
+/**
+ * QR encode helper for RemoteViews / Glance deepen.
+ * Requires `android.qr: true` (or an explicit ZXing `implementation`) on the widget config.
+ */
+object ExpoTargetsQr {
+    @JvmStatic
+    fun encode(text: String, sizePx: Int): Bitmap {
+        val writer = QRCodeWriter()
+        val matrix = writer.encode(text, BarcodeFormat.QR_CODE, sizePx, sizePx)
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        for (x in 0 until sizePx) {
+            for (y in 0 until sizePx) {
+                bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
+            }
+        }
+        return bitmap
+    }
+}

--- a/packages/expo-targets/android/src/main/java/expo/modules/targets/liveActivity/ExpoTargetsLiveActivityModule.kt
+++ b/packages/expo-targets/android/src/main/java/expo/modules/targets/liveActivity/ExpoTargetsLiveActivityModule.kt
@@ -86,6 +86,22 @@ class ExpoTargetsLiveActivityModule : Module() {
       persistIds(ctx)
     }
 
+    AsyncFunction("endAllForAttributes") { attributesName: String ->
+      val ctx =
+        appContext.reactContext
+          ?: throw Exception("React context unavailable")
+      val loaded = loadIds(ctx)
+      val toEnd =
+        (activeIds.filter { it.value == attributesName }.keys +
+          loaded.filter { it.value == attributesName }.keys)
+          .toSet()
+      for (id in toEnd) {
+        ExpoTargetsNotificationRouter.cancelOngoing(ctx, id)
+        activeIds.remove(id)
+      }
+      persistIds(ctx)
+    }
+
     AsyncFunction("areActivitiesEnabled") {
       val ctx =
         appContext.reactContext
@@ -137,12 +153,30 @@ class ExpoTargetsLiveActivityModule : Module() {
     ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
   private fun persistIds(ctx: Context) {
-    prefs(ctx).edit().putString(KEY_IDS, activeIds.keys.joinToString(",")).commit()
+    val json = JSONObject()
+    for ((id, name) in activeIds) {
+      json.put(id, name)
+    }
+    prefs(ctx).edit().putString(KEY_IDS, json.toString()).commit()
   }
 
   private fun loadIds(ctx: Context): Map<String, String> {
     val raw = prefs(ctx).getString(KEY_IDS, "") ?: ""
     if (raw.isEmpty()) return emptyMap()
+    if (raw.startsWith("{")) {
+      return try {
+        val obj = JSONObject(raw)
+        val out = mutableMapOf<String, String>()
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+          val id = keys.next()
+          out[id] = obj.optString(id, "live")
+        }
+        out
+      } catch (_: Exception) {
+        emptyMap()
+      }
+    }
     return raw.split(',').filter { it.isNotEmpty() }.associateWith { "live" }
   }
 

--- a/packages/expo-targets/cli/src/checks/generatedTypes.test.ts
+++ b/packages/expo-targets/cli/src/checks/generatedTypes.test.ts
@@ -4,8 +4,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { writeTargetsTypesFile } from '../../../plugin/src/codegen/typedTargets';
-import { checkGeneratedTypes } from './generatedTypes';
 import { loadProject } from '../project';
+import { checkGeneratedTypes } from './generatedTypes';
 
 const roots: string[] = [];
 

--- a/packages/expo-targets/cli/src/checks/generatedTypes.test.ts
+++ b/packages/expo-targets/cli/src/checks/generatedTypes.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { writeTargetsTypesFile } from '../../../plugin/src/codegen/typedTargets';
+import { checkGeneratedTypes } from './generatedTypes';
+import { loadProject } from '../project';
+
+const roots: string[] = [];
+
+function makeProject(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-types-'));
+  roots.push(root);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const shareTarget = {
+  'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
+  'targets/share/expo-target.config.json': JSON.stringify({
+    type: 'share',
+    name: 'Share',
+    platforms: ['ios'],
+  }),
+};
+
+describe('checkGeneratedTypes', () => {
+  test('errors when .d.ts is missing', () => {
+    const root = makeProject(shareTarget);
+    const results = checkGeneratedTypes(loadProject(root));
+    expect(results).toHaveLength(1);
+    expect(results[0]?.message).toContain('Missing');
+    expect(results[0]?.fix).toContain('expo-targets generate');
+  });
+
+  test('errors when .d.ts is stale', () => {
+    const root = makeProject(shareTarget);
+    writeTargetsTypesFile(root, [{ name: 'OldShare' }]);
+    const results = checkGeneratedTypes(loadProject(root));
+    expect(results[0]?.message).toContain('stale');
+  });
+
+  test('passes after generate-equivalent write', () => {
+    const root = makeProject(shareTarget);
+    writeTargetsTypesFile(root, [{ name: 'Share', type: 'share' }]);
+    expect(checkGeneratedTypes(loadProject(root))).toEqual([]);
+  });
+});

--- a/packages/expo-targets/cli/src/checks/generatedTypes.ts
+++ b/packages/expo-targets/cli/src/checks/generatedTypes.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  collectRuntimeConfigs,
+  formatTargetsTypesFile,
+  GENERATED_RELATIVE_PATH,
+  widgetKindNamesForCodegen,
+} from 'expo-targets/codegen';
+
+import type { CheckResult, ProjectContext } from '../types';
+
+function expectedTypesContents(ctx: ProjectContext): string {
+  const runtimeConfigs = collectRuntimeConfigs(
+    ctx.targets
+      .filter((target) => Boolean(target.config.name))
+      .map((target) => ({
+        config:
+          target.config as import('expo-targets/codegen').RuntimeTargetConfig,
+      })),
+    {
+      ios: ctx.expo.ios as
+        | { entitlements?: Record<string, unknown> }
+        | undefined,
+    }
+  );
+
+  return formatTargetsTypesFile(
+    runtimeConfigs.map((cfg) => ({
+      name: cfg.name,
+      type: cfg.type,
+      ios: cfg.ios,
+      android: cfg.android,
+      widgetKinds: widgetKindNamesForCodegen(cfg),
+      liveActivity: cfg.liveActivity,
+      liveActivities: cfg.liveActivities,
+    }))
+  );
+}
+
+export function checkGeneratedTypes(ctx: ProjectContext): CheckResult[] {
+  if (ctx.targets.length === 0) {
+    return [];
+  }
+
+  const filePath = path.join(ctx.projectRoot, GENERATED_RELATIVE_PATH);
+  const expected = expectedTypesContents(ctx);
+  const fix = 'Run `npx expo-targets generate` (no full prebuild).';
+
+  if (!fs.existsSync(filePath)) {
+    return [
+      {
+        ok: false,
+        level: 'error',
+        title: 'Generated types',
+        message: `Missing ${GENERATED_RELATIVE_PATH}`,
+        fix,
+      },
+    ];
+  }
+
+  const actual = fs.readFileSync(filePath, 'utf8');
+  if (actual !== expected) {
+    return [
+      {
+        ok: false,
+        level: 'error',
+        title: 'Generated types',
+        message: `${GENERATED_RELATIVE_PATH} is stale relative to targets/`,
+        fix,
+      },
+    ];
+  }
+
+  return [];
+}

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   }
 });
 
-test('warnHeavyExclusions warns when heavy dep is unused by entry and not excluded', () => {
+test('warnHeavyExclusions quiet when unused heavy is auto-inferred', () => {
   const root = makeProject({
     'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
     'package.json': JSON.stringify({
@@ -39,10 +39,7 @@ test('warnHeavyExclusions warns when heavy dep is unused by entry and not exclud
     'targets/share/index.tsx':
       "import { View } from 'react-native';\nexport default function App() { return null; }\n",
   });
-  const warnings = warnHeavyExclusions(loadProject(root));
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0]?.message).toContain('react-native-reanimated');
-  expect(warnings[0]?.fix).toContain('excludedPackages');
+  expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
 });
 
 test('warnHeavyExclusions quiet when entry imports the package', () => {

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.ts
@@ -1,16 +1,12 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
-import { resolveExcludedPackages } from '../../../plugin/build/resolveExcludedPackages';
+import {
+  collectImportsFromEntry,
+  HEAVY_EXCLUSION_CANDIDATES,
+  readPackageDeps,
+} from '../../../plugin/src/entryGraph';
+import { resolveExcludedPackages } from '../../../plugin/src/resolveExcludedPackages';
 import type { CheckResult, ProjectContext } from '../types';
 
-/** Heavy / host-leaning packages worth warning about when unused by the entry. */
-export const HEAVY_EXCLUSION_CANDIDATES = [
-  'react-native-reanimated',
-  '@sentry/react-native',
-  'react-native-screens',
-  '@react-native-community/netinfo',
-] as const;
+export { HEAVY_EXCLUSION_CANDIDATES };
 
 const RN_NATIVE_TYPES = new Set([
   'share',
@@ -19,115 +15,6 @@ const RN_NATIVE_TYPES = new Set([
   'messages',
   'notification-content',
 ]);
-
-const IMPORT_RE = /(?:from\s+|require\s*\(\s*)['"](@?[^'"]+)['"]/g;
-
-function readPackageDeps(projectRoot: string): Set<string> {
-  const pkgPath = path.join(projectRoot, 'package.json');
-  if (!fs.existsSync(pkgPath)) {
-    return new Set();
-  }
-  try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    return new Set([
-      ...Object.keys(pkg.dependencies ?? {}),
-      ...Object.keys(pkg.devDependencies ?? {}),
-    ]);
-  } catch {
-    return new Set();
-  }
-}
-
-function packageRoot(specifier: string): string {
-  if (specifier.startsWith('@')) {
-    const parts = specifier.split('/');
-    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
-  }
-  return specifier.split('/')[0] ?? specifier;
-}
-
-function resolveLocal(fromDir: string, spec: string): string | null {
-  const base = path.resolve(fromDir, spec);
-  const candidates = [
-    base,
-    `${base}.ts`,
-    `${base}.tsx`,
-    `${base}.js`,
-    `${base}.jsx`,
-    path.join(base, 'index.ts'),
-    path.join(base, 'index.tsx'),
-    path.join(base, 'index.js'),
-    path.join(base, 'index.jsx'),
-  ];
-  for (const c of candidates) {
-    if (fs.existsSync(c) && fs.statSync(c).isFile()) {
-      return c;
-    }
-  }
-  return null;
-}
-
-function readSourceFile(file: string): string | null {
-  try {
-    return fs.readFileSync(file, 'utf8');
-  } catch {
-    return null;
-  }
-}
-
-function collectSpecifiersFromSource(opts: {
-  source: string;
-  file: string;
-  queue: string[];
-}): string[] {
-  const roots: string[] = [];
-  for (const match of opts.source.matchAll(IMPORT_RE)) {
-    const spec = match[1];
-    if (!spec) continue;
-    if (spec.startsWith('.') || spec.startsWith('/')) {
-      const resolved = resolveLocal(path.dirname(opts.file), spec);
-      if (resolved) {
-        opts.queue.push(resolved);
-      }
-      continue;
-    }
-    roots.push(packageRoot(spec));
-  }
-  return roots;
-}
-
-function collectImportsFromEntry(
-  projectRoot: string,
-  entryRel: string
-): Set<string> {
-  const seen = new Set<string>();
-  const visited = new Set<string>();
-  const queue: string[] = [path.resolve(projectRoot, entryRel)];
-
-  while (queue.length > 0) {
-    const file = queue.pop();
-    if (!file || visited.has(file) || !fs.existsSync(file)) {
-      continue;
-    }
-    visited.add(file);
-    const source = readSourceFile(file);
-    if (!source) {
-      continue;
-    }
-    for (const root of collectSpecifiersFromSource({
-      source,
-      file,
-      queue,
-    })) {
-      seen.add(root);
-    }
-  }
-
-  return seen;
-}
 
 function findUnusedHeavyCandidates(opts: {
   deps: Set<string>;
@@ -159,6 +46,7 @@ function warnTargetHeavyExclusions(
       type,
       entry,
       excludedPackages,
+      projectRoot: ctx.projectRoot,
     }) ?? []
   );
   const imported = collectImportsFromEntry(ctx.projectRoot, entry);

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.ts
@@ -2,8 +2,8 @@ import {
   collectImportsFromEntry,
   HEAVY_EXCLUSION_CANDIDATES,
   readPackageDeps,
-} from '../../../plugin/src/entryGraph';
-import { resolveExcludedPackages } from '../../../plugin/src/resolveExcludedPackages';
+} from '../../../plugin/build/entryGraph';
+import { resolveExcludedPackages } from '../../../plugin/build/resolveExcludedPackages';
 import type { CheckResult, ProjectContext } from '../types';
 
 export { HEAVY_EXCLUSION_CANDIDATES };

--- a/packages/expo-targets/cli/src/checks/liveActivitiesConfig.ts
+++ b/packages/expo-targets/cli/src/checks/liveActivitiesConfig.ts
@@ -1,42 +1,57 @@
 import type { CheckResult, ProjectContext } from '../types';
 
+type WidgetTarget = ProjectContext['targets'][number];
+
+function mixedLiveActivityError(dirName: string): CheckResult {
+  return {
+    ok: false,
+    level: 'error',
+    title: 'Live Activity config',
+    message: `targets/${dirName}: use ios.liveActivities OR ios.liveActivity, not both.`,
+    fix: 'Move all Live Activity rows onto ios.liveActivities, or keep a single ios.liveActivity object.',
+  };
+}
+
+function duplicateAttributesError(dirName: string, name: string): CheckResult {
+  return {
+    ok: false,
+    level: 'error',
+    title: 'Live Activity config',
+    message: `targets/${dirName}: duplicate ios.liveActivities attributesName "${name}".`,
+    fix: 'Use a unique attributesName for each Live Activity in the target.',
+  };
+}
+
+function firstDuplicateName(names: string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) {
+      return name;
+    }
+    seen.add(name);
+  }
+}
+
+function widgetLiveActivityErrors(target: WidgetTarget): CheckResult[] {
+  const ios = target.config.ios;
+  const hasSingular = Boolean(ios?.liveActivity?.attributesName);
+  const hasArray = Boolean(ios?.liveActivities?.length);
+  if (hasSingular && hasArray) {
+    return [mixedLiveActivityError(target.dirName)];
+  }
+  const names = (ios?.liveActivities ?? [])
+    .map((row) => row.attributesName)
+    .filter((name): name is string => Boolean(name));
+  const duplicate = firstDuplicateName(names);
+  if (duplicate) {
+    return [duplicateAttributesError(target.dirName, duplicate)];
+  }
+  return [];
+}
+
 /** Fail when a widget mixes singular and array Live Activity config. */
 export function checkLiveActivitiesConfig(ctx: ProjectContext): CheckResult[] {
-  const errors: CheckResult[] = [];
-  for (const target of ctx.targets) {
-    if (target.config.type !== 'widget') {
-      continue;
-    }
-    const ios = target.config.ios;
-    const hasSingular = Boolean(ios?.liveActivity?.attributesName);
-    const hasArray = Boolean(ios?.liveActivities?.length);
-    if (hasSingular && hasArray) {
-      errors.push({
-        ok: false,
-        level: 'error',
-        title: 'Live Activity config',
-        message: `targets/${target.dirName}: use ios.liveActivities OR ios.liveActivity, not both.`,
-        fix: 'Move all Live Activity rows onto ios.liveActivities, or keep a single ios.liveActivity object.',
-      });
-      continue;
-    }
-    const names = (ios?.liveActivities ?? [])
-      .map((row) => row.attributesName)
-      .filter((name): name is string => Boolean(name));
-    const seen = new Set<string>();
-    for (const name of names) {
-      if (seen.has(name)) {
-        errors.push({
-          ok: false,
-          level: 'error',
-          title: 'Live Activity config',
-          message: `targets/${target.dirName}: duplicate ios.liveActivities attributesName "${name}".`,
-          fix: 'Use a unique attributesName for each Live Activity in the target.',
-        });
-        break;
-      }
-      seen.add(name);
-    }
-  }
-  return errors;
+  return ctx.targets
+    .filter((target) => target.config.type === 'widget')
+    .flatMap(widgetLiveActivityErrors);
 }

--- a/packages/expo-targets/cli/src/checks/liveActivityHostApi.ts
+++ b/packages/expo-targets/cli/src/checks/liveActivityHostApi.ts
@@ -77,68 +77,84 @@ function parseLiveActivityHelperNames(filePath: string): string[] {
   return names;
 }
 
+function warnDeprecatedGlobal(
+  target: ProjectContext['targets'][number],
+  helper: string,
+  configured: string[]
+): CheckResult {
+  return {
+    ok: false,
+    level: 'warn',
+    title: 'Live Activity host API',
+    message: `targets/${target.dirName}: prefer createTarget('${target.config.name}').liveActivity('AttributesName') over LiveActivity.create / createLiveActivity / LiveActivity.start in ${path.basename(helper)}.`,
+    fix: `export const la = createTarget('${target.config.name}').liveActivity('${configured[0] ?? 'AttributesName'}');`,
+  };
+}
+
+function warnSingularHelperMissing(
+  target: ProjectContext['targets'][number],
+  helper: string,
+  attributesName: string
+): CheckResult {
+  return {
+    ok: false,
+    level: 'warn',
+    title: 'Live Activity host API',
+    message: `targets/${target.dirName}: ios.liveActivity is configured but ${path.basename(helper)} does not call .liveActivity().`,
+    fix: `Add: export const island = createTarget('${target.config.name}').liveActivity('${attributesName}');`,
+  };
+}
+
+function warnMultiHelperMissing(
+  target: ProjectContext['targets'][number],
+  helper: string,
+  names: { configured: string[]; missing: string[] }
+): CheckResult {
+  return {
+    ok: false,
+    level: 'warn',
+    title: 'Live Activity host API',
+    message: `targets/${target.dirName}: missing .liveActivity(${JSON.stringify(names.missing[0])}) in ${path.basename(helper)} (configured: ${names.configured.join(', ')}).`,
+    fix: `Add .liveActivity('${names.missing[0]}') for each ios.liveActivities row.`,
+  };
+}
+
+function checkWidgetLiveActivityHost(
+  target: ProjectContext['targets'][number]
+): CheckResult[] {
+  const configured = configuredLiveActivityNames(target.config.ios);
+  if (configured.length === 0) {
+    return [];
+  }
+  const helper = helperPath(path.dirname(target.configPath));
+  if (!helper) {
+    return [];
+  }
+  const source = fs.readFileSync(helper, 'utf8');
+  if (usesDeprecatedGlobalLiveActivity(source)) {
+    return [warnDeprecatedGlobal(target, helper, configured)];
+  }
+  const wired = parseLiveActivityHelperNames(helper);
+  const covered = new Set(wired);
+  const missing = configured.filter((name) => !covered.has(name));
+  if (missing.length === 0) {
+    return [];
+  }
+  if (configured.length === 1 && wired.length === 0) {
+    if (usesNoArgLiveActivityHelper(source)) {
+      return [];
+    }
+    return [warnSingularHelperMissing(target, helper, configured[0] ?? '')];
+  }
+  if (configured.length > 1) {
+    return [warnMultiHelperMissing(target, helper, { configured, missing })];
+  }
+  return [];
+}
+
 /** Warn when target entries use deprecated global Live Activity factories. */
 export function checkLiveActivityHostApi(ctx: ProjectContext): CheckResult[] {
-  const results: CheckResult[] = [];
-
-  for (const target of ctx.targets) {
-    if (target.config.type !== 'widget') {
-      continue;
-    }
-
-    const configured = configuredLiveActivityNames(target.config.ios);
-    if (configured.length === 0) {
-      continue;
-    }
-
-    const helper = helperPath(path.dirname(target.configPath));
-    if (!helper) {
-      continue;
-    }
-
-    const source = fs.readFileSync(helper, 'utf8');
-    if (usesDeprecatedGlobalLiveActivity(source)) {
-      results.push({
-        ok: false,
-        level: 'warn',
-        title: 'Live Activity host API',
-        message: `targets/${target.dirName}: prefer createTarget('${target.config.name}').liveActivity('AttributesName') over LiveActivity.create / createLiveActivity / LiveActivity.start in ${path.basename(helper)}.`,
-        fix: `export const la = createTarget('${target.config.name}').liveActivity('${configured[0] ?? 'AttributesName'}');`,
-      });
-      continue;
-    }
-
-    const wired = parseLiveActivityHelperNames(helper);
-    const covered = new Set(wired);
-    const missing = configured.filter((name) => !covered.has(name));
-    if (missing.length === 0) {
-      continue;
-    }
-
-    if (configured.length === 1 && wired.length === 0) {
-      if (usesNoArgLiveActivityHelper(source)) {
-        continue;
-      }
-      results.push({
-        ok: false,
-        level: 'warn',
-        title: 'Live Activity host API',
-        message: `targets/${target.dirName}: ios.liveActivity is configured but ${path.basename(helper)} does not call .liveActivity().`,
-        fix: `Add: export const island = createTarget('${target.config.name}').liveActivity('${configured[0]}');`,
-      });
-      continue;
-    }
-
-    if (missing.length > 0 && configured.length > 1) {
-      results.push({
-        ok: false,
-        level: 'warn',
-        title: 'Live Activity host API',
-        message: `targets/${target.dirName}: missing .liveActivity(${JSON.stringify(missing[0])}) in ${path.basename(helper)} (configured: ${configured.join(', ')}).`,
-        fix: `Add .liveActivity('${missing[0]}') for each ios.liveActivities row.`,
-      });
-    }
-  }
-
-  return results;
+  return ctx.targets
+    .filter((target) => target.config.type === 'widget')
+    .flatMap(checkWidgetLiveActivityHost);
 }

--- a/packages/expo-targets/cli/src/doctor.test.ts
+++ b/packages/expo-targets/cli/src/doctor.test.ts
@@ -432,7 +432,9 @@ describe('checkLiveActivityHostApi', () => {
     expect(warnings[0]?.level).toBe('warn');
     expect(warnings[0]?.message).toContain('.liveActivity(');
   });
+});
 
+describe('checkLiveActivityHostApi folder helper', () => {
   test('passes when target index uses folder.liveActivity()', () => {
     const root = makeProject({
       'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
@@ -451,7 +453,7 @@ describe('checkLiveActivityHostApi', () => {
       'targets/widget/index.ts':
         "import { createTarget } from 'expo-targets';\n" +
         "export const hello = createTarget('HelloWidget');\n" +
-        "export const la = hello.liveActivity();\n",
+        'export const la = hello.liveActivity();\n',
     });
     expect(checkLiveActivityHostApi(loadProject(root))).toHaveLength(0);
   });

--- a/packages/expo-targets/cli/src/doctor.ts
+++ b/packages/expo-targets/cli/src/doctor.ts
@@ -7,9 +7,10 @@ import {
   checkEasCredentialWarnings,
 } from './checks/easCredentials';
 import { checkEntries } from './checks/entries';
+import { checkGeneratedTypes } from './checks/generatedTypes';
 import { warnHeavyExclusions } from './checks/heavyExclusions';
-import { checkLiveActivityHostApi } from './checks/liveActivityHostApi';
 import { checkLiveActivitiesConfig } from './checks/liveActivitiesConfig';
+import { checkLiveActivityHostApi } from './checks/liveActivityHostApi';
 import { checkLiveActivityKind } from './checks/liveActivityKind';
 import { checkMetro } from './checks/metro';
 import { checkNameSync } from './checks/nameSync';
@@ -43,6 +44,7 @@ function collectFailures(ctx: ReturnType<typeof loadProject>): CheckResult[] {
   results.push(...checkLiveActivityKind(ctx));
   results.push(...checkLiveActivitiesConfig(ctx));
   results.push(...checkEasCredentialErrors(ctx));
+  results.push(...checkGeneratedTypes(ctx));
   return results;
 }
 

--- a/packages/expo-targets/cli/src/expo-targets-codegen.d.ts
+++ b/packages/expo-targets/cli/src/expo-targets-codegen.d.ts
@@ -46,6 +46,26 @@ declare module 'expo-targets/codegen' {
     cfg: Pick<RuntimeTargetConfig, 'name' | 'ios'>
   ): string[];
 
+  export function formatTargetsTypesFile(
+    configs: Array<{
+      name: string;
+      type?: string;
+      ios?: RuntimeTargetConfig['ios'];
+      android?: RuntimeTargetConfig['android'];
+      widgetKinds?: string[];
+      liveActivity?: {
+        attributesName?: string;
+        static?: Record<string, LiveActivityFieldType>;
+        contentState?: Record<string, LiveActivityFieldType>;
+      };
+      liveActivities?: Array<{
+        attributesName?: string;
+        static?: Record<string, LiveActivityFieldType>;
+        contentState?: Record<string, LiveActivityFieldType>;
+      }>;
+    }>
+  ): string;
+
   export function writeTargetsTypesFile(
     projectRoot: string,
     configs: Array<{

--- a/packages/expo-targets/ios/ExpoTargetsLiveActivityModule.swift
+++ b/packages/expo-targets/ios/ExpoTargetsLiveActivityModule.swift
@@ -54,6 +54,15 @@ public class ExpoTargetsLiveActivityModule: Module {
       }
     }
 
+    AsyncFunction("endAllForAttributes") { (attributesName: String) in
+      guard #available(iOS 16.2, *) else { return }
+      ensureGeneratedBridgeRegistered(attributesName)
+      guard let handler = ExpoTargetsLiveActivityBridge.handler(for: attributesName) else {
+        return
+      }
+      try await handler.endAll()
+    }
+
     AsyncFunction("areActivitiesEnabled") { () -> Bool in
       guard #available(iOS 16.2, *) else { return false }
       return ActivityAuthorizationInfo().areActivitiesEnabled

--- a/packages/expo-targets/plugin/src/android/extraImplementations.test.ts
+++ b/packages/expo-targets/plugin/src/android/extraImplementations.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  appendGradleImplementations,
+  resolveAndroidExtraImplementations,
+  ZXING_CORE_COORD,
+} from './extraImplementations';
+
+describe('resolveAndroidExtraImplementations', () => {
+  test('empty when qr is off and implementation omitted', () => {
+    expect(resolveAndroidExtraImplementations()).toEqual([]);
+    expect(resolveAndroidExtraImplementations({})).toEqual([]);
+  });
+
+  test('qr true injects ZXing', () => {
+    expect(resolveAndroidExtraImplementations({ qr: true })).toEqual([
+      ZXING_CORE_COORD,
+    ]);
+  });
+
+  test('custom implementation list is preserved; qr does not duplicate ZXing', () => {
+    expect(
+      resolveAndroidExtraImplementations({
+        qr: true,
+        implementation: [ZXING_CORE_COORD, 'com.example:lib:1.0'],
+      })
+    ).toEqual([ZXING_CORE_COORD, 'com.example:lib:1.0']);
+  });
+});
+
+describe('appendGradleImplementations', () => {
+  test('inserts missing coordinates into dependencies', () => {
+    const next = appendGradleImplementations('dependencies {\n}', [
+      'com.google.zxing:core:3.4.1',
+    ]);
+    expect(next).toContain('implementation("com.google.zxing:core:3.4.1")');
+  });
+
+  test('is idempotent', () => {
+    const once = appendGradleImplementations('dependencies {\n}', [
+      ZXING_CORE_COORD,
+    ]);
+    const twice = appendGradleImplementations(once, [ZXING_CORE_COORD]);
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/expo-targets/plugin/src/android/extraImplementations.ts
+++ b/packages/expo-targets/plugin/src/android/extraImplementations.ts
@@ -1,0 +1,43 @@
+import type { AndroidTargetConfig } from '../config';
+
+export const ZXING_CORE_COORD = 'com.google.zxing:core:3.4.1';
+
+/** Gradle `implementation` coordinates from widget android config. */
+export function resolveAndroidExtraImplementations(
+  android?: AndroidTargetConfig
+): string[] {
+  const extra = android?.implementation ?? [];
+  const coords = extra.filter(
+    (c): c is string => typeof c === 'string' && c.length > 0
+  );
+  if (
+    android?.qr === true &&
+    !coords.some((c) => c.includes('com.google.zxing:core'))
+  ) {
+    return [...coords, ZXING_CORE_COORD];
+  }
+  return coords;
+}
+
+export function appendGradleImplementations(
+  contents: string,
+  coordinates: string[]
+): string {
+  if (coordinates.length === 0) {
+    return contents;
+  }
+  let next = contents;
+  for (const coord of coordinates) {
+    if (next.includes(coord)) {
+      continue;
+    }
+    if (!/dependencies\s*\{/.test(next)) {
+      continue;
+    }
+    next = next.replace(
+      /dependencies\s*\{/,
+      (match) => `${match}\n    implementation("${coord}")`
+    );
+  }
+  return next;
+}

--- a/packages/expo-targets/plugin/src/android/withAndroidWidget.ts
+++ b/packages/expo-targets/plugin/src/android/withAndroidWidget.ts
@@ -11,6 +11,10 @@ import {
 } from '@expo/config-plugins';
 import type { AndroidTargetConfig, Color } from '../config';
 import {
+  appendGradleImplementations,
+  resolveAndroidExtraImplementations,
+} from './extraImplementations';
+import {
   buildAppWidgetProviderXml,
   mergeAppWidgetProviderXml,
   type ResolvedAndroidWidgetProvider,
@@ -136,6 +140,15 @@ export const withAndroidWidget: ConfigPlugin<WidgetProps> = (config, props) => {
   } else {
     config = configureRemoteViewsBuild(config, props);
   }
+
+  config = withAppBuildGradle(config, (buildGradleConfig) => {
+    const extras = resolveAndroidExtraImplementations(androidConfig);
+    buildGradleConfig.modResults.contents = appendGradleImplementations(
+      buildGradleConfig.modResults.contents,
+      extras
+    );
+    return buildGradleConfig;
+  });
 
   config = configureWidgetManifest(config, props);
 

--- a/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.test.ts
+++ b/packages/expo-targets/plugin/src/codegen/collectRuntimeConfigs.test.ts
@@ -32,7 +32,9 @@ describe('collectRuntimeConfigs', () => {
     );
     expect(configs[0]?.appGroup).toBe('group.com.example.app');
   });
+});
 
+describe('collectRuntimeConfigs live activities', () => {
   test('copies ios.liveActivities onto the runtime row', () => {
     const configs = collectRuntimeConfigs(
       [

--- a/packages/expo-targets/plugin/src/codegen/typedTargets.ts
+++ b/packages/expo-targets/plugin/src/codegen/typedTargets.ts
@@ -68,26 +68,30 @@ function formatRecordFields(
   return `{\n${body}\n    }`;
 }
 
-function liveActivityCodegenRows(
-  configs: TargetCodegenConfig[]
-): Array<{
+type LiveActivityCodegenRow = {
   attributesName: string;
   static?: Record<string, LiveActivityFieldType>;
   contentState?: Record<string, LiveActivityFieldType>;
-}> {
-  const rows: Array<{
-    attributesName: string;
-    static?: Record<string, LiveActivityFieldType>;
-    contentState?: Record<string, LiveActivityFieldType>;
-  }> = [];
+};
+
+function liveActivityEntries(
+  cfg: TargetCodegenConfig
+): NonNullable<TargetCodegenConfig['liveActivities']> {
+  if (cfg.liveActivities && cfg.liveActivities.length > 0) {
+    return cfg.liveActivities;
+  }
+  if (cfg.liveActivity?.attributesName) {
+    return [cfg.liveActivity];
+  }
+  return [];
+}
+
+function liveActivityCodegenRows(
+  configs: TargetCodegenConfig[]
+): LiveActivityCodegenRow[] {
+  const rows: LiveActivityCodegenRow[] = [];
   for (const cfg of configs) {
-    const entries =
-      cfg.liveActivities && cfg.liveActivities.length > 0
-        ? cfg.liveActivities
-        : cfg.liveActivity?.attributesName
-          ? [cfg.liveActivity]
-          : [];
-    for (const la of entries) {
+    for (const la of liveActivityEntries(cfg)) {
       if (la.attributesName) {
         rows.push({
           attributesName: la.attributesName,

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -564,6 +564,16 @@ export interface AndroidTargetConfig {
   imeLabel?: string;
   /** VPN service label (network-packet-tunnel). */
   vpnDisplayName?: string;
+  /**
+   * Extra `implementation("…")` coordinates for the host app `build.gradle`.
+   * Use for widget deepen that needs libraries the host does not already ship.
+   */
+  implementation?: string[];
+  /**
+   * When true, inject `com.google.zxing:core` (QR encode helper on
+   * `ExpoTargetsQr`). Off by default.
+   */
+  qr?: boolean;
 }
 
 /** Authoring mode — see docs/react-native-extensions.md and resolveUiMode(). */

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
@@ -78,7 +78,9 @@ describe('ensureHostAppGroups', () => {
       config.ios?.entitlements?.['com.apple.security.application-groups']
     ).toEqual(['group.custom']);
   });
+});
 
+describe('ensureHostAppGroups union', () => {
   test('unions target appGroup into a non-empty host list', () => {
     const logger = new Logger(false);
     const config = ensureHostAppGroups(

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
@@ -78,6 +78,34 @@ describe('ensureHostAppGroups', () => {
       config.ios?.entitlements?.['com.apple.security.application-groups']
     ).toEqual(['group.custom']);
   });
+
+  test('unions target appGroup into a non-empty host list', () => {
+    const logger = new Logger(false);
+    const config = ensureHostAppGroups(
+      {
+        ios: {
+          bundleIdentifier: 'com.example.app',
+          entitlements: {
+            'com.apple.security.application-groups': ['group.onesignal'],
+          },
+        },
+      },
+      [
+        {
+          config: {
+            type: 'widget' as const,
+            platforms: ['ios'],
+            appGroup: 'group.widgets',
+          },
+        },
+      ],
+      logger
+    );
+
+    expect(
+      config.ios?.entitlements?.['com.apple.security.application-groups']
+    ).toEqual(['group.onesignal', 'group.widgets']);
+  });
 });
 
 describe('warnMissingMetroWrapper', () => {

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.ts
@@ -17,7 +17,46 @@ interface EvaluatedTarget {
     type?: ExtensionType;
     platforms?: string[];
     entry?: string;
+    appGroup?: string;
+    ios?: {
+      entitlements?: Record<string, unknown>;
+    };
   };
+}
+
+function addStringGroups(groups: Set<string>, values: unknown): void {
+  if (!Array.isArray(values)) {
+    return;
+  }
+  for (const group of values) {
+    if (typeof group === 'string' && group.length > 0) {
+      groups.add(group);
+    }
+  }
+}
+
+export function collectTargetAppGroups(targets: EvaluatedTarget[]): string[] {
+  const groups = new Set<string>();
+  for (const target of targets) {
+    if (!target.config.platforms?.includes('ios')) {
+      continue;
+    }
+    if (!targetNeedsAppGroup(target.config.type)) {
+      continue;
+    }
+    if (typeof target.config.appGroup === 'string' && target.config.appGroup) {
+      groups.add(target.config.appGroup);
+    }
+    addStringGroups(
+      groups,
+      target.config.ios?.entitlements?.[APP_GROUP_ENTITLEMENT_KEY]
+    );
+  }
+  return [...groups];
+}
+
+function uniqueGroups(groups: string[]): string[] {
+  return [...new Set(groups.filter((g) => g.length > 0))];
 }
 
 export function targetNeedsAppGroup(type: ExtensionType | undefined): boolean {
@@ -34,6 +73,67 @@ export function anyTargetNeedsAppGroup(targets: EvaluatedTarget[]): boolean {
   );
 }
 
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((g): g is string => typeof g === 'string');
+}
+
+function resolveMergedHostGroups(
+  config: ExpoConfig,
+  targets: EvaluatedTarget[],
+  logger: Logger
+): string[] | null {
+  const existing = stringList(
+    config.ios?.entitlements?.[APP_GROUP_ENTITLEMENT_KEY]
+  );
+  const fromTargets = collectTargetAppGroups(targets);
+  let merged = uniqueGroups([...existing, ...fromTargets]);
+
+  if (merged.length === 0) {
+    const bundleId = config.ios?.bundleIdentifier;
+    if (!bundleId) {
+      return null;
+    }
+    const invented = getAppGroup(bundleId);
+    logger.log(`Invented App Group for host: ${invented}`);
+    return [invented];
+  }
+
+  for (const group of fromTargets) {
+    if (!existing.includes(group)) {
+      logger.log(`Union App Group into host: ${group}`);
+    }
+  }
+  return merged;
+}
+
+function writeHostAppGroups(config: ExpoConfig, merged: string[]): ExpoConfig {
+  let next: ExpoConfig = {
+    ...config,
+    ios: {
+      ...config.ios,
+      entitlements: {
+        ...config.ios?.entitlements,
+        [APP_GROUP_ENTITLEMENT_KEY]: merged,
+      },
+    },
+  };
+
+  next = withEntitlementsPlist(next, async (cfg) => {
+    const entitlements = cfg.modResults;
+    entitlements[APP_GROUP_ENTITLEMENT_KEY] = uniqueGroups([
+      ...stringList(entitlements[APP_GROUP_ENTITLEMENT_KEY]),
+      ...merged,
+    ]);
+    cfg.modResults = entitlements;
+    return cfg;
+  });
+
+  return next;
+}
+
 export function ensureHostAppGroups(
   config: ExpoConfig,
   targets: EvaluatedTarget[],
@@ -43,41 +143,21 @@ export function ensureHostAppGroups(
     return config;
   }
 
-  const existing = config.ios?.entitlements?.[APP_GROUP_ENTITLEMENT_KEY];
-  if (Array.isArray(existing) && existing.length > 0) {
+  const existing = stringList(
+    config.ios?.entitlements?.[APP_GROUP_ENTITLEMENT_KEY]
+  );
+  const merged = resolveMergedHostGroups(config, targets, logger);
+  if (!merged) {
+    return config;
+  }
+  const same =
+    merged.length === existing.length &&
+    merged.every((g, i) => g === existing[i]);
+  if (same) {
     return config;
   }
 
-  const bundleId = config.ios?.bundleIdentifier;
-  if (!bundleId) {
-    return config;
-  }
-
-  const group = getAppGroup(bundleId);
-  logger.log(`Invented App Group for host: ${group}`);
-
-  let next: ExpoConfig = {
-    ...config,
-    ios: {
-      ...config.ios,
-      entitlements: {
-        ...config.ios?.entitlements,
-        [APP_GROUP_ENTITLEMENT_KEY]: [group],
-      },
-    },
-  };
-
-  next = withEntitlementsPlist(next, async (cfg) => {
-    const entitlements = cfg.modResults;
-    const current = entitlements[APP_GROUP_ENTITLEMENT_KEY];
-    if (!Array.isArray(current) || current.length === 0) {
-      entitlements[APP_GROUP_ENTITLEMENT_KEY] = [group];
-      cfg.modResults = entitlements;
-    }
-    return cfg;
-  });
-
-  return next;
+  return writeHostAppGroups(config, merged);
 }
 
 export function warnMissingMetroWrapper(

--- a/packages/expo-targets/plugin/src/entryGraph.ts
+++ b/packages/expo-targets/plugin/src/entryGraph.ts
@@ -1,0 +1,129 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Heavy / host-leaning packages to auto-exclude when unused by the entry. */
+export const HEAVY_EXCLUSION_CANDIDATES = [
+  'react-native-reanimated',
+  '@sentry/react-native',
+  'react-native-screens',
+  '@react-native-community/netinfo',
+] as const;
+
+const IMPORT_RE = /(?:from\s+|require\s*\(\s*)['"](@?[^'"]+)['"]/g;
+
+export function readPackageDeps(projectRoot: string): Set<string> {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    return new Set();
+  }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return new Set([
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ]);
+  } catch {
+    return new Set();
+  }
+}
+
+function packageRoot(specifier: string): string {
+  if (specifier.startsWith('@')) {
+    const parts = specifier.split('/');
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
+  }
+  return specifier.split('/')[0] ?? specifier;
+}
+
+function resolveLocal(fromDir: string, spec: string): string | null {
+  const base = path.resolve(fromDir, spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.js`,
+    `${base}.jsx`,
+    path.join(base, 'index.ts'),
+    path.join(base, 'index.tsx'),
+    path.join(base, 'index.js'),
+    path.join(base, 'index.jsx'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) {
+      return c;
+    }
+  }
+  return null;
+}
+
+function collectSpecifiersFromSource(opts: {
+  source: string;
+  file: string;
+  queue: string[];
+}): string[] {
+  const roots: string[] = [];
+  for (const match of opts.source.matchAll(IMPORT_RE)) {
+    const spec = match[1];
+    if (!spec) continue;
+    if (spec.startsWith('.') || spec.startsWith('/')) {
+      const resolved = resolveLocal(path.dirname(opts.file), spec);
+      if (resolved) {
+        opts.queue.push(resolved);
+      }
+      continue;
+    }
+    roots.push(packageRoot(spec));
+  }
+  return roots;
+}
+
+/** Package roots imported from `entryRel` (and local relative files). */
+export function collectImportsFromEntry(
+  projectRoot: string,
+  entryRel: string
+): Set<string> {
+  const seen = new Set<string>();
+  const visited = new Set<string>();
+  const queue: string[] = [path.resolve(projectRoot, entryRel)];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || visited.has(file) || !fs.existsSync(file)) {
+      continue;
+    }
+    visited.add(file);
+    let source: string;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const root of collectSpecifiersFromSource({
+      source,
+      file,
+      queue,
+    })) {
+      seen.add(root);
+    }
+  }
+
+  return seen;
+}
+
+export function unusedHeavyPackages(opts: {
+  projectRoot: string;
+  entry: string;
+}): string[] {
+  const deps = readPackageDeps(opts.projectRoot);
+  const imported = collectImportsFromEntry(opts.projectRoot, opts.entry);
+  const unused: string[] = [];
+  for (const candidate of HEAVY_EXCLUSION_CANDIDATES) {
+    if (!deps.has(candidate)) continue;
+    if (imported.has(candidate)) continue;
+    unused.push(candidate);
+  }
+  return unused;
+}

--- a/packages/expo-targets/plugin/src/ios/apply/pbx/applyTargetPlan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/pbx/applyTargetPlan.ts
@@ -12,6 +12,7 @@ import {
 } from './buildPhases';
 import { applyBuildSettings, removeBuildSetting } from './buildSettings';
 import { ensureBundleReactNativePhase } from './bundleReactNative';
+import { ensureClipBuildNumberPhase } from './clipBuildNumber';
 import { ensureCopyFrameworksIntoAppClipPhase } from './copyFrameworksIntoAppClip';
 import {
   configureAppClipEmbed,
@@ -402,6 +403,49 @@ function applyMainAndWatchDependencies({
   }
 }
 
+function applyClipAndBundlePhases(
+  project: XcodeProject,
+  plan: XcodeTargetPlan,
+  {
+    target,
+    mainTarget,
+    logger,
+  }: {
+    target: XcodeTarget;
+    mainTarget: ApplyContext['mainTarget'];
+    logger: Logger;
+  }
+): void {
+  if (plan.identity.type === 'clip') {
+    const hostName =
+      mainTarget.target?.name || mainTarget.target?.productName || 'App';
+    ensureClipBuildNumberPhase({
+      project,
+      clipTargetUuid: target.uuid,
+      hostProductName: String(hostName).replace(/"/g, ''),
+      logger,
+    });
+  }
+
+  if (plan.bundleReactNative) {
+    ensureBundleReactNativePhase({
+      project,
+      targetUuid: target.uuid,
+      plan: plan.bundleReactNative,
+      logger,
+    });
+  }
+
+  if (plan.safariWebBundle) {
+    ensureSafariWebBundlePhase({
+      project,
+      targetUuid: target.uuid,
+      plan: plan.safariWebBundle,
+      logger,
+    });
+  }
+}
+
 /**
  * Apply a target plan to a parsed Xcode project.
  * Idempotent: running it twice against the same project is a no-op.
@@ -440,24 +484,7 @@ export function applyXcodeTargetPlan(
     mainTargetUuid: mainTarget.uuid,
   });
   applyEmbed(project, plan, { target, mainTargetUuid: mainTarget.uuid });
-
-  if (plan.bundleReactNative) {
-    ensureBundleReactNativePhase({
-      project,
-      targetUuid: target.uuid,
-      plan: plan.bundleReactNative,
-      logger,
-    });
-  }
-
-  if (plan.safariWebBundle) {
-    ensureSafariWebBundlePhase({
-      project,
-      targetUuid: target.uuid,
-      plan: plan.safariWebBundle,
-      logger,
-    });
-  }
+  applyClipAndBundlePhases(project, plan, { target, mainTarget, logger });
 
   logger.log(`Configured target ${plan.identity.targetProductName}`);
   return target;

--- a/packages/expo-targets/plugin/src/ios/apply/pbx/clipBuildNumber.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/pbx/clipBuildNumber.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildClipBuildNumberScript } from './clipBuildNumber';
+
+describe('buildClipBuildNumberScript', () => {
+  test('copies host CURRENT_PROJECT_VERSION into Clip Info.plist', () => {
+    const script = buildClipBuildNumberScript('Popl');
+    expect(script).toContain('-target "Popl"');
+    expect(script).toContain('CFBundleVersion');
+    expect(script).toContain('PlistBuddy');
+    expect(script).toContain('CURRENT_PROJECT_VERSION');
+  });
+
+  test('does not fail the native build when host version is missing', () => {
+    const script = buildClipBuildNumberScript('App');
+    expect(script).toContain('skip Clip CFBundleVersion');
+    expect(script).toContain('exit 0');
+  });
+});

--- a/packages/expo-targets/plugin/src/ios/apply/pbx/clipBuildNumber.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/pbx/clipBuildNumber.ts
@@ -1,0 +1,122 @@
+import type { XcodeProject } from '@expo/config-plugins';
+
+import type { Logger } from '../../../logger';
+
+const PHASE_NAME = '[expo-targets] Sync App Clip CFBundleVersion';
+
+/** Quote a string the way Expo writes host shell phases (single-line + \\n). */
+function toPbxString(value: string): string {
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')}"`;
+}
+
+/**
+ * Copy host CURRENT_PROJECT_VERSION into the Clip Info.plist at compile time.
+ * EAS remote versioning updates the host after prebuild; Clip plist would stay stale.
+ */
+export function buildClipBuildNumberScript(hostProductName: string): string {
+  const host = hostProductName.replace(/"/g, '').replace(/\.app$/i, '');
+  return `set +e
+CLIP_PLIST="\${TARGET_BUILD_DIR}/\${INFOPLIST_PATH}"
+if [ ! -f "$CLIP_PLIST" ]; then
+  echo "expo-targets: skip Clip CFBundleVersion — Clip Info.plist missing"
+  exit 0
+fi
+
+HOST_VERSION=""
+if [ -n "\${PROJECT_FILE_PATH:-}" ] && [ -f "\${PROJECT_FILE_PATH}" ]; then
+  HOST_VERSION=$(xcodebuild -project "\${PROJECT_FILE_PATH}" -target "${host}" -configuration "\${CONFIGURATION:-Release}" -showBuildSettings 2>/dev/null | awk -F' = ' '/^    CURRENT_PROJECT_VERSION = / { print $2; exit }')
+fi
+
+case "$HOST_VERSION" in
+  ''|*'$('*|*[!0-9]*)
+    echo "expo-targets: skip Clip CFBundleVersion — host build number unresolved"
+    exit 0
+    ;;
+esac
+
+/usr/libexec/PlistBuddy -c "Delete :CFBundleVersion" "$CLIP_PLIST" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Add :CFBundleVersion string \${HOST_VERSION}" "$CLIP_PLIST" 2>/dev/null
+echo "expo-targets: set Clip CFBundleVersion to \${HOST_VERSION}"
+exit 0
+`;
+}
+
+function findShellScriptPhase({
+  project,
+  targetUuid,
+  phaseName,
+}: {
+  project: XcodeProject;
+  targetUuid: string;
+  phaseName: string;
+}): { uuid: string; phase: any } | undefined {
+  const xcodeProject = project as any;
+  const target = xcodeProject.hash.project.objects.PBXNativeTarget[targetUuid];
+  const section = xcodeProject.hash.project.objects.PBXShellScriptBuildPhase;
+  if (!(target?.buildPhases && section)) {
+    return;
+  }
+
+  const quoted = `"${phaseName}"`;
+  for (const ref of target.buildPhases) {
+    const phase = section[ref.value];
+    if (!phase) continue;
+    if (phase.name === phaseName || phase.name === quoted) {
+      return { uuid: ref.value, phase };
+    }
+  }
+}
+
+function applyPhaseFields(phase: any, shellScript: string): void {
+  phase.name = `"${PHASE_NAME}"`;
+  phase.shellPath = '/bin/sh';
+  phase.shellScript = toPbxString(shellScript);
+  phase.alwaysOutOfDate = 1;
+  phase.inputPaths = [];
+  phase.outputPaths = [];
+  phase.runOnlyForDeploymentPostprocessing = 0;
+}
+
+export function ensureClipBuildNumberPhase({
+  project,
+  clipTargetUuid,
+  hostProductName,
+  logger,
+}: {
+  project: XcodeProject;
+  clipTargetUuid: string;
+  hostProductName: string;
+  logger?: Logger;
+}): void {
+  const xcodeProject = project as any;
+  const shellScript = buildClipBuildNumberScript(hostProductName);
+  const existing = findShellScriptPhase({
+    project,
+    targetUuid: clipTargetUuid,
+    phaseName: PHASE_NAME,
+  });
+
+  if (existing) {
+    applyPhaseFields(existing.phase, shellScript);
+    logger?.log(`Updated ${PHASE_NAME}`);
+    return;
+  }
+
+  const added = xcodeProject.addBuildPhase(
+    [],
+    'PBXShellScriptBuildPhase',
+    PHASE_NAME,
+    clipTargetUuid,
+    {
+      shellPath: '/bin/sh',
+      shellScript: ':',
+      inputPaths: [],
+      outputPaths: [],
+    }
+  );
+  applyPhaseFields(added.buildPhase, shellScript);
+  logger?.log(`Added ${PHASE_NAME}`);
+}

--- a/packages/expo-targets/plugin/src/ios/cng/liveActivityCodegen.test.ts
+++ b/packages/expo-targets/plugin/src/ios/cng/liveActivityCodegen.test.ts
@@ -26,8 +26,12 @@ describe('liveActivityCodegen multi-target rows', () => {
 
     expect(files[0]?.attributes).toContain('struct DynamicIslandAttributes');
     expect(files[1]?.attributes).toContain('struct MeetingLiveAttributes');
-    expect(files[0]?.bridge).toContain('expo_targets_la_bootstrap_DynamicIslandAttributes');
-    expect(files[1]?.bridge).toContain('expo_targets_la_bootstrap_MeetingLiveAttributes');
+    expect(files[0]?.bridge).toContain(
+      'expo_targets_la_bootstrap_DynamicIslandAttributes'
+    );
+    expect(files[1]?.bridge).toContain(
+      'expo_targets_la_bootstrap_MeetingLiveAttributes'
+    );
     expect(files[0]?.bridge).not.toContain('MeetingLiveAttributes');
   });
 });

--- a/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
@@ -5,7 +5,6 @@ import type { TargetWorkspace } from '../observe/workspace';
 import {
   hasExplicitGalleryKinds,
   resolveGalleryWidgetKinds,
-  resolveLiveActivityConfig,
   resolveLiveActivityConfigs,
 } from '../utils/resolveIosKinds';
 import type {

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.test.ts
@@ -131,7 +131,9 @@ describe('resolveLiveActivityConfig', () => {
   test('omitted liveActivity and kinds has no live activity', () => {
     expect(resolveLiveActivityConfig({ ios: {} })).toBeUndefined();
   });
+});
 
+describe('resolveLiveActivityConfigs', () => {
   test('reads ios.liveActivities array', () => {
     const configs = resolveLiveActivityConfigs({
       ios: {
@@ -152,9 +154,10 @@ describe('resolveLiveActivityConfig', () => {
       'DynamicIslandAttributes',
       'MeetingLiveAttributes',
     ]);
-    expect(resolveLiveActivityConfig({ ios: { liveActivities: configs } })?.attributesName).toBe(
-      'DynamicIslandAttributes'
-    );
+    expect(
+      resolveLiveActivityConfig({ ios: { liveActivities: configs } })
+        ?.attributesName
+    ).toBe('DynamicIslandAttributes');
   });
 
   test('singular and array together throw', () => {
@@ -175,7 +178,9 @@ describe('resolveLiveActivityConfig', () => {
       })
     ).toThrow(/OR ios\.liveActivity/);
   });
+});
 
+describe('resolveLiveActivityConfigs uniqueness', () => {
   test('duplicate attributesName in liveActivities throws', () => {
     expect(() =>
       resolveLiveActivityConfigs({

--- a/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/resolveIosKinds.ts
@@ -81,9 +81,7 @@ export function resolveLiveActivityConfigs(input: {
   const fromArray = (ios?.liveActivities ?? []).filter(
     (row) => row.attributesName
   );
-  const singular = ios?.liveActivity?.attributesName
-    ? [ios.liveActivity]
-    : [];
+  const singular = ios?.liveActivity?.attributesName ? [ios.liveActivity] : [];
 
   if (fromArray.length > 0 && singular.length > 0) {
     throw new Error(

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import {
   HOST_ONLY_EXCLUDED_PACKAGES,
@@ -75,5 +78,53 @@ describe('resolveExcludedPackages non-RN', () => {
         entry: './targets/safari/popup.tsx',
       })
     ).toBeUndefined();
+  });
+});
+
+describe('resolveExcludedPackages inferred heavies', () => {
+  test('unions unused host Sentry when projectRoot + entry are set', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@sentry/react-native': '6.0.0' },
+      })
+    );
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    expect(
+      resolveExcludedPackages({
+        type: 'messages',
+        entry: './targets/messages/index.tsx',
+        projectRoot: root,
+      })
+    ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES, '@sentry/react-native']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('does not infer Sentry when the entry imports it', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@sentry/react-native': '6.0.0' },
+      })
+    );
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import * as Sentry from '@sentry/react-native';\nexport default function App() { return null; }\n"
+    );
+    expect(
+      resolveExcludedPackages({
+        type: 'messages',
+        entry: './targets/messages/index.tsx',
+        projectRoot: root,
+      })
+    ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES]);
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
@@ -1,5 +1,6 @@
 import type { ExtensionType } from './config';
 import { REACT_NATIVE_NATIVE_TYPES } from './domain';
+import { unusedHeavyPackages } from './entryGraph';
 
 /** Host-only Expo packages that crash / blank RN appex processes. Always merged in. */
 export const HOST_ONLY_EXCLUDED_PACKAGES = [
@@ -13,6 +14,8 @@ export type ResolveExcludedPackagesInput = {
   type: ExtensionType | string;
   entry?: string;
   excludedPackages?: string[];
+  /** When set, unused heavy host packages are union-merged (Sentry, reanimated, …). */
+  projectRoot?: string;
 };
 
 function isRnNativeType(type: string): boolean {
@@ -27,14 +30,18 @@ function isRnNativeType(type: string): boolean {
 export function resolveExcludedPackages(
   input: ResolveExcludedPackagesInput
 ): string[] | undefined {
-  const { type, entry, excludedPackages } = input;
+  const { type, entry, excludedPackages, projectRoot } = input;
   if (!(entry && isRnNativeType(type))) {
     return excludedPackages?.length ? [...excludedPackages] : undefined;
   }
 
+  const inferred =
+    projectRoot && entry ? unusedHeavyPackages({ projectRoot, entry }) : [];
+
   const merged = new Set<string>([
     ...HOST_ONLY_EXCLUDED_PACKAGES,
     ...(excludedPackages ?? []),
+    ...inferred,
   ]);
   return [...merged];
 }

--- a/packages/expo-targets/plugin/src/withTargetsDir.ts
+++ b/packages/expo-targets/plugin/src/withTargetsDir.ts
@@ -6,11 +6,11 @@ import { globSync } from 'glob';
 import { withAndroidTarget } from './android/withAndroidTarget';
 import { withAndroidTargetsConfig } from './android/withAndroidTargetsConfig';
 import { collectRuntimeConfigs } from './codegen/collectRuntimeConfigs';
-import { widgetKindNamesForCodegen } from './codegen/widgetKindNames';
 import {
   type TargetCodegenConfig,
   writeTargetsTypesFile,
 } from './codegen/typedTargets';
+import { widgetKindNamesForCodegen } from './codegen/widgetKindNames';
 import {
   ensureHostAppGroups,
   warnMissingMetroWrapper,
@@ -162,6 +162,7 @@ interface TargetContext {
   targetDirectory: string;
   targetName: string;
   appGroup?: string;
+  projectRoot: string;
   logger: Logger;
 }
 
@@ -291,6 +292,7 @@ const withTargetIos: ConfigPlugin<{
     type: evaluatedConfig.type,
     entry: evaluatedConfig.entry,
     excludedPackages: evaluatedConfig.excludedPackages,
+    projectRoot: context.projectRoot,
   });
 
   const runtimeVersion = resolveRuntimeVersionFromExpoConfig(config);
@@ -358,6 +360,7 @@ const withTarget: ConfigPlugin<{
     targetDirectory,
     targetName,
     appGroup,
+    projectRoot,
     logger,
   };
 

--- a/packages/expo-targets/src/Target.folderSetData.test.ts
+++ b/packages/expo-targets/src/Target.folderSetData.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { TargetConfig } from '../plugin/src/config';
+
+const setDataCalls: { name?: string; data: Record<string, unknown> }[] = [];
+const refreshCalls: string[] = [];
+
+const poplWidgets: TargetConfig = {
+  type: 'widget',
+  name: 'PoplWidgets',
+  platforms: ['ios'],
+  appGroup: 'group.test.popl',
+  ios: {
+    kinds: [
+      { name: 'HomescreenWidgets' },
+      { name: 'LockScreenWidgets' },
+      { name: 'LockScreenScanWidget' },
+    ],
+  },
+};
+
+mock.module('react-native', () => ({
+  Platform: { OS: 'ios' },
+  AppRegistry: { registerComponent: mock() },
+}));
+
+mock.module('expo-modules-core', () => ({
+  requireNativeModule: () => ({
+    setInt: mock(),
+    setString: mock(),
+    remove: mock(),
+    get: mock(),
+    getAllData: mock(() => ({})),
+    getAllKeys: mock(() => []),
+    clearAll: mock(),
+    refreshTarget: mock(),
+    getTargetsConfig: mock(() => [poplWidgets]),
+  }),
+}));
+
+mock.module('./modules/storage/index', () => ({
+  AppGroupStorage: class {
+    constructor(
+      _appGroup: string,
+      private readonly targetName?: string
+    ) {}
+    setData(data: Record<string, unknown>) {
+      setDataCalls.push({ name: this.targetName, data });
+    }
+    getData() {
+      return {};
+    }
+    refresh(name?: string) {
+      refreshCalls.push(name ?? this.targetName ?? '');
+    }
+  },
+}));
+
+mock.module('./modules/targetsConfig', () => ({
+  listTargets: () => [poplWidgets],
+  findTargetsByType: mock(),
+  resolveUniqueTarget: mock(),
+  assertMatchesConfig: mock(),
+}));
+
+const { createTarget } = await import('./Target');
+
+describe('widget folder setData', () => {
+  beforeEach(() => {
+    setDataCalls.length = 0;
+    refreshCalls.length = 0;
+  });
+
+  test('writes the same payload to every kind', () => {
+    const folder = createTarget('PoplWidgets');
+    folder.setData({ shareUrl: 'https://popl.co' });
+    expect(setDataCalls.map((c) => c.name).sort()).toEqual([
+      'HomescreenWidgets',
+      'LockScreenScanWidget',
+      'LockScreenWidgets',
+    ]);
+    expect(
+      setDataCalls.every((c) => c.data.shareUrl === 'https://popl.co')
+    ).toBe(true);
+    expect(refreshCalls.sort()).toEqual([
+      'HomescreenWidgets',
+      'LockScreenScanWidget',
+      'LockScreenWidgets',
+    ]);
+  });
+
+  test('refresh false skips reload', () => {
+    const folder = createTarget('PoplWidgets');
+    folder.setData({ shareUrl: 'https://popl.co' }, { refresh: false });
+    expect(setDataCalls).toHaveLength(3);
+    expect(refreshCalls).toEqual([]);
+  });
+});

--- a/packages/expo-targets/src/Target.folderSetData.test.ts
+++ b/packages/expo-targets/src/Target.folderSetData.test.ts
@@ -73,7 +73,10 @@ describe('widget folder setData', () => {
   test('writes the same payload to every kind', () => {
     const folder = createTarget('PoplWidgets');
     folder.setData({ shareUrl: 'https://popl.co' });
-    expect(setDataCalls.map((c) => c.name).sort()).toEqual([
+    const names = setDataCalls
+      .map((c) => c.name)
+      .sort((a, b) => (a ?? '').localeCompare(b ?? ''));
+    expect(names).toEqual([
       'HomescreenWidgets',
       'LockScreenScanWidget',
       'LockScreenWidgets',
@@ -81,7 +84,7 @@ describe('widget folder setData', () => {
     expect(
       setDataCalls.every((c) => c.data.shareUrl === 'https://popl.co')
     ).toBe(true);
-    expect(refreshCalls.sort()).toEqual([
+    expect([...refreshCalls].sort((a, b) => a.localeCompare(b))).toEqual([
       'HomescreenWidgets',
       'LockScreenScanWidget',
       'LockScreenWidgets',

--- a/packages/expo-targets/src/Target.liveActivity.test.ts
+++ b/packages/expo-targets/src/Target.liveActivity.test.ts
@@ -1,10 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { TargetConfig } from '../plugin/src/config';
 
 const poplWidgets: TargetConfig = {
@@ -69,7 +63,7 @@ mock.module('./modules/targetsConfig', () => ({
 
 const { createTarget } = await import('./Target');
 
-describe('createTarget().liveActivity()', () => {
+describe('createTarget().liveActivity() resolve', () => {
   beforeEach(() => {
     nativeStart.mockClear();
     nativeUpdate.mockClear();
@@ -107,6 +101,14 @@ describe('createTarget().liveActivity()', () => {
     expect(() => folder.liveActivity('MissingAttributes')).toThrow(
       /Unknown Live Activity "MissingAttributes"/
     );
+  });
+});
+
+describe('createTarget().liveActivity() native', () => {
+  beforeEach(() => {
+    nativeStart.mockClear();
+    nativeUpdate.mockClear();
+    nativeEnd.mockClear();
   });
 
   test('handle update and end delegate to native module', async () => {

--- a/packages/expo-targets/src/Target.liveActivity.test.ts
+++ b/packages/expo-targets/src/Target.liveActivity.test.ts
@@ -55,6 +55,7 @@ mock.module('expo-modules-core', () => ({
     update: nativeUpdate,
     end: nativeEnd,
     endAll: mock(async () => {}),
+    endAllForAttributes: mock(async () => {}),
     areActivitiesEnabled: mock(async () => true),
   }),
 }));

--- a/packages/expo-targets/src/Target.ts
+++ b/packages/expo-targets/src/Target.ts
@@ -87,6 +87,8 @@ export interface WidgetFolderTarget {
   liveActivity: (
     attributesName?: LiveActivityAttributesName
   ) => LiveActivityHandle<LiveActivityAttributesName>;
+  /** Write the same payload to every gallery kind / provider in this folder. */
+  setData: (data: Record<string, any>, options?: SetDataOptions) => void;
   /** Reload every gallery kind / provider in this folder. */
   refresh: () => void;
 }
@@ -436,6 +438,21 @@ function createWidgetFolderTarget(config: TargetConfig): WidgetFolderTarget {
     },
     liveActivity: (attributesName?: LiveActivityAttributesName) =>
       liveActivityHandleForConfig(config, attributesName),
+    setData(data: Record<string, any>, options?: SetDataOptions) {
+      for (const product of galleryProductNames(config)) {
+        createWidgetProductHandle({
+          config,
+          productName: product,
+        }).setData(data, { refresh: false });
+      }
+      if (options?.refresh !== false) {
+        const storage = new AppGroupStorage(appGroup, config.name);
+        for (const product of galleryProductNames(config)) {
+          storage.refresh(product);
+          expoUiWidgets.get(product)?.reload();
+        }
+      }
+    },
     refresh() {
       const storage = new AppGroupStorage(appGroup, config.name);
       for (const product of galleryProductNames(config)) {

--- a/packages/expo-targets/src/modules/liveActivity/index.test.ts
+++ b/packages/expo-targets/src/modules/liveActivity/index.test.ts
@@ -1,10 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { TargetConfig } from '../../../plugin/src/config';
 
 const trickWidget: TargetConfig = {
@@ -56,7 +50,7 @@ const {
   LiveActivity,
 } = await import('./index');
 
-describe('liveActivity module', () => {
+describe('liveActivity module start', () => {
   beforeEach(() => {
     nativeStart.mockClear();
     nativeEndAll.mockClear();
@@ -107,6 +101,14 @@ describe('liveActivity module', () => {
     });
     expect(nativeEndAllForAttributes).not.toHaveBeenCalled();
     expect(nativeStart).toHaveBeenCalled();
+  });
+});
+
+describe('liveActivity module endAll', () => {
+  beforeEach(() => {
+    nativeStart.mockClear();
+    nativeEndAll.mockClear();
+    nativeEndAllForAttributes.mockClear();
   });
 
   test('LiveActivity.endAll delegates to native module', async () => {

--- a/packages/expo-targets/src/modules/liveActivity/index.test.ts
+++ b/packages/expo-targets/src/modules/liveActivity/index.test.ts
@@ -22,6 +22,7 @@ const trickWidget: TargetConfig = {
 
 const nativeStart = mock(async () => 'act-99');
 const nativeEndAll = mock(async () => {});
+const nativeEndAllForAttributes = mock(async () => {});
 
 mock.module('react-native', () => ({
   Platform: { OS: 'ios' },
@@ -33,6 +34,7 @@ mock.module('expo-modules-core', () => ({
     update: mock(async () => true),
     end: mock(async () => {}),
     endAll: nativeEndAll,
+    endAllForAttributes: nativeEndAllForAttributes,
     areActivitiesEnabled: mock(async () => true),
   }),
 }));
@@ -58,6 +60,7 @@ describe('liveActivity module', () => {
   beforeEach(() => {
     nativeStart.mockClear();
     nativeEndAll.mockClear();
+    nativeEndAllForAttributes.mockClear();
   });
 
   test('buildLiveActivityHandle starts via native bridge', async () => {
@@ -76,6 +79,33 @@ describe('liveActivity module', () => {
       attributes: {},
       contentState: { status: 'x' },
     });
+    expect(nativeStart).toHaveBeenCalled();
+    expect(nativeEndAllForAttributes).toHaveBeenCalledWith(
+      'TrickActivityAttributes'
+    );
+  });
+
+  test('start default replaceExisting ends that attributesName only', async () => {
+    const handle = buildLiveActivityHandle('TrickActivityAttributes');
+    await handle.start({
+      attributes: {},
+      contentState: { status: 'x' },
+    });
+    expect(nativeEndAllForAttributes).toHaveBeenCalledWith(
+      'TrickActivityAttributes'
+    );
+    expect(nativeEndAll).not.toHaveBeenCalled();
+    expect(nativeStart).toHaveBeenCalled();
+  });
+
+  test('start replaceExisting false skips end', async () => {
+    const handle = buildLiveActivityHandle('TrickActivityAttributes');
+    await handle.start({
+      attributes: {},
+      contentState: { status: 'x' },
+      replaceExisting: false,
+    });
+    expect(nativeEndAllForAttributes).not.toHaveBeenCalled();
     expect(nativeStart).toHaveBeenCalled();
   });
 

--- a/packages/expo-targets/src/modules/liveActivity/index.ts
+++ b/packages/expo-targets/src/modules/liveActivity/index.ts
@@ -25,6 +25,7 @@ type NativeLiveActivity = {
   update: (activityId: string, contentStateJson: string) => Promise<boolean>;
   end: (activityId: string) => Promise<void>;
   endAll: () => Promise<void>;
+  endAllForAttributes?: (attributesName: string) => Promise<void>;
   areActivitiesEnabled: () => Promise<boolean>;
 };
 
@@ -36,6 +37,11 @@ export type LiveActivityContentState = Record<
 export type LiveActivityStartOptions = {
   attributes: LiveActivityContentState;
   contentState: LiveActivityContentState;
+  /**
+   * When true (default), end activities for this attributesName before start.
+   * Does not call global `endAll`.
+   */
+  replaceExisting?: boolean;
 };
 
 export type LiveActivityHandle<
@@ -45,6 +51,7 @@ export type LiveActivityHandle<
   start: (options: {
     attributes: LiveActivityPayloadFor<N>['attributes'];
     contentState: LiveActivityPayloadFor<N>['contentState'];
+    replaceExisting?: boolean;
   }) => Promise<string>;
   update: (
     activityId: string,
@@ -118,14 +125,29 @@ function mergeExpoUiProps(options: {
   return { ...options.attributes, ...options.contentState };
 }
 
+async function endActivitiesForAttributes(
+  attributesName: string
+): Promise<void> {
+  const native = getNative();
+  if (typeof native.endAllForAttributes === 'function') {
+    await native.endAllForAttributes(attributesName);
+    return;
+  }
+  await native.endAll();
+}
+
 /** Start a Live Activity by configured attributesName (used by target handles). */
 export async function startLiveActivity<N extends LiveActivityAttributesName>(
   attributesName: N,
   options: {
     attributes: LiveActivityPayloadFor<N>['attributes'];
     contentState: LiveActivityPayloadFor<N>['contentState'];
+    replaceExisting?: boolean;
   }
 ): Promise<string> {
+  if (options.replaceExisting !== false) {
+    await endActivitiesForAttributes(attributesName);
+  }
   const { target } = resolveMatch(attributesName);
   if (target.entry) {
     ensureExpoUiAttributesLink(attributesName);
@@ -184,9 +206,9 @@ export async function areLiveActivitiesEnabled(): Promise<boolean> {
 }
 
 /** Target-scoped Live Activity handle (preferred host API). */
-export function buildLiveActivityHandle<
-  N extends LiveActivityAttributesName,
->(attributesName: N): LiveActivityHandle<N> {
+export function buildLiveActivityHandle<N extends LiveActivityAttributesName>(
+  attributesName: N
+): LiveActivityHandle<N> {
   resolveAttributesConfig(attributesName);
   ensureExpoUiAttributesLink(attributesName);
   return {


### PR DESCRIPTION
## Summary
- Doctor fails on missing/stale `.expo/types/expo-targets.d.ts`; generate stays the no-prebuild fix.
- Host App Group union, Clip compile-time CFBundleVersion, folder `setData`, Live Activity `start({ replaceExisting })` (attributes-scoped), inferred unused heavies, opt-in Android QR.

## Test plan
- [x] `bun test` in packages/expo-targets
- [x] `bun run typecheck`
- [ ] Operator: pin next minor in popl-mobile-app after npm publish