### PR TITLE
fix(ios): omit App Groups on clips unless they share data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- App Clips no longer inherit host App Groups. An empty or absent group list omits `com.apple.security.application-groups` so AdHoc codesign matches Clip profiles that have no App Groups capability.
 - Metro `withTargets` no longer writes `expo-targets/extension-bundle-assets` under gitignored `.expo/` during `resolveRequest` (EAS `export:embed` SHA-1 failure). Missing host assets resolve to a packaged empty stub.
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,9 @@ When you omit `appGroup` in your target config, it inherits automatically from y
 }
 ```
 
-The first App Group in the array is used. When no App Group is configured in `app.json`, you **must** specify `appGroup` in each target config.
+The first App Group in the array is used. When no App Group is configured in `app.json`, you **must** specify `appGroup` in each target that needs one.
+
+**App Clips** do not inherit host App Groups. If the Clip does not share data, omit `appGroup` and do not set `com.apple.security.application-groups`. An empty list also omits the key, so AdHoc codesign can match a Clip profile that has no App Groups capability. Set `appGroup` or a non-empty group list only when the Clip shares data with the host.
 
 **Best practice:** Use the same App Group ID everywhere:
 

--- a/packages/expo-targets/cli/src/checks/easCredentials.ts
+++ b/packages/expo-targets/cli/src/checks/easCredentials.ts
@@ -1,20 +1,12 @@
+import {
+  APP_GROUP_ENTITLEMENT_KEY,
+  EAS_APP_GROUP_TYPES,
+  shouldUseAppGroups,
+} from '../../../plugin/src/domain';
+import type { ExtensionType } from '../../../plugin/src/domain/types';
 import type { CheckResult, ProjectContext } from '../types';
 
-const APP_GROUP_KEY = 'com.apple.security.application-groups';
-
-/** Mirror plugin EAS_APP_GROUP_TYPES — types that should carry App Groups in EAS. */
-const EAS_APP_GROUP_TYPES = new Set([
-  'widget',
-  'clip',
-  'share',
-  'bg-download',
-  'messages',
-  'action',
-  'notification-service',
-  'notification-content',
-  'intent',
-  'intent-ui',
-]);
+const APP_GROUP_KEY = APP_GROUP_ENTITLEMENT_KEY;
 
 type AppExtensionRow = {
   targetName?: string;
@@ -102,6 +94,16 @@ function wrongProductNameError(
   };
 }
 
+function targetUsesAppGroupsForEas(
+  type: ExtensionType | undefined,
+  appGroup: unknown
+): boolean {
+  if (typeof appGroup === 'string' && appGroup.length > 0) {
+    return true;
+  }
+  return Boolean(type && shouldUseAppGroups(type));
+}
+
 function checkExtensionRow(
   target: ProjectContext['targets'][number],
   row: AppExtensionRow | undefined,
@@ -120,8 +122,13 @@ function checkExtensionRow(
     );
   }
 
-  const type = target.config.type;
-  if (type && EAS_APP_GROUP_TYPES.has(type) && hostAppGroups.length > 0) {
+  const type = target.config.type as ExtensionType | undefined;
+  if (
+    type &&
+    EAS_APP_GROUP_TYPES.includes(type) &&
+    hostAppGroups.length > 0 &&
+    targetUsesAppGroupsForEas(type, target.config.appGroup)
+  ) {
     const groups = row.entitlements?.[APP_GROUP_KEY];
     const hasGroups = Array.isArray(groups) && groups.length > 0;
     if (!hasGroups) {

--- a/packages/expo-targets/cli/src/checks/easCredentials.ts
+++ b/packages/expo-targets/cli/src/checks/easCredentials.ts
@@ -1,9 +1,9 @@
 import {
   APP_GROUP_ENTITLEMENT_KEY,
   EAS_APP_GROUP_TYPES,
+  type ExtensionType,
   shouldUseAppGroups,
-} from '../../../plugin/src/domain';
-import type { ExtensionType } from '../../../plugin/src/domain/types';
+} from '../../../plugin/build/domain';
 import type { CheckResult, ProjectContext } from '../types';
 
 const APP_GROUP_KEY = APP_GROUP_ENTITLEMENT_KEY;

--- a/packages/expo-targets/plugin/src/domain/appGroups.ts
+++ b/packages/expo-targets/plugin/src/domain/appGroups.ts
@@ -14,22 +14,65 @@ export function shouldUseAppGroups(type: ExtensionType): boolean {
 /**
  * Types that cannot build without an App Group. This is the historical
  * "required" set — a strict subset of the types that default to App Groups.
+ * App Clips are opt-in: they share nothing unless the target lists a group.
  */
 export const REQUIRES_APP_GROUP_TYPES: ExtensionType[] = [
   'widget',
-  'clip',
   'share',
   'bg-download',
 ];
+
+/**
+ * Resolve the App Groups list for a target. An empty configured array omits
+ * the entitlement (no host copy). A real `appGroup` or non-empty list wins.
+ */
+export function resolveApplicationGroups({
+  configured,
+  appGroup,
+  mainAppGroups,
+  inheritHost,
+}: {
+  configured: unknown;
+  appGroup?: string;
+  mainAppGroups?: unknown;
+  inheritHost: boolean;
+}): string[] | undefined {
+  if (Array.isArray(configured)) {
+    const groups = configured.filter(
+      (g): g is string => typeof g === 'string' && g.length > 0
+    );
+    return groups.length > 0 ? groups : undefined;
+  }
+  if (typeof appGroup === 'string' && appGroup.length > 0) {
+    return [appGroup];
+  }
+  if (inheritHost && Array.isArray(mainAppGroups) && mainAppGroups.length > 0) {
+    return mainAppGroups.filter(
+      (g): g is string => typeof g === 'string' && g.length > 0
+    );
+  }
+}
+
+export function omitEmptyApplicationGroups<T extends Record<string, unknown>>(
+  entitlements: T
+): T {
+  const value = entitlements[APP_GROUP_ENTITLEMENT_KEY];
+  if (!Array.isArray(value) || value.length > 0) {
+    return entitlements;
+  }
+  const next = { ...entitlements };
+  delete next[APP_GROUP_ENTITLEMENT_KEY];
+  return next;
+}
 
 export function requiresAppGroup(type: ExtensionType): boolean {
   return REQUIRES_APP_GROUP_TYPES.includes(type);
 }
 
 /**
- * Types whose EAS credentials should carry App Groups. Wider than
- * `shouldUseAppGroups` on purpose: extra capabilities are harmless, missing
- * ones break builds when a user hand-configures App Groups.
+ * Types whose EAS credentials can carry App Groups. Wider than
+ * `shouldUseAppGroups` on purpose: missing capabilities break builds when a
+ * user hand-configures App Groups. Clips still omit unless they list a group.
  */
 export const EAS_APP_GROUP_TYPES: ExtensionType[] = [
   'widget',

--- a/packages/expo-targets/plugin/src/domain/characteristics.test.ts
+++ b/packages/expo-targets/plugin/src/domain/characteristics.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { TYPE_MINIMUM_DEPLOYMENT_TARGETS } from '../config';
-import { REQUIRES_APP_GROUP_TYPES, shouldUseAppGroups } from './appGroups';
+import {
+  REQUIRES_APP_GROUP_TYPES,
+  resolveApplicationGroups,
+  shouldUseAppGroups,
+} from './appGroups';
 import { TYPE_BUNDLE_IDENTIFIER_SUFFIXES } from './bundleIds';
 import {
   EXTENSION_POINT_IDENTIFIERS,
@@ -212,9 +216,42 @@ describe('appGroups', () => {
     }
     expect(sorted(REQUIRES_APP_GROUP_TYPES)).toEqual([
       'bg-download',
-      'clip',
       'share',
       'widget',
     ]);
+    expect(shouldUseAppGroups('clip')).toBe(false);
+  });
+
+  test('resolveApplicationGroups omits empty lists and inherits only when asked', () => {
+    expect(
+      resolveApplicationGroups({
+        configured: [],
+        mainAppGroups: ['group.host'],
+        inheritHost: true,
+      })
+    ).toBeUndefined();
+    expect(
+      resolveApplicationGroups({
+        configured: undefined,
+        mainAppGroups: ['group.host'],
+        inheritHost: false,
+      })
+    ).toBeUndefined();
+    expect(
+      resolveApplicationGroups({
+        configured: undefined,
+        appGroup: 'group.clip',
+        mainAppGroups: ['group.host'],
+        inheritHost: false,
+      })
+    ).toEqual(['group.clip']);
+    expect(
+      resolveApplicationGroups({
+        configured: ['group.explicit'],
+        appGroup: 'group.clip',
+        mainAppGroups: ['group.host'],
+        inheritHost: true,
+      })
+    ).toEqual(['group.explicit']);
   });
 });

--- a/packages/expo-targets/plugin/src/domain/characteristics.test.ts
+++ b/packages/expo-targets/plugin/src/domain/characteristics.test.ts
@@ -221,8 +221,10 @@ describe('appGroups', () => {
     ]);
     expect(shouldUseAppGroups('clip')).toBe(false);
   });
+});
 
-  test('resolveApplicationGroups omits empty lists and inherits only when asked', () => {
+describe('resolveApplicationGroups', () => {
+  test('omits empty lists and inherits only when asked', () => {
     expect(
       resolveApplicationGroups({
         configured: [],

--- a/packages/expo-targets/plugin/src/domain/characteristics.ts
+++ b/packages/expo-targets/plugin/src/domain/characteristics.ts
@@ -181,7 +181,7 @@ const BASE_TYPE_CHARACTERISTICS: Record<
     frameworks: [], // SwiftUI auto-linked
     productType: 'com.apple.product-type.application.on-demand-install-capable',
     extensionPointIdentifier: '',
-    defaultUsesAppGroups: true,
+    defaultUsesAppGroups: false,
     requiresEntitlements: true,
     basePlist: {
       CFBundleShortVersionString: '$(MARKETING_VERSION)',

--- a/packages/expo-targets/plugin/src/domain/index.ts
+++ b/packages/expo-targets/plugin/src/domain/index.ts
@@ -8,8 +8,10 @@
 export {
   APP_GROUP_ENTITLEMENT_KEY,
   EAS_APP_GROUP_TYPES,
+  omitEmptyApplicationGroups,
   REQUIRES_APP_GROUP_TYPES,
   requiresAppGroup,
+  resolveApplicationGroups,
   shouldUseAppGroups,
 } from './appGroups';
 export {

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
@@ -22,6 +22,10 @@ describe('targetNeedsAppGroup', () => {
   test('safari does not need app groups', () => {
     expect(targetNeedsAppGroup('safari')).toBe(false);
   });
+
+  test('clip does not need app groups by default', () => {
+    expect(targetNeedsAppGroup('clip')).toBe(false);
+  });
 });
 
 describe('ensureHostAppGroups', () => {
@@ -107,6 +111,54 @@ describe('ensureHostAppGroups union', () => {
     expect(
       config.ios?.entitlements?.['com.apple.security.application-groups']
     ).toEqual(['group.onesignal', 'group.widgets']);
+  });
+
+  test('does not invent a host group for a clip that lists none', () => {
+    const logger = new Logger(false);
+    const config = ensureHostAppGroups(
+      {
+        ios: { bundleIdentifier: 'com.example.app' },
+      },
+      [
+        {
+          config: {
+            type: 'clip' as const,
+            platforms: ['ios'],
+          },
+        },
+      ],
+      logger
+    );
+
+    expect(config.ios?.entitlements).toBeUndefined();
+  });
+
+  test('unions an explicit clip appGroup into the host list', () => {
+    const logger = new Logger(false);
+    const config = ensureHostAppGroups(
+      {
+        ios: {
+          bundleIdentifier: 'com.example.app',
+          entitlements: {
+            'com.apple.security.application-groups': ['group.onesignal'],
+          },
+        },
+      },
+      [
+        {
+          config: {
+            type: 'clip' as const,
+            platforms: ['ios'],
+            appGroup: 'group.clip',
+          },
+        },
+      ],
+      logger
+    );
+
+    expect(
+      config.ios?.entitlements?.['com.apple.security.application-groups']
+    ).toEqual(['group.onesignal', 'group.clip']);
   });
 });
 

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.test.ts
@@ -112,27 +112,22 @@ describe('ensureHostAppGroups union', () => {
       config.ios?.entitlements?.['com.apple.security.application-groups']
     ).toEqual(['group.onesignal', 'group.widgets']);
   });
+});
 
+describe('ensureHostAppGroups clip omit', () => {
   test('does not invent a host group for a clip that lists none', () => {
     const logger = new Logger(false);
     const config = ensureHostAppGroups(
-      {
-        ios: { bundleIdentifier: 'com.example.app' },
-      },
-      [
-        {
-          config: {
-            type: 'clip' as const,
-            platforms: ['ios'],
-          },
-        },
-      ],
+      { ios: { bundleIdentifier: 'com.example.app' } },
+      [{ config: { type: 'clip' as const, platforms: ['ios'] } }],
       logger
     );
 
     expect(config.ios?.entitlements).toBeUndefined();
   });
+});
 
+describe('ensureHostAppGroups clip union', () => {
   test('unions an explicit clip appGroup into the host list', () => {
     const logger = new Logger(false);
     const config = ensureHostAppGroups(

--- a/packages/expo-targets/plugin/src/ensureHostAppGroups.ts
+++ b/packages/expo-targets/plugin/src/ensureHostAppGroups.ts
@@ -35,13 +35,30 @@ function addStringGroups(groups: Set<string>, values: unknown): void {
   }
 }
 
+function targetHasExplicitAppGroup(target: EvaluatedTarget): boolean {
+  if (typeof target.config.appGroup === 'string' && target.config.appGroup) {
+    return true;
+  }
+  const configured =
+    target.config.ios?.entitlements?.[APP_GROUP_ENTITLEMENT_KEY];
+  return (
+    Array.isArray(configured) &&
+    configured.some((g) => typeof g === 'string' && g.length > 0)
+  );
+}
+
 export function collectTargetAppGroups(targets: EvaluatedTarget[]): string[] {
   const groups = new Set<string>();
   for (const target of targets) {
     if (!target.config.platforms?.includes('ios')) {
       continue;
     }
-    if (!targetNeedsAppGroup(target.config.type)) {
+    if (
+      !(
+        targetNeedsAppGroup(target.config.type) ||
+        targetHasExplicitAppGroup(target)
+      )
+    ) {
       continue;
     }
     if (typeof target.config.appGroup === 'string' && target.config.appGroup) {
@@ -69,7 +86,8 @@ export function targetNeedsAppGroup(type: ExtensionType | undefined): boolean {
 export function anyTargetNeedsAppGroup(targets: EvaluatedTarget[]): boolean {
   return targets.some(
     (t) =>
-      t.config.platforms?.includes('ios') && targetNeedsAppGroup(t.config.type)
+      t.config.platforms?.includes('ios') &&
+      (targetNeedsAppGroup(t.config.type) || targetHasExplicitAppGroup(t))
   );
 }
 

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
@@ -16,8 +16,10 @@ import {
   isReactNativeCompatible,
   isReactNativeNative,
   isReactNativeWeb,
+  omitEmptyApplicationGroups,
   REACT_NATIVE_COMPATIBLE_TYPES,
   requiresAppGroup,
+  resolveApplicationGroups,
   resolveUiMode,
   shouldUseAppGroups,
   TYPE_CHARACTERISTICS,
@@ -89,7 +91,12 @@ function validateEntry(props: IosTargetProps, projectRoot: string): void {
 function validateAppGroup(props: IosTargetProps, mainAppGroups: unknown): void {
   let appGroup = props.appGroup;
 
-  if (!appGroup && Array.isArray(mainAppGroups) && mainAppGroups.length > 0) {
+  if (
+    !appGroup &&
+    shouldUseAppGroups(props.type) &&
+    Array.isArray(mainAppGroups) &&
+    mainAppGroups.length > 0
+  ) {
     appGroup = mainAppGroups[0];
     props.logger.log(`Inherited App Group: ${appGroup}`);
   }
@@ -117,18 +124,17 @@ function resolveTargetEntitlements(
     ...(props.entitlements || {}),
   };
 
-  if (!entitlements[APP_GROUP_ENTITLEMENT_KEY]) {
-    // Explicit target appGroup wins even when the type does not default-sync
-    // (action historically had defaultUsesAppGroups:false).
-    if (props.appGroup) {
-      entitlements[APP_GROUP_ENTITLEMENT_KEY] = [props.appGroup];
-    } else if (
-      shouldUseAppGroups(props.type) &&
-      Array.isArray(mainAppGroups) &&
-      mainAppGroups.length > 0
-    ) {
-      entitlements[APP_GROUP_ENTITLEMENT_KEY] = mainAppGroups;
-    }
+  const groups = resolveApplicationGroups({
+    configured: entitlements[APP_GROUP_ENTITLEMENT_KEY],
+    appGroup: props.appGroup,
+    mainAppGroups,
+    inheritHost: shouldUseAppGroups(props.type),
+  });
+
+  if (groups && groups.length > 0) {
+    entitlements[APP_GROUP_ENTITLEMENT_KEY] = groups;
+  } else {
+    delete entitlements[APP_GROUP_ENTITLEMENT_KEY];
   }
 
   return entitlements;
@@ -334,12 +340,19 @@ function buildEasEntitlements({
   };
 
   const mainAppGroups = mainAppEntitlements?.[APP_GROUP_ENTITLEMENT_KEY];
-  if (
-    Array.isArray(mainAppGroups) &&
-    mainAppGroups.length > 0 &&
-    EAS_APP_GROUP_TYPES.includes(props.type)
-  ) {
-    easEntitlements[APP_GROUP_ENTITLEMENT_KEY] = mainAppGroups;
+  const groups = resolveApplicationGroups({
+    configured: easEntitlements[APP_GROUP_ENTITLEMENT_KEY],
+    appGroup: props.appGroup,
+    mainAppGroups,
+    inheritHost:
+      shouldUseAppGroups(props.type) &&
+      EAS_APP_GROUP_TYPES.includes(props.type),
+  });
+
+  if (groups && groups.length > 0) {
+    easEntitlements[APP_GROUP_ENTITLEMENT_KEY] = groups;
+  } else {
+    delete easEntitlements[APP_GROUP_ENTITLEMENT_KEY];
   }
 
   if (props.type === 'clip') {
@@ -352,7 +365,7 @@ function buildEasEntitlements({
     );
   }
 
-  return easEntitlements;
+  return omitEmptyApplicationGroups(easEntitlements);
 }
 
 /**

--- a/packages/expo-targets/plugin/src/ios/plan/entitlements.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/entitlements.ts
@@ -1,6 +1,7 @@
 import type { ExtensionType } from '../../domain';
 import {
   APP_GROUP_ENTITLEMENT_KEY,
+  omitEmptyApplicationGroups,
   shouldUseAppGroups,
   TYPE_CHARACTERISTICS,
 } from '../../domain';
@@ -68,6 +69,8 @@ export function planEntitlements({
       mainAppGroups,
     });
   }
+
+  entitlements = omitEmptyApplicationGroups(entitlements);
 
   return {
     required,

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -639,6 +639,51 @@ describe('planEntitlements per type', () => {
     ).toBe(true);
   });
 
+  test('omits App Groups on clip when host groups exist but clip lists none', () => {
+    const plan = planEntitlements({
+      type: 'clip',
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app', 'group.com.example.extra'],
+      paths: entitlementPaths,
+    });
+
+    expect(plan.entitlements).not.toHaveProperty(
+      'com.apple.security.application-groups'
+    );
+    expect(plan.syncedAppGroups).toBe(false);
+  });
+
+  test('omits empty clip application-groups instead of writing the key', () => {
+    const plan = planEntitlements({
+      type: 'clip',
+      entitlements: { 'com.apple.security.application-groups': [] },
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app'],
+      paths: entitlementPaths,
+    });
+
+    expect(plan.entitlements).not.toHaveProperty(
+      'com.apple.security.application-groups'
+    );
+    expect(plan.syncedAppGroups).toBe(false);
+  });
+
+  test('keeps an explicit non-empty clip App Group list', () => {
+    const plan = planEntitlements({
+      type: 'clip',
+      entitlements: {
+        'com.apple.security.application-groups': ['group.com.example.clip'],
+      },
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app'],
+      paths: entitlementPaths,
+    });
+
+    expect(plan.entitlements['com.apple.security.application-groups']).toEqual([
+      'group.com.example.clip',
+    ]);
+  });
+
   test('adds payment pass provisioning for wallet targets', () => {
     const plan = planEntitlements({ type: 'wallet', paths: entitlementPaths });
 

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -639,51 +639,6 @@ describe('planEntitlements per type', () => {
     ).toBe(true);
   });
 
-  test('omits App Groups on clip when host groups exist but clip lists none', () => {
-    const plan = planEntitlements({
-      type: 'clip',
-      mainBundleIdentifier: MAIN_BUNDLE_ID,
-      mainAppGroups: ['group.com.example.app', 'group.com.example.extra'],
-      paths: entitlementPaths,
-    });
-
-    expect(plan.entitlements).not.toHaveProperty(
-      'com.apple.security.application-groups'
-    );
-    expect(plan.syncedAppGroups).toBe(false);
-  });
-
-  test('omits empty clip application-groups instead of writing the key', () => {
-    const plan = planEntitlements({
-      type: 'clip',
-      entitlements: { 'com.apple.security.application-groups': [] },
-      mainBundleIdentifier: MAIN_BUNDLE_ID,
-      mainAppGroups: ['group.com.example.app'],
-      paths: entitlementPaths,
-    });
-
-    expect(plan.entitlements).not.toHaveProperty(
-      'com.apple.security.application-groups'
-    );
-    expect(plan.syncedAppGroups).toBe(false);
-  });
-
-  test('keeps an explicit non-empty clip App Group list', () => {
-    const plan = planEntitlements({
-      type: 'clip',
-      entitlements: {
-        'com.apple.security.application-groups': ['group.com.example.clip'],
-      },
-      mainBundleIdentifier: MAIN_BUNDLE_ID,
-      mainAppGroups: ['group.com.example.app'],
-      paths: entitlementPaths,
-    });
-
-    expect(plan.entitlements['com.apple.security.application-groups']).toEqual([
-      'group.com.example.clip',
-    ]);
-  });
-
   test('adds payment pass provisioning for wallet targets', () => {
     const plan = planEntitlements({ type: 'wallet', paths: entitlementPaths });
 
@@ -700,6 +655,47 @@ describe('planEntitlements per type', () => {
 
     expect(plan.required).toBe(false);
     expect(plan.entitlements).toEqual({});
+  });
+});
+
+describe('planEntitlements clip omit', () => {
+  test('omits host groups when clip lists none or []', () => {
+    const absent = planEntitlements({
+      type: 'clip',
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app'],
+      paths: entitlementPaths,
+    });
+    const empty = planEntitlements({
+      type: 'clip',
+      entitlements: { 'com.apple.security.application-groups': [] },
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app'],
+      paths: entitlementPaths,
+    });
+
+    expect(absent.entitlements).not.toHaveProperty(
+      'com.apple.security.application-groups'
+    );
+    expect(empty.entitlements).not.toHaveProperty(
+      'com.apple.security.application-groups'
+    );
+  });
+
+  test('keeps an explicit non-empty clip App Group list', () => {
+    const plan = planEntitlements({
+      type: 'clip',
+      entitlements: {
+        'com.apple.security.application-groups': ['group.com.example.clip'],
+      },
+      mainBundleIdentifier: MAIN_BUNDLE_ID,
+      mainAppGroups: ['group.com.example.app'],
+      paths: entitlementPaths,
+    });
+
+    expect(plan.entitlements['com.apple.security.application-groups']).toEqual([
+      'group.com.example.clip',
+    ]);
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/utils/plist.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/plist.test.ts
@@ -63,12 +63,24 @@ describe('syncAppGroups', () => {
 
     expect(result).toEqual({ foo: 'bar' });
   });
+
+  test('omits an empty application-groups array instead of writing the key', () => {
+    const result = syncAppGroups({
+      targetEntitlements: {
+        foo: 'bar',
+        'com.apple.security.application-groups': [],
+      },
+      mainAppGroups: ['group.com.example.app'],
+    });
+
+    expect(result).toEqual({ foo: 'bar' });
+  });
 });
 
 describe('shouldUseAppGroups', () => {
-  test('share, clip, widget, messages, action, and bg-download default to true', () => {
+  test('share, widget, messages, action, and bg-download default to true', () => {
     expect(shouldUseAppGroups('share')).toBe(true);
-    expect(shouldUseAppGroups('clip')).toBe(true);
+    expect(shouldUseAppGroups('clip')).toBe(false);
     expect(shouldUseAppGroups('widget')).toBe(true);
     expect(shouldUseAppGroups('messages')).toBe(true);
     expect(shouldUseAppGroups('action')).toBe(true);

--- a/packages/expo-targets/plugin/src/ios/utils/plist.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/plist.ts
@@ -54,12 +54,14 @@ export function syncAppGroups({
   mainAppGroups: string[] | undefined;
 }): Record<string, any> {
   const AppGroupKey = 'com.apple.security.application-groups';
+  const configured = targetEntitlements[AppGroupKey];
 
-  if (
-    !targetEntitlements[AppGroupKey] &&
-    Array.isArray(mainAppGroups) &&
-    mainAppGroups.length > 0
-  ) {
+  if (Array.isArray(configured) && configured.length === 0) {
+    const { [AppGroupKey]: _omitted, ...rest } = targetEntitlements;
+    return rest;
+  }
+
+  if (!configured && Array.isArray(mainAppGroups) && mainAppGroups.length > 0) {
     return {
       ...targetEntitlements,
       [AppGroupKey]: mainAppGroups,


### PR DESCRIPTION
## Summary
- App Clips no longer inherit host `com.apple.security.application-groups`. Empty or absent lists omit the key so AdHoc codesign matches Clip profiles that have no App Groups capability.
- Explicit `appGroup` or a non-empty group list still writes those groups and unions them into the host. Share, widget, and action inherit as before.
- Merge publishes a **patch** (no `major`/`minor` label) so Popl can bump and drop `withStripClipAppGroups`.

## Test plan
- [x] Plugin unit tests: clip omit / empty `[]` / explicit list (`planners`, `plist`, `characteristics`, `ensureHostAppGroups`)
- [ ] After publish: Popl AdHoc Fastlane Clip codesign without the strip plugin
- [ ] After Popl bump: delete `plugins/withStripClipAppGroups.js` and the empty-`[]` workaround