### PR TITLE
feat(ios): emit sealed @main WidgetBundle for native kinds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 **Source of truth for** `expo-target.config` options and extension types.
 
-<!-- doc-meta: owner=eng | last-reviewed=2026-08-26 -->
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-31 -->
 
 > **Orphan-stub freeze:** do not add new `ExtensionType` values without registry, scaffold, example, and Devicewright row. See [deprecations.md](./deprecations.md). Widgets policy: [widgets.md](./widgets.md).
 
@@ -563,7 +563,7 @@ widget.setData(
 }
 ```
 
-`ios.kinds` lists WidgetKit picker products (`name` matches `createTarget`). `supportedFamilies` on a kind is sizes of that one picker row, not extra products. Declare Live Activity on `ios.liveActivity` (one) or `ios.liveActivities` (two or more in the same `.appex`). Do not set both on one target. Each row holds `attributesName` / `static` / `contentState` / `pushType`. That drives sealed CNG for native widgets and `WidgetLiveActivity()` on expo-ui Bundles. Ambient TypeScript payload types still land in `.expo/types/expo-targets.d.ts`. Host JS: `LiveActivity.create('WeatherAttributes')` or `folder.liveActivity('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
+`ios.kinds` lists WidgetKit picker products (`name` matches `createTarget`). `supportedFamilies` on a kind is sizes of that one picker row, not extra products. Declare Live Activity on `ios.liveActivity` (one) or `ios.liveActivities` (two or more in the same `.appex`). Do not set both on one target. Each row holds `attributesName` / `static` / `contentState` / `pushType`. That drives sealed CNG for native widgets and `WidgetLiveActivity()` on expo-ui Bundles. A native widget with `ios.kinds` and no user `*Bundle.swift` also gets a sealed `@main` WidgetBundle (`<name>LiveActivity()` when a Live Activity is set). Ambient TypeScript payload types still land in `.expo/types/expo-targets.d.ts`. Host JS: `LiveActivity.create('WeatherAttributes')` or `folder.liveActivity('WeatherAttributes')`. See [api.md](./api.md) and [widgets.md](./widgets.md).
 
 ### File Provider domain (iOS)
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2,7 +2,7 @@
 
 **Source of truth for** WidgetKit / ActivityKit ownership in expo-targets.
 
-<!-- doc-meta: owner=eng | last-reviewed=2026-08-14 -->
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-31 -->
 
 ## Ownership
 
@@ -103,7 +103,7 @@ npx expo-targets add
 # optional: --configurable (Edit Widget) · --live-activity
 ```
 
-- **native (default)** — SwiftUI / Glance deepen under `targets/<name>/ios|android/`.
+- **native (default)** — SwiftUI / Glance deepen under `targets/<name>/ios|android/`. When `ios.kinds` lists gallery widgets and the user did not add a `*Bundle.swift`, CNG writes a sealed `@main` WidgetBundle into ExpoTargetsGenerated. That bundle constructs each kind and `<name>LiveActivity()` when `ios.liveActivity` is set.
 - **expo-ui** — writes `entry` + `createTarget(name, Layout)` with the `'widget'` directive; CNG emits `ExpoUiWidget` (+ optional AppIntentConfiguration / `WidgetLiveActivity`).
 - **Configurable (Edit Widget)** — native scaffolds `AppIntentConfiguration` under user deepen; expo-ui uses `ios.configuration` → sealed AppIntent + `environment.configuration` in Layout.
 - **Live Activity** — writes `ios.liveActivity` (one) or `ios.liveActivities` (multiple in the same `.appex`). Native: one `LiveActivity.swift` deepen UI block per attributes type + typed CNG attributes. Expo-ui: same entry registers `createLiveActivityLayout` + Bundle includes `WidgetLiveActivity()` (blob attrs; skip typed CNG).

--- a/packages/expo-targets/plugin/src/ios/apply/fs/swift.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/fs/swift.ts
@@ -20,6 +20,8 @@ function renderSwiftTemplate(plan: SwiftTemplatePlan): string {
       return ExpoUiWidgetSwift.generateExpoUiWidgetSwift(plan.options);
     case 'expoUiWidgetBundle':
       return ExpoUiWidgetSwift.generateExpoUiWidgetBundleSwift(plan.options);
+    case 'nativeWidgetBundle':
+      return ExpoUiWidgetSwift.generateNativeWidgetBundleSwift(plan.options);
     default:
       return ReactNativeSwift.generateReactNativeViewController(plan.options);
   }

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -424,6 +424,112 @@ describe('planSwiftSources per type', () => {
   });
 });
 
+describe('planSwiftSources native widget bundle emit', () => {
+  test('emits a sealed WidgetBundle from ios.kinds when the user has no Bundle.swift', () => {
+    const plans = swiftSourcesFor(
+      {
+        type: 'widget',
+        name: 'PoplWidgets',
+        kinds: [
+          { name: 'HomescreenWidgets' },
+          { name: 'LockScreenWidgets' },
+          { name: 'LockScreenScanWidget' },
+        ],
+        liveActivity: {
+          attributesName: 'DynamicIslandAttributes',
+          static: { id: 'string' },
+          contentState: { title: 'string' },
+        },
+      },
+      {
+        type: 'widget',
+        swiftFiles: ['HomescreenWidgets.swift', 'LiveActivity.swift'],
+      }
+    );
+
+    expect(plans.map((plan) => plan.file)).toEqual([
+      'HomescreenWidgets.swift',
+      'LiveActivity.swift',
+      'PoplWidgetsBundle.swift',
+    ]);
+    const bundle = plans[2];
+    expect(bundle.generate?.template).toBe('nativeWidgetBundle');
+    expect(bundle.generate?.options).toMatchObject({
+      name: 'PoplWidgets',
+      widgets: [
+        { name: 'HomescreenWidgets' },
+        { name: 'LockScreenWidgets' },
+        { name: 'LockScreenScanWidget' },
+      ],
+      includeLiveActivity: true,
+    });
+    expect(bundle.sourcePath).toContain(
+      path.join(
+        'ios',
+        PROJECT_NAME,
+        'ExpoTargetsGenerated',
+        PRODUCT_NAME,
+        'PoplWidgetsBundle.swift'
+      )
+    );
+  });
+});
+
+describe('planSwiftSources native widget bundle user files', () => {
+  test('keeps a user *Bundle.swift and does not emit a sealed bundle', () => {
+    const plans = swiftSourcesFor(
+      {
+        type: 'widget',
+        name: 'HelloWidget',
+        kinds: [{ name: 'HelloWidget' }],
+      },
+      {
+        type: 'widget',
+        swiftFiles: ['Widget.swift', 'WidgetBundle.swift'],
+      }
+    );
+
+    expect(plans.map((plan) => plan.file)).toEqual([
+      'Widget.swift',
+      'WidgetBundle.swift',
+    ]);
+    expect(plans.every((plan) => plan.generate === undefined)).toBe(true);
+  });
+
+  test('keeps a user target-named Bundle.swift and does not emit a sealed bundle', () => {
+    const plans = swiftSourcesFor(
+      {
+        type: 'widget',
+        name: 'PoplWidgets',
+        kinds: [{ name: 'HomescreenWidgets' }],
+      },
+      {
+        type: 'widget',
+        swiftFiles: ['HomescreenWidgets.swift', 'PoplWidgetsBundle.swift'],
+      }
+    );
+
+    expect(plans.map((plan) => plan.file)).toEqual([
+      'HomescreenWidgets.swift',
+      'PoplWidgetsBundle.swift',
+    ]);
+    expect(plans.every((plan) => plan.generate === undefined)).toBe(true);
+    expect(plans[1].sourcePath).toBe(
+      path.join(PROJECT_ROOT, 'targets/my-share/ios/PoplWidgetsBundle.swift')
+    );
+  });
+
+  test('does not emit a sealed bundle when ios.kinds is omitted', () => {
+    const plans = swiftSourcesFor(
+      { type: 'widget', name: 'HelloWidget' },
+      { type: 'widget', swiftFiles: ['Widget.swift'] }
+    );
+
+    expect(plans.map((plan) => plan.file)).toEqual(['Widget.swift']);
+    expect(plans[0].generate).toBeUndefined();
+  });
+});
+
 describe('planAssets', () => {
   test('plans colorsets and a reference relative to ios/', () => {
     const plan = assetsFor({

--- a/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
@@ -33,6 +33,22 @@ function isExpoUiWidget(props: IOSTargetProps): boolean {
   );
 }
 
+function isNativeWidgetKitTarget(props: IOSTargetProps): boolean {
+  return (
+    (props.type === 'widget' || props.type === 'watch-widget') &&
+    !isExpoUiWidget(props)
+  );
+}
+
+function isWidgetBundleFile(file: string): boolean {
+  const base = file.replace(/\\/g, '/').split('/').pop() ?? file;
+  return base.endsWith('Bundle.swift');
+}
+
+function hasUserWidgetBundle(workspace: TargetWorkspace): boolean {
+  return workspace.swiftFiles.some(isWidgetBundleFile);
+}
+
 /** Match a well-known file name at the root or nested in a subdirectory. */
 function isNamed(file: string, fileName: string): boolean {
   return (
@@ -85,6 +101,20 @@ function resolveEntryOnlySwiftFiles(props: IOSTargetProps): string[] {
   return [REACT_NATIVE_VIEW_CONTROLLER];
 }
 
+function maybeEnsureNativeWidgetBundle(
+  files: string[],
+  workspace: TargetWorkspace,
+  props: IOSTargetProps
+): void {
+  if (!(isNativeWidgetKitTarget(props) && hasExplicitGalleryKinds(props))) {
+    return;
+  }
+  if (hasUserWidgetBundle(workspace)) {
+    return;
+  }
+  ensureNamed(files, `${props.name}Bundle.swift`);
+}
+
 function resolveSwiftFileNames(
   workspace: TargetWorkspace,
   props: IOSTargetProps
@@ -102,6 +132,8 @@ function resolveSwiftFileNames(
     }
     return files;
   }
+
+  maybeEnsureNativeWidgetBundle(files, workspace, props);
 
   if (props.entry && files.length === 0) {
     return resolveEntryOnlySwiftFiles(props);
@@ -261,6 +293,59 @@ function planExpoUiBundleFile(opts: {
   });
 }
 
+function planNativeWidgetSwiftFile({
+  file,
+  workspace,
+  props,
+}: {
+  file: string;
+  workspace: TargetWorkspace;
+  props: IOSTargetProps;
+}): UnresolvedSwiftFilePlan | undefined {
+  if (
+    !(
+      isNativeWidgetKitTarget(props) &&
+      hasExplicitGalleryKinds(props) &&
+      isNamed(file, `${props.name}Bundle.swift`)
+    )
+  ) {
+    return;
+  }
+  return planNativeWidgetBundleFile({ file, workspace, props });
+}
+
+function planNativeWidgetBundleFile(opts: {
+  file: string;
+  workspace: TargetWorkspace;
+  props: IOSTargetProps;
+}): UnresolvedSwiftFilePlan {
+  const { file, workspace, props } = opts;
+  const kinds = resolveGalleryWidgetKinds({
+    targetName: props.name,
+    displayName: props.displayName,
+    ios: props,
+  });
+  return planGeneratedFile({
+    file,
+    fileName: `${props.name}Bundle.swift`,
+    hasUserFile: hasUserWidgetBundle(workspace),
+    workspace,
+    template: {
+      template: 'nativeWidgetBundle',
+      options: {
+        name: props.name,
+        widgets: kinds.map((row) => ({
+          name: row.name,
+          configurable: Boolean(row.configuration),
+        })),
+        includeLiveActivity:
+          resolveLiveActivityConfigs({ ios: props }).length > 0,
+        configurable: kinds.some((row) => Boolean(row.configuration)),
+      },
+    },
+  });
+}
+
 function planExpoUiWidgetSwiftFile({
   file,
   workspace,
@@ -288,7 +373,7 @@ function planExpoUiWidgetSwiftFile({
   }
 }
 
-function planSwiftFile({
+function planExtensionHostSwiftFile({
   file,
   workspace,
   props,
@@ -299,11 +384,6 @@ function planSwiftFile({
   props: IOSTargetProps;
   identity: TargetIdentity;
 }): UnresolvedSwiftFilePlan | undefined {
-  const expoUiPlan = planExpoUiWidgetSwiftFile({ file, workspace, props });
-  if (expoUiPlan) {
-    return expoUiPlan;
-  }
-
   if (
     props.entry &&
     props.type === 'messages' &&
@@ -352,8 +432,25 @@ function planSwiftFile({
       },
     });
   }
+}
 
-  return planUserFile({ file, workspace });
+function planSwiftFile({
+  file,
+  workspace,
+  props,
+  identity,
+}: {
+  file: string;
+  workspace: TargetWorkspace;
+  props: IOSTargetProps;
+  identity: TargetIdentity;
+}): UnresolvedSwiftFilePlan | undefined {
+  return (
+    planExpoUiWidgetSwiftFile({ file, workspace, props }) ??
+    planNativeWidgetSwiftFile({ file, workspace, props }) ??
+    planExtensionHostSwiftFile({ file, workspace, props, identity }) ??
+    planUserFile({ file, workspace })
+  );
 }
 
 /**

--- a/packages/expo-targets/plugin/src/ios/plan/types.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/types.ts
@@ -99,6 +99,15 @@ export type SwiftTemplatePlan =
         configurable?: boolean;
         widgets?: { name: string; configurable?: boolean }[];
       };
+    }
+  | {
+      template: 'nativeWidgetBundle';
+      options: {
+        name: string;
+        includeLiveActivity?: boolean;
+        configurable?: boolean;
+        widgets?: { name: string; configurable?: boolean }[];
+      };
     };
 
 /** One Swift file that should end up in the target's Sources phase. */

--- a/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   generateExpoUiWidgetBundleSwift,
   generateExpoUiWidgetSwift,
+  generateNativeWidgetBundleSwift,
 } from './expoUiWidgetSwift';
 
 describe('generateExpoUiWidgetSwift', () => {
@@ -44,5 +45,27 @@ describe('generateExpoUiWidgetBundleSwift', () => {
     expect(src).toContain('HomescreenWidgets()');
     expect(src).toContain('LockScreenWidgets()');
     expect(src).toContain('WidgetLiveActivity()');
+  });
+});
+
+describe('generateNativeWidgetBundleSwift', () => {
+  test('lists gallery kinds and the native Live Activity type without ExpoWidgets', () => {
+    const src = generateNativeWidgetBundleSwift({
+      name: 'PoplWidgets',
+      widgets: [
+        { name: 'HomescreenWidgets' },
+        { name: 'LockScreenWidgets' },
+        { name: 'LockScreenScanWidget' },
+      ],
+      includeLiveActivity: true,
+    });
+    expect(src).toContain('@main');
+    expect(src).toContain('struct PoplWidgetsBundle: WidgetBundle');
+    expect(src).toContain('HomescreenWidgets()');
+    expect(src).toContain('LockScreenWidgets()');
+    expect(src).toContain('LockScreenScanWidget()');
+    expect(src).toContain('PoplWidgetsLiveActivity()');
+    expect(src).not.toContain('WidgetLiveActivity()');
+    expect(src).not.toContain('ExpoWidgets');
   });
 });

--- a/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/expoUiWidgetSwift.ts
@@ -264,14 +264,12 @@ struct ${options.name}: Widget {
 `;
 }
 
