### PR TITLE
fix(ios): init ExpoReactNativeFactory before bundleURL()

### DIFF
--- a/packages/expo-targets/plugin/src/ios/templates/ReactNativeViewController.swift
+++ b/packages/expo-targets/plugin/src/ios/templates/ReactNativeViewController.swift
@@ -179,18 +179,22 @@ class ReactNativeViewController: UIViewController {
     private func setupReactNativeView(with sharedData: [String: Any]?) {
         // Create delegate with target-specific bundle root
         let delegate = ExtensionReactDelegate(bundleRoot: "{{BUNDLE_ROOT}}")
+        reactNativeFactoryDelegate = delegate
+        reactNativeFactoryDelegate!.dependencyProvider = RCTAppDependencyProvider()
+
+        // Factory must exist before any RCTBundleURLProvider / bundleURL() call.
+        // Those read RN feature flags; ExpoReactNativeFactory.init overrides them.
+        // Reading first aborts in ReactNativeFeatureFlagsAccessor::ensureFlagsNotAccessed.
+        reactNativeFactory = ExpoReactNativeFactory(delegate: reactNativeFactoryDelegate!)
+
         guard delegate.bundleURL() != nil else {
             showError(
                 "Could not load the JavaScript bundle. Start Metro with `npx expo start` for live reload, or rebuild with an embedded bundle (Release / no packager)."
             )
+            reactNativeFactory = nil
+            reactNativeFactoryDelegate = nil
             return
         }
-
-        reactNativeFactoryDelegate = delegate
-        reactNativeFactoryDelegate!.dependencyProvider = RCTAppDependencyProvider()
-
-        // Create factory via Expo (pulls RCTAppDelegate APIs through Expo.h)
-        reactNativeFactory = ExpoReactNativeFactory(delegate: reactNativeFactoryDelegate!)
 
         // Capture current view properties
         let currentBounds = self.view.bounds

--- a/packages/expo-targets/plugin/src/ios/utils/reactNativeSwift.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/reactNativeSwift.test.ts
@@ -58,6 +58,23 @@ describe('generateReactNativeViewController', () => {
     expect(result).toContain('Could not load the JavaScript bundle');
   });
 
+  test('creates ExpoReactNativeFactory before any bundleURL() read in setup', () => {
+    const result = generateReactNativeViewController({
+      ...baseOptions,
+      entry: './index.tsx',
+    });
+    const setupStart = result.indexOf('private func setupReactNativeView');
+    const setupEnd = result.indexOf('private func cleanupAfterClose');
+    const setup = result.slice(setupStart, setupEnd);
+    const factoryAt = setup.indexOf('ExpoReactNativeFactory(delegate:');
+    const bundleUrlAt = setup.indexOf('.bundleURL()');
+
+    expect(setupStart).toBeGreaterThan(-1);
+    expect(factoryAt).toBeGreaterThan(-1);
+    expect(bundleUrlAt).toBeGreaterThan(-1);
+    expect(factoryAt).toBeLessThan(bundleUrlAt);
+  });
+
   test('empty runtimeVersion disables App Group load (fail closed)', () => {
     const result = generateReactNativeViewController({
       ...baseOptions,


### PR DESCRIPTION
## Summary
- Create `ExpoReactNativeFactory` before any `bundleURL()` / `RCTBundleURLProvider` call so Debug RN extensions do not abort in `ReactNativeFeatureFlagsAccessor::ensureFlagsNotAccessed`.
- Lock the order in `generateReactNativeViewController` tests.

## Test plan
- [x] `bun test plugin/src/ios/utils/reactNativeSwift.test.ts` in `packages/expo-targets`
- [ ] Debug rebuild of Popl Messages on iPhone 17 Pro sim; open compose UI with no `PoplMessagesTarget` ips