### PR TITLE
fix(metro): packaged stub for extension-bundle-assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Metro `withTargets` no longer writes `expo-targets/extension-bundle-assets` under gitignored `.expo/` during `resolveRequest` (EAS `export:embed` SHA-1 failure). Missing host assets resolve to a packaged empty stub.
+
 ### Added
 
 - `npx expo-targets doctor` fails when `.expo/types/expo-targets.d.ts` is missing or stale; `npx expo-targets generate` stays the no-prebuild fix.

--- a/docs/api.md
+++ b/docs/api.md
@@ -588,7 +588,7 @@ ExtensionUpdates.enable();
 `enable()`:
 
 - Discovers RN-native targets + App Group from `expo.extra.targets`
-- Resolves bundles via Metro alias `expo-targets/extension-bundle-assets` → `assets/expo-targets/extensionBundleModules.js`
+- Resolves bundles via Metro alias `expo-targets/extension-bundle-assets` → `assets/expo-targets/extensionBundleModules.js` when that file exists. Otherwise Metro uses the packaged empty stub (`expo-targets/extension-bundle-assets`). The resolver does not write under `.expo/`.
 - Syncs App Group from the **currently running** update on launch (`syncOnStart`, default `true`)
 - Returns the Updates-shaped API (`checkForUpdateAsync`, `fetchUpdateAsync`, `reloadAsync`, `syncFromCurrentUpdate`)
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -431,7 +431,7 @@ Layout on disk (App Group container):
 1. **String `expo.runtimeVersion`** in `app.json` or `app.config` (for example `"1.0.0"`). Prebuild bakes it into the extension RN host. When it is missing or a policy object, App Group load is skipped forever and Release always uses the embedded bundle.
 2. **Shared App Group** on host + target (`appGroup` / entitlements).
 3. **Host import** of `expo-targets` (auto-enables `ExtensionUpdates`) or an explicit `ExtensionUpdates.enable()`.
-4. **Metro** wrapped with `withTargets` so the publish-time asset module resolves.
+4. **Metro** wrapped with `withTargets` so the publish-time asset module resolves when `assets/expo-targets/extensionBundleModules.js` exists. Before that export, the packaged `expo-targets/extension-bundle-assets` stub is an empty map.
 
 #### Publish pipeline
 

--- a/packages/expo-targets/extension-bundle-assets.js
+++ b/packages/expo-targets/extension-bundle-assets.js
@@ -1,0 +1,2 @@
+/** Empty map until `export-extension-bundles` writes assets/expo-targets/extensionBundleModules.js. */
+module.exports = {};

--- a/packages/expo-targets/metro/src/withTargets.test.ts
+++ b/packages/expo-targets/metro/src/withTargets.test.ts
@@ -120,7 +120,14 @@ function shareContentProject() {
   ]);
 }
 