-export function generateExpoUiWidgetBundleSwift(options: {
+function widgetBundleBodyLines(options: {
   name: string;
-  /** Gallery Widget structs to instantiate (kind names). */
   widgets?: { name: string; configurable?: boolean }[];
-  /** When true, include expo-widgets WidgetLiveActivity() for expo-ui LA slots. */
   includeLiveActivity?: boolean;
-  /** Wrap home widget in iOS 17 availability (configurable AppIntent). */
   configurable?: boolean;
+  liveActivityExpr: string;
 }): string {
   const widgets =
     options.widgets && options.widgets.length > 0
@@ -290,8 +288,25 @@ export function generateExpoUiWidgetBundleSwift(options: {
     .join('\n');
 
   const liveLine = options.includeLiveActivity
-    ? '\n    WidgetLiveActivity()'
+    ? `\n    ${options.liveActivityExpr}`
     : '';
+
+  return `${widgetLines}${liveLine}`;
+}
+
+export function generateExpoUiWidgetBundleSwift(options: {
+  name: string;
+  /** Gallery Widget structs to instantiate (kind names). */
+  widgets?: { name: string; configurable?: boolean }[];
+  /** When true, include expo-widgets WidgetLiveActivity() for expo-ui LA slots. */
+  includeLiveActivity?: boolean;
+  /** Wrap home widget in iOS 17 availability (configurable AppIntent). */
+  configurable?: boolean;
+}): string {
+  const body = widgetBundleBodyLines({
+    ...options,
+    liveActivityExpr: 'WidgetLiveActivity()',
+  });
 
   return `import WidgetKit
 import SwiftUI
@@ -300,7 +315,31 @@ internal import ExpoWidgets
 @main
 struct ${options.name}Bundle: WidgetBundle {
   var body: some Widget {
-${widgetLines}${liveLine}
+${body}
+  }
+}
+`;
+}
+
+/** Native WidgetKit `@main` — kinds only; user deepen supplies the Widget structs. */
+export function generateNativeWidgetBundleSwift(options: {
+  name: string;
+  widgets?: { name: string; configurable?: boolean }[];
+  includeLiveActivity?: boolean;
+  configurable?: boolean;
+}): string {
+  const body = widgetBundleBodyLines({
+    ...options,
+    liveActivityExpr: `${options.name}LiveActivity()`,
+  });
+
+  return `import WidgetKit
+import SwiftUI
+
+@main
+struct ${options.name}Bundle: WidgetBundle {
+  var body: some Widget {
+${body}
   }
 }
 `;


### PR DESCRIPTION
## Summary
- Native WidgetKit targets with `ios.kinds` now get a sealed `@main` WidgetBundle in ExpoTargetsGenerated when the user did not add `*Bundle.swift`.
- Live Activity uses `<name>LiveActivity()` (not expo-ui `WidgetLiveActivity()`). User deepen bundles still win.
- Docs: `docs/widgets.md` scaffolding and `docs/configuration.md`.

## Test plan
- [x] `bun test` planner + `generateNativeWidgetBundleSwift` (50 pass)
- [ ] Operator: kinds-only native target, delete user bundle, prebuild, gallery registers
- [ ] After publish: bump Popl pin; keep `PoplWidgetsBundle.swift` if LA type stays `PoplLiveActivity()`