-test('withTargets resolveRequest returns extension bundle assets stub', () => {
+const packagedExtensionBundleAssetsStub = path.join(
+  import.meta.dir,
+  '..',
+  '..',
+  'extension-bundle-assets.js'
+);
+
+test('withTargets resolveRequest uses packaged stub when host assets are missing', () => {
   const root = shareContentProject();
   tempRoots.push(root);
   const config = buildWithTargetsConfig(root);
@@ -131,9 +138,40 @@ test('withTargets resolveRequest returns extension bundle assets stub', () => {
     'expo-targets/extension-bundle-assets',
     'ios'
   );
-  expect(assetsResult.filePath).toContain(
-    'expo-targets-extension-bundle-assets.js'
+  expect(assetsResult).toEqual({
+    type: 'sourceFile',
+    filePath: packagedExtensionBundleAssetsStub,
+  });
+  expect(
+    fs.existsSync(
+      path.join(root, '.expo', 'expo-targets-extension-bundle-assets.js')
+    )
+  ).toBe(false);
+});
+
+test('withTargets resolveRequest prefers exported extensionBundleModules.js', () => {
+  const root = shareContentProject();
+  tempRoots.push(root);
+  const generated = path.join(
+    root,
+    'assets',
+    'expo-targets',
+    'extensionBundleModules.js'
   );
+  fs.mkdirSync(path.dirname(generated), { recursive: true });
+  fs.writeFileSync(generated, 'module.exports = { Share: 1 };\n');
+  const config = buildWithTargetsConfig(root);
+  const assetsResult = config.resolver!.resolveRequest!(
+    {
+      resolveRequest: () => ({ type: 'sourceFile', filePath: '/fallback' }),
+    } as any,
+    'expo-targets/extension-bundle-assets',
+    'ios'
+  );
+  expect(assetsResult).toEqual({
+    type: 'sourceFile',
+    filePath: generated,
+  });
 });
 
 test('withTargets resolveRequest returns mapped entry files', () => {

--- a/packages/expo-targets/metro/src/withTargets.ts
+++ b/packages/expo-targets/metro/src/withTargets.ts
@@ -119,6 +119,10 @@ function logScanSummary(
   );
 }
 
+function packagedExtensionBundleAssetsPath(): string {
+  return path.join(__dirname, '..', '..', 'extension-bundle-assets.js');
+}
+
 function resolveExtensionBundleAssets(projectRoot: string): {
   type: 'sourceFile';
   filePath: string;
@@ -129,19 +133,13 @@ function resolveExtensionBundleAssets(projectRoot: string): {
     'expo-targets',
     'extensionBundleModules.js'
   );
-  const stubAssets = path.join(
-    projectRoot,
-    '.expo',
-    'expo-targets-extension-bundle-assets.js'
-  );
   if (fs.existsSync(extensionAssets)) {
     return { type: 'sourceFile', filePath: extensionAssets };
   }
-  fs.mkdirSync(path.dirname(stubAssets), { recursive: true });
-  if (!fs.existsSync(stubAssets)) {
-    fs.writeFileSync(stubAssets, 'module.exports = {};\n');
-  }
-  return { type: 'sourceFile', filePath: stubAssets };
+  return {
+    type: 'sourceFile',
+    filePath: packagedExtensionBundleAssetsPath(),
+  };
 }
 
 function createTargetsResolveRequest(

--- a/packages/expo-targets/package.json
+++ b/packages/expo-targets/package.json
@@ -17,6 +17,7 @@
     "ios",
     "android",
     "expo-module.config.json",
+    "extension-bundle-assets.js",
     "README.md"
   ],
   "exports": {
@@ -24,6 +25,7 @@
       "import": "./build/src/index.js",
       "require": "./build/src/index.js"
     },
+    "./extension-bundle-assets": "./extension-bundle-assets.js",
     "./metro": {
       "import": "./metro/build/index.js",
       "require": "./metro/build/index.js"

--- a/packages/expo-targets/src/modules/extensionBundle/enableExtensionUpdates.ts
+++ b/packages/expo-targets/src/modules/extensionBundle/enableExtensionUpdates.ts
@@ -62,7 +62,7 @@ function rnNativeSyncTargets(): {
 
 function loadBundledAssetModules(): Record<string, number> {
   try {
-    // Resolved by `withTargets` → assets/expo-targets/extensionBundleModules.js
+    // withTargets: assets/expo-targets/extensionBundleModules.js, else packaged stub
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('expo-targets/extension-bundle-assets') as Record<
       string,


### PR DESCRIPTION
## Summary
- Stop `withTargets` from writing `expo-targets/extension-bundle-assets` under gitignored `.expo/` during Metro `resolveRequest` (EAS `export:embed` SHA-1 miss).
- Ship `extension-bundle-assets.js` (`module.exports = {}`) plus `package.json` export `./extension-bundle-assets`. Prefer host `assets/expo-targets/extensionBundleModules.js` when present.

## Test plan
- [x] `cd packages/expo-targets && bun test metro/src/withTargets.test.ts`
- [ ] Merge publishes **1.7.1** (patch, no `minor`/`major` label).
- [ ] Bump Popl `expo-targets` to 1.7.1 (not PR 2424 env-contract).
- [ ] Re-run Popl EAS iOS `export:embed` on `dev`/`qa`.