### PR TITLE
fix(ios): invert unused autolinked packages off RN entry native link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,8 @@ targets/my-widget/
 | `displayName`      | `name`      | Human-readable name (`CFBundleDisplayName` or `CFBundleName` on iOS; widget picker label)                                                                          |
 | `appGroup`         | _inherited_ | App Group ID. When omitted, inherits from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
 | `entry`            | —           | React Native entry point for share, action, clip, and messages (see [Entry Field](#entry-field) below)                                                                  |
-| `excludedPackages` | auto for RN `entry` | Extra packages to omit from the nested `ExpoModulesProvider` (`post_integrate`). Crash-class packages (`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) are always merged for RN-native `entry` targets. Unused heavy host packages (Sentry, reanimated, screens, netinfo) are inferred when the entry does not import them. List only extras the infer pass misses |
+| `excludedPackages` | auto for RN `entry` | Force-strip extra packages from the nested `ExpoModulesProvider` and the extension linker. For RN `entry` targets, unused autolinked host packages are stripped by default. Crash-class packages (`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) always merge. Do not use this field as a keep-list. |
+| `linkedPackages` | `[]` | Force-keep these autolinked packages on the extension when the JS entry does not import them. |
 
 ### Entry Field
 
@@ -164,6 +165,7 @@ Add iOS-specific options under the `ios` key:
 | `colors`            | `{}`      | Named colors for Assets.xcassets                                                                                                                                                                            |
 | `images`            | `{}`      | Named images for Assets.xcassets                                                                                                                                                                            |
 | `frameworks`        | _by type_ | Additional frameworks to link                                                                                                                                                                               |
+| `nativeLink`        | `entry`   | RN `entry` targets only. `entry` strips unused autolinked packages from the provider and the `Pods-<Target>` linker. `host` keeps the old fat host copy. |
 | `entitlements`      | `{}`      | Custom entitlements                                                                                                                                                                                         |
 | `infoPlist`         | `{}`      | Custom Info.plist entries (deep merged with defaults)                                                                                                                                                       |
 | `icon`              | —         | Path to extension icon file                                                                                                                                                                                 |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ Add the plugin and App Groups to your `app.json`:
 
 Update the placeholder `appGroup` to match your `app.json`.
 
-For RN `entry` targets, the plugin **always** strips `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` from the nested `ExpoModulesProvider` (they crash appex processes). Unused heavy host packages (Sentry, reanimated) are inferred when the entry does not import them. Add `excludedPackages` only for extras the infer pass misses.
+For RN `entry` targets, the plugin strips unused autolinked host packages from the nested `ExpoModulesProvider` and from the extension linker. It always strips `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` (they crash appex processes). Keep a package with `linkedPackages` when the entry does not import it. Set `ios.nativeLink` to `"host"` only when you need the old fat host link. `excludedPackages` is force-strip only. Do not add a long deny-list in the target config.
 
 Extension JS can still OTA without linking Updates in the appex: the host runs `eas update`, then sideloads Hermes bundles into the App Group. Set a string `expo.runtimeVersion`, run `npx expo-targets export-extension-bundles` before each update, and use a **Release** build to verify the share sheet. Full flow: [Extension bundle sideload](./react-native-extensions.md#extension-bundle-sideload-with-expo-updates).
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -112,7 +112,7 @@ Or manually configure `expo-target.config.json`:
 Key fields:
 
 - `entry`: Path to your React Native entry file **(relative to project root)**
-- `excludedPackages`: Optional **additional** packages to omit from the extension's `ExpoModulesProvider` (through CocoaPods `post_integrate`). `expo-updates` and `expo-dev-client` are **auto-merged** for RN-native `entry` targets. Do not list them. Nested `use_expo_modules!(exclude:)` alone does **not** work.
+- `excludedPackages`: Optional force-strip list. Unused autolinked host packages are already stripped for RN `entry` targets. `expo-updates` and `expo-dev-client` are always merged. Nested `use_expo_modules!(exclude:)` alone does **not** work.
 
 ### 2. Create the Entry Point
 
@@ -357,51 +357,48 @@ iOS extensions have **strict memory limits**. Exceeding them causes iOS to termi
 
 ### Excluding Packages
 
-Omit host-only Expo modules from the nested extension's `ExpoModulesProvider`. Nested
-`use_expo_modules!(exclude:)` is a no-op (parent AutolinkingManager). expo-targets
-strips the listed packages from `expo-configure-project.sh` in a `post_integrate`
-hook and regenerates the provider.
+Omit unused host packages from the nested extension's `ExpoModulesProvider` and
+from the `Pods-<Target>` linker. Nested `use_expo_modules!(exclude:)` is a no-op
+(parent AutolinkingManager). expo-targets strips names from `expo-configure-project.sh`
+in a `post_integrate` hook, regenerates the provider, and drops matching `-l` /
+`-framework` / module-map flags.
 
-For RN-native targets with `entry`, **`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` are always
-union-merged** (no escape hatch). Updates asserts before the RN factory is ready and
-blanks the sheet. Unused heavy host packages (Sentry, reanimated, screens, netinfo)
-are inferred when the entry does not import them. List only **additional** packages:
+For RN-native targets with `entry`, the plugin inverts the host autolink set:
+
+`strip = autolinked − (core ∪ entry imports ∪ linkedPackages)`
+
+Core keep is React Native, Hermes, Yoga, ExpoModulesCore, and `expo-targets`.
+The same strip set is applied to `ExpoModulesProvider` and to `Pods-<Target>`
+linker flags (`-l`, `-framework`, module maps). The host can still embed those
+frameworks in the app. The plugin does not copy host `OTHER_LDFLAGS`.
+
+**Always stripped (no escape hatch):**
+
+| Package           | Reason                 |
+| ----------------- | ---------------------- |
+| `expo-updates`    | Crashes appex process  |
+| `expo-dev-client` | Host-only dev tooling  |
+| `expo-dev-launcher` | Host-only dev tooling |
+| `expo-dev-menu`   | Host-only dev tooling  |
+
+`excludedPackages` is force-strip only. Use `linkedPackages` when a native
+module must stay and the entry does not import it. Set `ios.nativeLink` to
+`"host"` only when you need the old fat host link.
 
 ```json
 {
-  "excludedPackages": [
-    "@react-native-community/netinfo",
-    "react-native-reanimated"
-  ]
+  "linkedPackages": ["expo-image"],
+  "ios": {
+    "nativeLink": "entry"
+  }
 }
 ```
 
-`npx expo-targets doctor` is quiet when unused heavies are already inferred into the exclude list.
-It still warns only if a heavy remains after that merge.
-
-**Auto-excluded (always):**
-
-| Package           | Reason                 | Savings |
-| ----------------- | ---------------------- | ------- |
-| `expo-updates`    | Crashes appex process  | ~500KB  |
-| `expo-dev-client` | Host-only dev tooling  | ~800KB  |
-| `expo-dev-launcher` | Host-only dev tooling | — |
-| `expo-dev-menu`   | Host-only dev tooling  | — |
-
-**Inferred when unused by the entry:**
-
-| Package                   | Reason                     | Savings |
-| ------------------------- | -------------------------- | ------- |
-| `react-native-reanimated` | Heavy animation library    | ~1.5MB  |
-| `@sentry/react-native`    | Error reporting not needed | ~1MB    |
-| `react-native-screens`    | Native nav not needed      | ~300KB  |
-| `@react-native-community/netinfo` | Host networking     | — |
-
-**Common extra exclusions:**
+`npx expo-targets doctor` reports the unlink count for each RN `entry` target.
 
 ### Tips for Smaller Bundles
 
-1. **Exclude aggressively** — Start minimal, add packages only when needed; run `npx expo-targets doctor`
+1. **Keep the invert default** — Import only what the entry needs. Use `linkedPackages` for native-only keep. Run `npx expo-targets doctor`
 2. **Avoid heavy UI libraries** — Use basic React Native components
 3. **Keep extension logic minimal** — Do heavy processing in your main app
 4. **Test on physical devices** — Simulators are more forgiving with memory
@@ -559,7 +556,7 @@ Causes:
   - Missing App Group configuration
 Solutions:
   - Check name consistency (see Naming Conventions above)
-  - Add more packages to excludedPackages
+  - Confirm invert unlinked unused host packages (`npx expo-targets doctor`)
   - Verify App Group IDs match everywhere
 ```
 

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
@@ -3,10 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadProject } from '../project';
-import {
-  nativeUnlinkSummaries,
-  warnHeavyExclusions,
-} from './heavyExclusions';
+import { nativeUnlinkSummaries, warnHeavyExclusions } from './heavyExclusions';
 
 const roots: string[] = [];
 

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.test.ts
@@ -3,7 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadProject } from '../project';
-import { warnHeavyExclusions } from './heavyExclusions';
+import {
+  nativeUnlinkSummaries,
+  warnHeavyExclusions,
+} from './heavyExclusions';
 
 const roots: string[] = [];
 
@@ -24,7 +27,7 @@ afterEach(() => {
   }
 });
 
-test('warnHeavyExclusions quiet when unused heavy is auto-inferred', () => {
+test('warnHeavyExclusions is quiet after invert default', () => {
   const root = makeProject({
     'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
     'package.json': JSON.stringify({
@@ -42,39 +45,20 @@ test('warnHeavyExclusions quiet when unused heavy is auto-inferred', () => {
   expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
 });
 
-test('warnHeavyExclusions quiet when entry imports the package', () => {
+test('nativeUnlinkSummaries reports unlink count for RN entry targets', () => {
   const root = makeProject({
     'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
-    'package.json': JSON.stringify({
-      dependencies: { 'react-native-reanimated': '3.0.0' },
-    }),
+    'package.json': JSON.stringify({ dependencies: {} }),
     'targets/share/expo-target.config.json': JSON.stringify({
       type: 'share',
       name: 'Share',
       platforms: ['ios'],
       entry: './targets/share/index.tsx',
-    }),
-    'targets/share/index.tsx':
-      "import Animated from 'react-native-reanimated';\nexport default function App() { return null; }\n",
-  });
-  expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
-});
-
-test('warnHeavyExclusions quiet when already in excludedPackages', () => {
-  const root = makeProject({
-    'app.json': JSON.stringify({ expo: { plugins: ['expo-targets'] } }),
-    'package.json': JSON.stringify({
-      dependencies: { 'react-native-reanimated': '3.0.0' },
-    }),
-    'targets/share/expo-target.config.json': JSON.stringify({
-      type: 'share',
-      name: 'Share',
-      platforms: ['ios'],
-      entry: './targets/share/index.tsx',
-      excludedPackages: ['react-native-reanimated'],
     }),
     'targets/share/index.tsx':
       "import { View } from 'react-native';\nexport default function App() { return null; }\n",
   });
-  expect(warnHeavyExclusions(loadProject(root))).toEqual([]);
+  expect(nativeUnlinkSummaries(loadProject(root))).toEqual([
+    'Native unlink (Share): 4 packages',
+  ]);
 });

--- a/packages/expo-targets/cli/src/checks/heavyExclusions.ts
+++ b/packages/expo-targets/cli/src/checks/heavyExclusions.ts
@@ -1,12 +1,5 @@
-import {
-  collectImportsFromEntry,
-  HEAVY_EXCLUSION_CANDIDATES,
-  readPackageDeps,
-} from '../../../plugin/build/entryGraph';
-import { resolveExcludedPackages } from '../../../plugin/build/resolveExcludedPackages';
+import { resolveNativeUnlink } from '../../../plugin/build/resolveExcludedPackages';
 import type { CheckResult, ProjectContext } from '../types';
-
-export { HEAVY_EXCLUSION_CANDIDATES };
 
 const RN_NATIVE_TYPES = new Set([
   'share',
@@ -16,66 +9,36 @@ const RN_NATIVE_TYPES = new Set([
   'notification-content',
 ]);
 
-function findUnusedHeavyCandidates(opts: {
-  deps: Set<string>;
-  imported: Set<string>;
-  resolved: Set<string>;
-}): string[] {
-  const unused: string[] = [];
-  for (const candidate of HEAVY_EXCLUSION_CANDIDATES) {
-    if (!opts.deps.has(candidate)) continue;
-    if (opts.imported.has(candidate)) continue;
-    if (opts.resolved.has(candidate)) continue;
-    unused.push(candidate);
-  }
-  return unused;
-}
+export function nativeUnlinkSummaries(ctx: ProjectContext): string[] {
+  const lines: string[] = [];
 
-function warnTargetHeavyExclusions(
-  ctx: ProjectContext,
-  target: ProjectContext['targets'][number],
-  deps: Set<string>
-): CheckResult | null {
-  const { type, entry, name, excludedPackages } = target.config;
-  if (!(entry && type && RN_NATIVE_TYPES.has(type))) {
-    return null;
-  }
-
-  const resolved = new Set(
-    resolveExcludedPackages({
+  for (const target of ctx.targets) {
+    const { type, entry, name, excludedPackages, linkedPackages, ios } =
+      target.config;
+    if (!(entry && type && RN_NATIVE_TYPES.has(type))) {
+      continue;
+    }
+    const resolved = resolveNativeUnlink({
       type,
       entry,
       excludedPackages,
+      linkedPackages,
+      nativeLink: ios?.nativeLink,
       projectRoot: ctx.projectRoot,
-    }) ?? []
-  );
-  const imported = collectImportsFromEntry(ctx.projectRoot, entry);
-  const targetLabel = name ?? target.dirName;
-  const unused = findUnusedHeavyCandidates({ deps, imported, resolved });
-
-  if (unused.length === 0) {
-    return null;
+    });
+    if (!resolved) {
+      continue;
+    }
+    const targetLabel = name ?? target.dirName;
+    lines.push(
+      `Native unlink (${targetLabel}): ${resolved.packages.length} packages`
+    );
   }
 
-  return {
-    ok: false,
-    level: 'warn',
-    title: 'Heavy exclusions',
-    message: `Target "${targetLabel}": host depends on ${unused.join(', ')} but ${unused.length === 1 ? 'it is' : 'they are'} not imported from ${entry}`,
-    fix: `Add ${unused.map((p) => `"${p}"`).join(', ')} to excludedPackages to shrink the nested ExpoModulesProvider`,
-  };
+  return lines;
 }
 
-export function warnHeavyExclusions(ctx: ProjectContext): CheckResult[] {
-  const deps = readPackageDeps(ctx.projectRoot);
-  const warnings: CheckResult[] = [];
-
-  for (const target of ctx.targets) {
-    const warning = warnTargetHeavyExclusions(ctx, target, deps);
-    if (warning) {
-      warnings.push(warning);
-    }
-  }
-
-  return warnings;
+/** Invert is default. Unused-host warnings are no longer emitted. */
+export function warnHeavyExclusions(_ctx: ProjectContext): CheckResult[] {
+  return [];
 }

--- a/packages/expo-targets/cli/src/doctor.ts
+++ b/packages/expo-targets/cli/src/doctor.ts
@@ -8,7 +8,10 @@ import {
 } from './checks/easCredentials';
 import { checkEntries } from './checks/entries';
 import { checkGeneratedTypes } from './checks/generatedTypes';
-import { warnHeavyExclusions } from './checks/heavyExclusions';
+import {
+  nativeUnlinkSummaries,
+  warnHeavyExclusions,
+} from './checks/heavyExclusions';
 import { checkLiveActivitiesConfig } from './checks/liveActivitiesConfig';
 import { checkLiveActivityHostApi } from './checks/liveActivityHostApi';
 import { checkLiveActivityKind } from './checks/liveActivityKind';
@@ -78,6 +81,7 @@ function passedChecks(ctx: ReturnType<typeof loadProject>): string[] {
   if (checkNameSync(ctx).length === 0) {
     passed.push('Name sync');
   }
+  passed.push(...nativeUnlinkSummaries(ctx));
   return passed;
 }
 

--- a/packages/expo-targets/cli/src/types.ts
+++ b/packages/expo-targets/cli/src/types.ts
@@ -17,12 +17,14 @@ export interface TargetConfig {
   ui?: 'native' | 'expo-ui' | 'react-native';
   appGroup?: string;
   excludedPackages?: string[];
+  linkedPackages?: string[];
   ios?: {
     kinds?: { type?: string; name?: string }[];
     liveActivity?: { attributesName?: string };
     liveActivities?: Array<{ attributesName?: string }>;
     intents?: { ui?: boolean | { name?: string } };
     wallet?: { ui?: boolean | { name?: string } };
+    nativeLink?: 'entry' | 'host';
   };
 }
 

--- a/packages/expo-targets/plugin/src/autolinkedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/autolinkedPackages.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  mergeAutolinkedPackages,
+  parseExpoAutolinkingResolve,
+  parseReactNativeConfig,
+} from './autolinkedPackages';
+
+describe('parseExpoAutolinkingResolve', () => {
+  test('maps packageName to pods and swift modules', () => {
+    expect(
+      parseExpoAutolinkingResolve({
+        modules: [
+          {
+            packageName: '@sentry/react-native',
+            pods: [{ podName: 'RNSentry' }],
+            swiftModuleNames: ['RNSentry'],
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        packageName: '@sentry/react-native',
+        linkerTokens: ['@sentry/react-native', 'RNSentry'],
+      },
+    ]);
+  });
+});
+
+describe('parseReactNativeConfig', () => {
+  test('maps RN community deps from podspec basename', () => {
+    expect(
+      parseReactNativeConfig({
+        dependencies: {
+          '@intercom/intercom-react-native': {
+            platforms: {
+              ios: {
+                podspecPath:
+                  '/app/node_modules/@intercom/intercom-react-native/intercom-react-native.podspec',
+              },
+            },
+          },
+          '@logrocket/react-native': {
+            platforms: {
+              ios: {
+                podspecPath:
+                  '/app/node_modules/@logrocket/react-native/LogRocket.podspec',
+              },
+            },
+          },
+          'left-pad': {
+            platforms: { android: {} },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        packageName: '@intercom/intercom-react-native',
+        linkerTokens: [
+          '@intercom/intercom-react-native',
+          'intercom-react-native',
+        ],
+      },
+      {
+        packageName: '@logrocket/react-native',
+        linkerTokens: ['@logrocket/react-native', 'LogRocket'],
+      },
+    ]);
+  });
+});
+
+describe('mergeAutolinkedPackages', () => {
+  test('unions tokens for the same package', () => {
+    expect(
+      mergeAutolinkedPackages([
+        [{ packageName: 'expo-image', linkerTokens: ['expo-image'] }],
+        [
+          {
+            packageName: 'expo-image',
+            linkerTokens: ['ExpoImage'],
+          },
+        ],
+      ])
+    ).toEqual([
+      {
+        packageName: 'expo-image',
+        linkerTokens: ['expo-image', 'ExpoImage'],
+      },
+    ]);
+  });
+});

--- a/packages/expo-targets/plugin/src/autolinkedPackages.ts
+++ b/packages/expo-targets/plugin/src/autolinkedPackages.ts
@@ -1,0 +1,257 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+export type AutolinkedNativePackage = {
+  packageName: string;
+  linkerTokens: string[];
+};
+
+/** Must never appear as a strip token (scoped packages often end in `react-native`). */
+const CORE_LINKER_BLOCKLIST = new Set([
+  'react',
+  'react-native',
+  'React',
+  'React-Core',
+  'hermes',
+  'hermes-engine',
+  'yoga',
+  'Yoga',
+  'ExpoModulesCore',
+  'expo-modules-core',
+  'expo-targets',
+  'expo',
+]);
+
+function lastSegment(packageName: string): string {
+  if (packageName.startsWith('@')) {
+    const parts = packageName.split('/');
+    return parts[1] ?? packageName;
+  }
+  return packageName.split('/')[0] ?? packageName;
+}
+
+export function linkerTokensForPackageName(packageName: string): string[] {
+  const last = lastSegment(packageName);
+  if (last === packageName || CORE_LINKER_BLOCKLIST.has(last)) {
+    return [packageName];
+  }
+  return [packageName, last];
+}
+
+function addTokens(into: Set<string>, tokens: readonly string[]): void {
+  for (const token of tokens) {
+    if (token) {
+      into.add(token);
+    }
+  }
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function collectNamedStrings(items: unknown, key: string): string[] {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const item of items) {
+    if (typeof item === 'string') {
+      names.push(item);
+      continue;
+    }
+    if (item && typeof item === 'object') {
+      const name = stringField((item as Record<string, unknown>)[key]);
+      if (name) {
+        names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
+function expoModuleToPackage(
+  mod: unknown
+): AutolinkedNativePackage | undefined {
+  if (!mod || typeof mod !== 'object') {
+    return;
+  }
+  const packageName = stringField(
+    (mod as { packageName?: unknown }).packageName
+  );
+  if (!packageName) {
+    return;
+  }
+  const tokens = new Set(linkerTokensForPackageName(packageName));
+  addTokens(
+    tokens,
+    collectNamedStrings((mod as { pods?: unknown }).pods, 'podName')
+  );
+  addTokens(
+    tokens,
+    collectNamedStrings(
+      (mod as { swiftModuleNames?: unknown }).swiftModuleNames,
+      ''
+    )
+  );
+  return { packageName, linkerTokens: [...tokens] };
+}
+
+export function parseExpoAutolinkingResolve(
+  data: unknown
+): AutolinkedNativePackage[] {
+  if (!data || typeof data !== 'object' || !('modules' in data)) {
+    return [];
+  }
+  const modules = (data as { modules: unknown }).modules;
+  if (!Array.isArray(modules)) {
+    return [];
+  }
+  return modules.flatMap((mod) => {
+    const parsed = expoModuleToPackage(mod);
+    return parsed ? [parsed] : [];
+  });
+}
+
+function podspecToken(podspecPath: string): string | undefined {
+  const base = path.basename(podspecPath);
+  if (!base.endsWith('.podspec')) {
+    return;
+  }
+  return base.slice(0, -'.podspec'.length);
+}
+
+function rnDepToPackage(
+  packageName: string,
+  value: unknown
+): AutolinkedNativePackage | undefined {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+  const ios = (value as { platforms?: { ios?: unknown } }).platforms?.ios;
+  if (!ios) {
+    return;
+  }
+  const tokens = new Set(linkerTokensForPackageName(packageName));
+  if (typeof ios === 'object') {
+    const token = podspecToken(
+      stringField((ios as { podspecPath?: unknown }).podspecPath) ?? ''
+    );
+    if (token) {
+      tokens.add(token);
+    }
+  }
+  return { packageName, linkerTokens: [...tokens] };
+}
+
+export function parseReactNativeConfig(
+  data: unknown
+): AutolinkedNativePackage[] {
+  if (!data || typeof data !== 'object' || !('dependencies' in data)) {
+    return [];
+  }
+  const deps = (data as { dependencies: unknown }).dependencies;
+  if (!deps || typeof deps !== 'object') {
+    return [];
+  }
+  return Object.entries(deps as Record<string, unknown>).flatMap(
+    ([packageName, value]) => {
+      const parsed = rnDepToPackage(packageName, value);
+      return parsed ? [parsed] : [];
+    }
+  );
+}
+
+export function mergeAutolinkedPackages(
+  lists: AutolinkedNativePackage[][]
+): AutolinkedNativePackage[] {
+  const map = new Map<string, Set<string>>();
+  for (const list of lists) {
+    for (const pkg of list) {
+      const tokens = map.get(pkg.packageName) ?? new Set<string>();
+      addTokens(tokens, pkg.linkerTokens);
+      map.set(pkg.packageName, tokens);
+    }
+  }
+  return [...map.entries()].map(([packageName, tokens]) => ({
+    packageName,
+    linkerTokens: [...tokens],
+  }));
+}
+
+export function normalizeAutolinkedPackages(
+  packages: readonly (string | AutolinkedNativePackage)[]
+): AutolinkedNativePackage[] {
+  return mergeAutolinkedPackages([
+    packages.map((pkg) =>
+      typeof pkg === 'string'
+        ? { packageName: pkg, linkerTokens: linkerTokensForPackageName(pkg) }
+        : pkg
+    ),
+  ]);
+}
+
+function runAutolinkingJson(
+  projectRoot: string,
+  args: string[]
+): unknown | null {
+  try {
+    const cli = require.resolve(
+      'expo-modules-autolinking/bin/expo-modules-autolinking.js',
+      { paths: [projectRoot] }
+    );
+    const result = spawnSync(process.execPath, [cli, ...args], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    if (result.status !== 0 || !result.stdout) {
+      return null;
+    }
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+/** Expo modules + RN community packages the host autolinks for iOS. */
+export function listAutolinkedNativePackages(
+  projectRoot: string
+): AutolinkedNativePackage[] {
+  const expo = parseExpoAutolinkingResolve(
+    runAutolinkingJson(projectRoot, [
+      'resolve',
+      '--json',
+      '--platform',
+      'apple',
+    ])
+  );
+  const rn = parseReactNativeConfig(
+    runAutolinkingJson(projectRoot, [
+      'react-native-config',
+      '--json',
+      '--platform',
+      'ios',
+    ])
+  );
+  return mergeAutolinkedPackages([expo, rn]);
+}
+
+export function linkerTokensForPackages(
+  packageNames: readonly string[],
+  autolinked: readonly AutolinkedNativePackage[]
+): string[] {
+  const byName = new Map(
+    autolinked.map((pkg) => [pkg.packageName, pkg.linkerTokens])
+  );
+  const tokens = new Set<string>();
+  for (const name of packageNames) {
+    for (const token of byName.get(name) ?? linkerTokensForPackageName(name)) {
+      if (!CORE_LINKER_BLOCKLIST.has(token)) {
+        tokens.add(token);
+      }
+    }
+  }
+  return [...tokens];
+}

--- a/packages/expo-targets/plugin/src/config.ts
+++ b/packages/expo-targets/plugin/src/config.ts
@@ -215,6 +215,8 @@ export const TYPE_BUNDLE_IDENTIFIER_SUFFIXES: Record<ExtensionType, string> = {
 };
 
 // Base configuration shared by all iOS targets
+export type NativeLinkMode = 'entry' | 'host';
+
 interface BaseIosTargetConfig {
   icon?: string;
   deploymentTarget?: string;
@@ -234,6 +236,12 @@ interface BaseIosTargetConfig {
    */
   targetIcon?: string;
   frameworks?: string[];
+  /**
+   * How the nested RN target links native host packages.
+   * `entry` (default): invert unused autolinked packages off provider + linker.
+   * `host`: copy the host fat link (old behavior).
+   */
+  nativeLink?: NativeLinkMode;
   entitlements?: Record<string, any>;
   infoPlist?: Record<string, any>;
 
@@ -598,13 +606,18 @@ interface BaseTargetConfig {
    */
   entry?: string;
   /**
-   * Extra Expo packages to omit from the nested extension's ExpoModulesProvider
-   * (via CocoaPods `post_integrate`). For RN-native / Host targets with `entry`,
-   * `expo-updates` and `expo-dev-client` are **always** union-merged — no escape
-   * hatch. Use this field only for additional packages (e.g. reanimated, Sentry).
-   * @example ['react-native-reanimated', '@sentry/react-native']
+   * Extra packages to omit from the nested extension's ExpoModulesProvider
+   * and linker. For RN-native `entry` targets, unused autolinked host packages
+   * are inverted out by default. Crash-class packages (`expo-updates`,
+   * `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) always merge.
+   * This list is force-strip only.
    */
   excludedPackages?: string[];
+  /**
+   * Force-keep these autolinked packages on the extension even when the JS
+   * entry does not import them.
+   */
+  linkedPackages?: string[];
 }
 
 // Target config for React Native compatible types

--- a/packages/expo-targets/plugin/src/domain/types.ts
+++ b/packages/expo-targets/plugin/src/domain/types.ts
@@ -13,6 +13,7 @@ export type {
   IOSTargetConfig,
   IOSTargetConfigNativeOnly,
   IOSTargetConfigWithReactNative,
+  NativeLinkMode,
   NativeOnlyType,
   ReactNativeCompatibleType,
   ShareExtensionActivationRule,

--- a/packages/expo-targets/plugin/src/entryGraph.test.ts
+++ b/packages/expo-targets/plugin/src/entryGraph.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CORE_KEEP_PACKAGES, unusedAutolinkedPackages } from './entryGraph';
+
+function makeEntry(source: string): { root: string; entry: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-graph-'));
+  fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+  const entry = './targets/messages/index.tsx';
+  fs.writeFileSync(path.join(root, 'targets', 'messages', 'index.tsx'), source);
+  return { root, entry };
+}
+
+describe('unusedAutolinkedPackages invert', () => {
+  test('strips unused autolinked hosts and keeps core + entry imports', () => {
+    const { root, entry } = makeEntry(
+      "import { Image } from 'expo-image';\nimport { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    expect(
+      unusedAutolinkedPackages({
+        projectRoot: root,
+        entry,
+        autolinked: [
+          'expo-image',
+          'expo-modules-core',
+          '@intercom/intercom-react-native',
+          '@logrocket/react-native',
+          '@sentry/react-native',
+        ],
+      })
+    ).toEqual([
+      '@intercom/intercom-react-native',
+      '@logrocket/react-native',
+      '@sentry/react-native',
+    ]);
+    expect(CORE_KEEP_PACKAGES).toContain('expo-modules-core');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('linkedPackages stay even when the entry does not import them', () => {
+    const { root, entry } = makeEntry(
+      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    expect(
+      unusedAutolinkedPackages({
+        projectRoot: root,
+        entry,
+        autolinked: [
+          '@intercom/intercom-react-native',
+          '@logrocket/react-native',
+        ],
+        linkedPackages: ['@intercom/intercom-react-native'],
+      })
+    ).toEqual(['@logrocket/react-native']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/expo-targets/plugin/src/entryGraph.ts
+++ b/packages/expo-targets/plugin/src/entryGraph.ts
@@ -1,12 +1,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-/** Heavy / host-leaning packages to auto-exclude when unused by the entry. */
-export const HEAVY_EXCLUSION_CANDIDATES = [
-  'react-native-reanimated',
-  '@sentry/react-native',
-  'react-native-screens',
-  '@react-native-community/netinfo',
+/** Always keep these npm names even when the entry does not import them. */
+export const CORE_KEEP_PACKAGES = [
+  'react',
+  'react-native',
+  'expo',
+  'expo-modules-core',
+  'expo-targets',
 ] as const;
 
 const IMPORT_RE = /(?:from\s+|require\s*\(\s*)['"](@?[^'"]+)['"]/g;
@@ -113,17 +114,24 @@ export function collectImportsFromEntry(
   return seen;
 }
 
-export function unusedHeavyPackages(opts: {
+/**
+ * Invert: autolinked − (core ∪ usedByEntry ∪ linkedPackages).
+ * Empty `autolinked` means "could not resolve" — strip nothing from invert.
+ */
+export function unusedAutolinkedPackages(opts: {
   projectRoot: string;
   entry: string;
+  autolinked: readonly string[];
+  linkedPackages?: readonly string[];
 }): string[] {
-  const deps = readPackageDeps(opts.projectRoot);
-  const imported = collectImportsFromEntry(opts.projectRoot, opts.entry);
-  const unused: string[] = [];
-  for (const candidate of HEAVY_EXCLUSION_CANDIDATES) {
-    if (!deps.has(candidate)) continue;
-    if (imported.has(candidate)) continue;
-    unused.push(candidate);
+  if (opts.autolinked.length === 0) {
+    return [];
   }
-  return unused;
+  const imported = collectImportsFromEntry(opts.projectRoot, opts.entry);
+  const keep = new Set<string>([
+    ...CORE_KEEP_PACKAGES,
+    ...imported,
+    ...(opts.linkedPackages ?? []),
+  ]);
+  return [...new Set(opts.autolinked.filter((pkg) => !keep.has(pkg)))];
 }

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
@@ -48,6 +48,7 @@ function targetBlockFor(
       extensionType: plan.extensionType,
       podsRbContent: plan.podsRbContent,
       excludedPackages: plan.excludedPackages,
+      linkerTokens: plan.linkerTokens,
     });
   }
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
@@ -91,6 +91,19 @@ describe('generateReactNativeTargetBlock', () => {
       '# [expo-targets-excluded-packages-list] expo-updates,expo-dev-client'
     );
   });
+
+  test('records linker tokens for the same strip set', () => {
+    const block = generateReactNativeTargetBlock({
+      targetName: 'ExampleMessagesTarget',
+      deploymentTarget: '16.4',
+      extensionType: 'messages',
+      excludedPackages: ['@intercom/intercom-react-native'],
+      linkerTokens: ['Intercom', 'intercom-react-native'],
+    });
+    expect(block).toContain(
+      '# [expo-targets-excluded-linker-list] Intercom,intercom-react-native'
+    );
+  });
 });
 
 describe('ensureExcludedPackagesPostIntegrate', () => {
@@ -105,11 +118,13 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
     expect(once).toContain('# [expo-targets-excluded-packages-done]');
     expect(once).toContain('post_integrate do |installer|');
     expect(once).toContain(
-      "'ExampleMessagesTarget' => ['expo-updates', 'expo-dev-client']"
+      "'ExampleMessagesTarget' => { :packages => ['expo-updates', 'expo-dev-client'], :linker => [] }"
     );
     expect(once).toContain('expo-configure-project.sh');
     expect(once).toContain('Pods-#{target_name}');
     expect(once).toContain('ExpoTargetsExtensionBundleModule');
+    expect(once).toContain('OTHER_LDFLAGS');
+    expect(once).toContain('-framework');
 
     const twice = ensureExcludedPackagesPostIntegrate(once, [
       {
@@ -120,6 +135,18 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
     expect(twice.split('# [expo-targets-excluded-packages-begin]').length).toBe(
       2
     );
+  });
+
+  test('records linker tokens in the post_integrate spec', () => {
+    const once = ensureExcludedPackagesPostIntegrate(plainPodfile, [
+      {
+        targetName: 'ExampleMessagesTarget',
+        packages: ['@intercom/intercom-react-native'],
+        linkerTokens: ['Intercom'],
+      },
+    ]);
+    expect(once).toContain(":linker => ['Intercom']");
+    expect(once).toContain('Dir.glob');
   });
 
   test('removes the hook when exclusions are empty', () => {
@@ -252,6 +279,7 @@ describe('ensureReactNativeExtensionFrameworkPaths', () => {
     expect(result).toContain(
       String.raw`.gsub(/\s*"\$\{PODS_CONFIGURATION_BUILD_DIR\}\/EXUpdates"/, '')`
     );
+    expect(result).not.toMatch(/OTHER_LDFLAGS = #\{/);
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -161,6 +161,7 @@ function indentCustomPods(podsRbContent?: string): string {
  */
 export const EXCLUDED_PACKAGES_MARKER =
   '# [expo-targets-excluded-packages-list]';
+export const EXCLUDED_LINKER_MARKER = '# [expo-targets-excluded-linker-list]';
 const EXCLUDED_PACKAGES_POST_INTEGRATE_START =
   '# [expo-targets-excluded-packages-begin]';
 const EXCLUDED_PACKAGES_POST_INTEGRATE_END =
@@ -171,9 +172,10 @@ const EXCLUDED_PACKAGES_POST_INTEGRATE_END =
  * Extension targets only inherit search paths, with no explicit pod dependencies.
  * This avoids linking incompatible modules like Expo that contain UIApplication APIs.
  *
- * `excludedPackages` is recorded as a comment marker so a `post_integrate` hook can
- * strip those names from `expo-configure-project.sh` and regenerate the provider.
- * Nested `use_expo_modules!(exclude:)` is a no-op (parent AutolinkingManager).
+ * `excludedPackages` and `linkerTokens` are recorded as comment markers so a
+ * `post_integrate` hook can strip those names from `expo-configure-project.sh`,
+ * regenerate the provider, and drop unused `-l` / `-framework` / module maps
+ * on `Pods-<target>`. Nested `use_expo_modules!(exclude:)` is a no-op.
  *
  * @param podsRbContent - Optional content from a pods.rb file in the target directory.
  *                        Allows custom CocoaPods configuration (e.g., Firebase, third-party SDKs).
@@ -184,20 +186,27 @@ export function generateReactNativeTargetBlock({
   extensionType: _extensionType,
   podsRbContent,
   excludedPackages,
+  linkerTokens,
 }: {
   targetName: string;
   deploymentTarget: string;
   extensionType: string;
   podsRbContent?: string;
   excludedPackages?: string[];
+  linkerTokens?: string[];
 }): string {
   const customPods = indentCustomPods(podsRbContent);
   const packages = (excludedPackages ?? [])
     .map((p) => p.trim())
     .filter(Boolean);
+  const tokens = (linkerTokens ?? []).map((p) => p.trim()).filter(Boolean);
   const excludeLine =
     packages.length > 0
       ? `\n    ${EXCLUDED_PACKAGES_MARKER} ${packages.join(',')}`
+      : '';
+  const linkerLine =
+    tokens.length > 0
+      ? `\n    ${EXCLUDED_LINKER_MARKER} ${tokens.join(',')}`
       : '';
 
   // App Clips still use search_paths here; framework embedding for the clip
@@ -206,7 +215,7 @@ export function generateReactNativeTargetBlock({
   return `
   target '${targetName}' do
     platform :ios, '${deploymentTarget}'
-    inherit! :search_paths${excludeLine}${customPods}
+    inherit! :search_paths${excludeLine}${linkerLine}${customPods}
   end
 `;
 }
@@ -825,42 +834,59 @@ function rubySingleQuoted(value: string): string {
 /** Ruby body lines for the excludedPackages post_integrate hook (minus hash). */
 const EXCLUDED_PACKAGES_RUBY_PREFIX = [
   EXCLUDED_PACKAGES_POST_INTEGRATE_START,
-  '# Strip host-only Expo packages from nested RN extension ExpoModulesProviders.',
+  '# Strip unused host packages from nested RN ExpoModulesProviders and linker flags.',
   '# Nested use_expo_modules!(exclude:) is a no-op (parent AutolinkingManager);',
   '# Expo regenerates the provider during integrate_user_targets after post_install.',
+  '# Do not copy host OTHER_LDFLAGS onto the appex — inherit! :search_paths already',
+  '# did; subtract unused -l / -framework / module maps from Pods-<target> xcconfigs.',
   'post_integrate do |installer|',
   '  exclusions = {',
 ] as const;
 
 const EXCLUDED_PACKAGES_RUBY_SUFFIX = [
   '  }',
-  '  exclusions.each do |target_name, packages|',
-  '    next if packages.nil? || packages.empty?',
+  '  exclusions.each do |target_name, spec|',
+  '    packages = spec[:packages] || []',
+  '    tokens = spec[:linker] || []',
+  '    next if packages.empty? && tokens.empty?',
   '    support_dir = File.join(installer.sandbox.root, \'Target Support Files\', "Pods-#{target_name}")',
   "    script_path = File.join(support_dir, 'expo-configure-project.sh')",
   "    provider_path = File.join(support_dir, 'ExpoModulesProvider.swift')",
-  '    unless File.exist?(script_path)',
+  '    if File.exist?(script_path) && !packages.empty?',
+  '      content = File.read(script_path)',
+  '      packages.each do |pkg|',
+  '        content.gsub!(/\\s*"#{Regexp.escape(pkg)}"/, \'\')',
+  '      end',
+  '      File.write(script_path, content)',
+  "      ok = system({ 'PODS_ROOT' => installer.sandbox.root.to_s }, 'bash', script_path)",
+  '      unless ok',
+  '        raise "[expo-targets] Failed to regenerate ExpoModulesProvider for #{target_name} after excludedPackages strip"',
+  '      end',
+  '      unless File.exist?(provider_path)',
+  '        raise "[expo-targets] ExpoModulesProvider missing after regenerate for #{target_name}"',
+  '      end',
+  '      # Host-only: ExtensionBundle install API must not register inside RN appexes',
+  '      # (auto-enable used to treat its presence as "running on host").',
+  '      provider = File.read(provider_path)',
+  "      provider.gsub!(/^\\s*\\(module: ExpoTargetsExtensionBundleModule\\.self.*?\\),?\\n/, '')",
+  '      File.write(provider_path, provider)',
+  '      Pod::UI.puts "[expo-targets] Applied excludedPackages to #{target_name}: #{packages.join(\', \')}"',
+  '    elsif !packages.empty?',
   '      Pod::UI.warn "[expo-targets] Missing #{script_path}; skip excludedPackages for #{target_name}"',
-  '      next',
   '    end',
-  '    content = File.read(script_path)',
-  '    packages.each do |pkg|',
-  '      content.gsub!(/\\s*"#{Regexp.escape(pkg)}"/, \'\')',
+  '    unless tokens.empty?',
+  "      Dir.glob(File.join(support_dir, '*.xcconfig')).each do |xcconfig_path|",
+  '        xc = File.read(xcconfig_path)',
+  '        tokens.each do |token|',
+  '          xc.gsub!(/\\s*-l"?#{Regexp.escape(token)}"?/, \'\')',
+  '          xc.gsub!(/\\s*-framework\\s+"?#{Regexp.escape(token)}"?/, \'\')',
+  '          xc.gsub!(/\\s*-Xcc\\s+-fmodule-map-file="[^"]*#{Regexp.escape(token)}[^"]*"/, \'\')',
+  '          xc.gsub!(/\\s*-fmodule-map-file="[^"]*#{Regexp.escape(token)}[^"]*"/, \'\')',
+  '        end',
+  '        File.write(xcconfig_path, xc)',
+  '      end',
+  '      Pod::UI.puts "[expo-targets] Stripped #{tokens.length} linker tokens from Pods-#{target_name}"',
   '    end',
-  '    File.write(script_path, content)',
-  "    ok = system({ 'PODS_ROOT' => installer.sandbox.root.to_s }, 'bash', script_path)",
-  '    unless ok',
-  '      raise "[expo-targets] Failed to regenerate ExpoModulesProvider for #{target_name} after excludedPackages strip"',
-  '    end',
-  '    unless File.exist?(provider_path)',
-  '      raise "[expo-targets] ExpoModulesProvider missing after regenerate for #{target_name}"',
-  '    end',
-  '    # Host-only: ExtensionBundle install API must not register inside RN appexes',
-  '    # (auto-enable used to treat its presence as "running on host").',
-  '    provider = File.read(provider_path)',
-  "    provider.gsub!(/^\\s*\\(module: ExpoTargetsExtensionBundleModule\\.self.*?\\),?\\n/, '')",
-  '    File.write(provider_path, provider)',
-  '    Pod::UI.puts "[expo-targets] Applied excludedPackages to #{target_name}: #{packages.join(\', \')}"',
   '  end',
   'end',
   EXCLUDED_PACKAGES_POST_INTEGRATE_END,
@@ -868,12 +894,17 @@ const EXCLUDED_PACKAGES_RUBY_SUFFIX = [
 ] as const;
 
 function buildExcludedPackagesPostIntegrate(
-  exclusions: { targetName: string; packages: string[] }[]
+  exclusions: {
+    targetName: string;
+    packages: string[];
+    linkerTokens?: string[];
+  }[]
 ): string {
   const hashEntries = exclusions
-    .map(({ targetName, packages }) => {
+    .map(({ targetName, packages, linkerTokens }) => {
       const pkgs = packages.map(rubySingleQuoted).join(', ');
-      return `    ${rubySingleQuoted(targetName)} => [${pkgs}]`;
+      const tokens = (linkerTokens ?? []).map(rubySingleQuoted).join(', ');
+      return `    ${rubySingleQuoted(targetName)} => { :packages => [${pkgs}], :linker => [${tokens}] }`;
     })
     .join(',\n');
 
@@ -891,7 +922,11 @@ function buildExcludedPackagesPostIntegrate(
  */
 export function ensureExcludedPackagesPostIntegrate(
   podfileContent: string,
-  exclusions: { targetName: string; packages: string[] }[]
+  exclusions: {
+    targetName: string;
+    packages: string[];
+    linkerTokens?: string[];
+  }[]
 ): string {
   const without = removeMarkedBlock(
     podfileContent,

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/scan.ts
@@ -14,6 +14,7 @@ export interface PodfileTargetRef {
 export interface ExcludedPackagesTargetRef {
   targetName: string;
   packages: string[];
+  linkerTokens: string[];
 }
 
 const NESTED_TARGET_START = /^\s+target\s+'([^']+)'\s+do/;
@@ -23,6 +24,7 @@ const STANDALONE_TARGET =
 /** Keep in sync with EXCLUDED_PACKAGES_MARKER in podfile.ts */
 const EXCLUDED_PACKAGES_LINE =
   /# \[expo-targets-excluded-packages-list\]\s*(.+)/;
+const EXCLUDED_LINKER_LINE = /# \[expo-targets-excluded-linker-list\]\s*(.+)/;
 
 /**
  * The main target's block, up to the `post_install` hook when there is one.
@@ -126,9 +128,14 @@ export function findExcludedPackagesTargets(
         .split(',')
         .map((p) => p.trim())
         .filter(Boolean);
-      return { targetName: name, packages };
+      const linkerMatch = block.match(EXCLUDED_LINKER_LINE);
+      const linkerTokens = (linkerMatch?.[1] ?? '')
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean);
+      return { targetName: name, packages, linkerTokens };
     })
-    .filter((t) => t.packages.length > 0);
+    .filter((t) => t.packages.length > 0 || t.linkerTokens.length > 0);
 }
 
 /**

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
@@ -267,14 +267,7 @@ const withTargetPods: ConfigPlugin<{
   }
 
   const isWebBasedEntry = Boolean(props.entry) && isReactNativeWeb(props.type);
-  const uiMode = resolveUiMode({
-    type: props.type,
-    entry: props.entry,
-    ui: props.ui,
-  });
-  // watch-widget returns earlier (no Podfile). Remaining expo-ui widget targets
-  // stay sibling/standalone (not nested RN share-class).
-  const isExpoUiWidget = uiMode === 'expo-ui' && props.type === 'widget';
+  const isExpoUiWidget = isExpoUiWidgetTarget(props);
 
   return withTargetPodfile(config, {
     targetName: targetProductName, // Use sanitized name to match Xcode target
@@ -288,6 +281,15 @@ const withTargetPods: ConfigPlugin<{
     logger: props.logger,
   });
 };
+
+function isExpoUiWidgetTarget(props: IosTargetProps): boolean {
+  const uiMode = resolveUiMode({
+    type: props.type,
+    entry: props.entry,
+    ui: props.ui,
+  });
+  return uiMode === 'expo-ui' && props.type === 'widget';
+}
 
 /**
  * App Clips are provisioned against their parent app and can claim the parent's

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
@@ -40,6 +40,7 @@ interface IosTargetProps extends IOSTargetConfigWithReactNative {
   entry?: string;
   ui?: 'native' | 'expo-ui' | 'react-native';
   excludedPackages?: string[];
+  linkerTokens?: string[];
   directory: string;
   configPath: string;
   logger: Logger;
@@ -280,6 +281,7 @@ const withTargetPods: ConfigPlugin<{
     deploymentTarget,
     extensionType: props.type,
     excludedPackages: props.excludedPackages,
+    linkerTokens: props.linkerTokens,
     standalone: !props.entry || isWebBasedEntry || isExpoUiWidget,
     expoUiWidget: isExpoUiWidget,
     targetDirectory: props.directory, // For pods.rb file detection

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withPodfile.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withPodfile.ts
@@ -23,6 +23,7 @@ export const withTargetPodfile: ConfigPlugin<{
   deploymentTarget: string;
   extensionType: ExtensionType;
   excludedPackages?: string[];
+  linkerTokens?: string[];
   standalone?: boolean;
   expoUiWidget?: boolean;
   targetDirectory?: string;
@@ -46,6 +47,7 @@ export const withTargetPodfile: ConfigPlugin<{
         standalone: Boolean(props.standalone),
         expoUiWidget: Boolean(props.expoUiWidget),
         excludedPackages: props.excludedPackages,
+        linkerTokens: props.linkerTokens,
         podsRbContent: readPodsRb({
           projectRoot,
           targetDirectory: props.targetDirectory,

--- a/packages/expo-targets/plugin/src/ios/plan/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/podfile.ts
@@ -15,6 +15,7 @@ export function planPodfile({
   standalone,
   expoUiWidget,
   excludedPackages,
+  linkerTokens,
   podsRbContent,
 }: {
   targetName: string;
@@ -23,6 +24,7 @@ export function planPodfile({
   standalone: boolean;
   expoUiWidget?: boolean;
   excludedPackages?: string[];
+  linkerTokens?: string[];
   podsRbContent?: string;
 }): PodfilePlan {
   return {
@@ -32,6 +34,7 @@ export function planPodfile({
     standalone,
     expoUiWidget,
     excludedPackages,
+    linkerTokens,
     podsRbContent,
   };
 }

--- a/packages/expo-targets/plugin/src/ios/plan/types.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/types.ts
@@ -17,6 +17,7 @@ export interface IOSTargetProps extends IOSTargetConfigWithReactNative {
   entry?: string;
   ui?: 'native' | 'expo-ui' | 'react-native';
   excludedPackages?: string[];
+  linkerTokens?: string[];
   appGroup?: string;
   /** Baked into RN VC for App Group sideload matching (optional). */
   runtimeVersion?: string;
@@ -240,6 +241,7 @@ export interface PodfilePlan {
   /** Link ExpoWidgets sandbox via use_expo_modules_widgets! */
   expoUiWidget?: boolean;
   excludedPackages?: string[];
+  linkerTokens?: string[];
   podsRbContent?: string;
 }
 

--- a/packages/expo-targets/plugin/src/ios/utils/reactNativeSwift.test.ts
+++ b/packages/expo-targets/plugin/src/ios/utils/reactNativeSwift.test.ts
@@ -8,7 +8,7 @@ const baseOptions = {
   targetName: 'ShareExt',
 };
 
-describe('generateReactNativeViewController', () => {
+describe('generateReactNativeViewController placeholders', () => {
   test('substitutes BUNDLE_ROOT from entry path', () => {
     const result = generateReactNativeViewController({
       ...baseOptions,
@@ -38,7 +38,9 @@ describe('generateReactNativeViewController', () => {
     expect(result).toContain('withModuleName: "ShareExt"');
     expect(result).toContain('URLQueryItem(name: "target", value: "ShareExt")');
   });
+});
 
+describe('generateReactNativeViewController factory', () => {
   test('includes Metro fallback and error handling in template output', () => {
     const result = generateReactNativeViewController({
       ...baseOptions,

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -82,7 +82,7 @@ describe('resolveExcludedPackages non-RN', () => {
   });
 });
 
-describe('resolveExcludedPackages invert autolinked', () => {
+describe('resolveExcludedPackages invert unused hosts', () => {
   test('unions unused autolinked hosts; user list is force-strip only', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
@@ -111,7 +111,9 @@ describe('resolveExcludedPackages invert autolinked', () => {
     ]);
     fs.rmSync(root, { recursive: true, force: true });
   });
+});
 
+describe('resolveExcludedPackages invert imported keep', () => {
   test('does not infer a package the entry imports', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
@@ -129,7 +131,9 @@ describe('resolveExcludedPackages invert autolinked', () => {
     ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES]);
     fs.rmSync(root, { recursive: true, force: true });
   });
+});
 
+describe('resolveNativeUnlink linker tokens', () => {
   test('resolveNativeUnlink maps unused packages to linker tokens', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
@@ -162,7 +166,9 @@ describe('resolveExcludedPackages invert autolinked', () => {
     );
     fs.rmSync(root, { recursive: true, force: true });
   });
+});
 
+describe('resolveNativeUnlink nativeLink host', () => {
   test('nativeLink host skips invert; user excludedPackages still strip', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import {
   HOST_ONLY_EXCLUDED_PACKAGES,
   resolveExcludedPackages,
+  resolveNativeUnlink,
 } from './resolveExcludedPackages';
 
 describe('resolveExcludedPackages omitted list', () => {
@@ -81,39 +82,39 @@ describe('resolveExcludedPackages non-RN', () => {
   });
 });
 
-describe('resolveExcludedPackages inferred heavies', () => {
-  test('unions unused host Sentry when projectRoot + entry are set', () => {
+describe('resolveExcludedPackages invert autolinked', () => {
+  test('unions unused autolinked hosts; user list is force-strip only', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
     fs.writeFileSync(
-      path.join(root, 'package.json'),
-      JSON.stringify({
-        dependencies: { '@sentry/react-native': '6.0.0' },
-      })
-    );
-    fs.writeFileSync(
       path.join(root, 'targets', 'messages', 'index.tsx'),
-      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+      "import { Image } from 'expo-image';\nexport default function App() { return null; }\n"
     );
     expect(
       resolveExcludedPackages({
         type: 'messages',
         entry: './targets/messages/index.tsx',
         projectRoot: root,
+        autolinkedPackages: [
+          'expo-image',
+          'expo-modules-core',
+          '@intercom/intercom-react-native',
+          '@sentry/react-native',
+        ],
+        excludedPackages: ['expo-font'],
       })
-    ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES, '@sentry/react-native']);
+    ).toEqual([
+      ...HOST_ONLY_EXCLUDED_PACKAGES,
+      'expo-font',
+      '@intercom/intercom-react-native',
+      '@sentry/react-native',
+    ]);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('does not infer Sentry when the entry imports it', () => {
+  test('does not infer a package the entry imports', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
     fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
-    fs.writeFileSync(
-      path.join(root, 'package.json'),
-      JSON.stringify({
-        dependencies: { '@sentry/react-native': '6.0.0' },
-      })
-    );
     fs.writeFileSync(
       path.join(root, 'targets', 'messages', 'index.tsx'),
       "import * as Sentry from '@sentry/react-native';\nexport default function App() { return null; }\n"
@@ -123,8 +124,65 @@ describe('resolveExcludedPackages inferred heavies', () => {
         type: 'messages',
         entry: './targets/messages/index.tsx',
         projectRoot: root,
+        autolinkedPackages: ['@sentry/react-native'],
       })
     ).toEqual([...HOST_ONLY_EXCLUDED_PACKAGES]);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('resolveNativeUnlink maps unused packages to linker tokens', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    const resolved = resolveNativeUnlink({
+      type: 'messages',
+      entry: './targets/messages/index.tsx',
+      projectRoot: root,
+      autolinkedPackages: [
+        {
+          packageName: '@intercom/intercom-react-native',
+          linkerTokens: [
+            '@intercom/intercom-react-native',
+            'intercom-react-native',
+            'Intercom',
+          ],
+        },
+      ],
+    });
+    expect(resolved?.packages).toContain('@intercom/intercom-react-native');
+    expect(resolved?.linkerTokens).toEqual(
+      expect.arrayContaining([
+        'intercom-react-native',
+        'Intercom',
+        '@intercom/intercom-react-native',
+      ])
+    );
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('nativeLink host skips invert; user excludedPackages still strip', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    const host = resolveNativeUnlink({
+      type: 'messages',
+      entry: './targets/messages/index.tsx',
+      projectRoot: root,
+      nativeLink: 'host',
+      autolinkedPackages: ['@intercom/intercom-react-native'],
+      excludedPackages: ['expo-font'],
+    });
+    expect(host?.packages).toEqual([
+      ...HOST_ONLY_EXCLUDED_PACKAGES,
+      'expo-font',
+    ]);
+    expect(host?.linkerTokens).toEqual([]);
     fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.ts
@@ -1,6 +1,12 @@
+import {
+  type AutolinkedNativePackage,
+  linkerTokensForPackages,
+  listAutolinkedNativePackages,
+  normalizeAutolinkedPackages,
+} from './autolinkedPackages';
 import type { ExtensionType } from './config';
 import { REACT_NATIVE_NATIVE_TYPES } from './domain';
-import { unusedHeavyPackages } from './entryGraph';
+import { unusedAutolinkedPackages } from './entryGraph';
 
 /** Host-only Expo packages that crash / blank RN appex processes. Always merged in. */
 export const HOST_ONLY_EXCLUDED_PACKAGES = [
@@ -10,38 +16,102 @@ export const HOST_ONLY_EXCLUDED_PACKAGES = [
   'expo-dev-menu',
 ] as const;
 
+export type NativeLinkMode = 'entry' | 'host';
+
 export type ResolveExcludedPackagesInput = {
   type: ExtensionType | string;
   entry?: string;
+  /** Force-strip only. Never a keep-list. */
   excludedPackages?: string[];
-  /** When set, unused heavy host packages are union-merged (Sentry, reanimated, …). */
+  /** When set, unused autolinked host packages are inverted out. */
   projectRoot?: string;
+  /** Injected autolinked set (tests). When omitted, loaded from projectRoot. */
+  autolinkedPackages?: readonly (string | AutolinkedNativePackage)[];
+  /** Force-keep even when the entry does not import them. */
+  linkedPackages?: string[];
+  /**
+   * `entry` (default): invert unused autolinked packages off provider + linker.
+   * `host`: old fat copy — invert off; still force-strip HOST_ONLY + user list.
+   */
+  nativeLink?: NativeLinkMode;
+};
+
+export type ResolvedNativeUnlink = {
+  packages: string[];
+  linkerTokens: string[];
 };
 
 function isRnNativeType(type: string): boolean {
   return (REACT_NATIVE_NATIVE_TYPES as string[]).includes(type);
 }
 
+function loadAutolinked(
+  input: ResolveExcludedPackagesInput
+): AutolinkedNativePackage[] {
+  if (input.autolinkedPackages) {
+    return normalizeAutolinkedPackages(input.autolinkedPackages);
+  }
+  if (input.projectRoot) {
+    return listAutolinkedNativePackages(input.projectRoot);
+  }
+  return [];
+}
+
+/**
+ * Resolve Expo + RN packages to strip from a nested RN extension.
+ * Invert: autolinked − (core ∪ entry imports ∪ linkedPackages).
+ * User `excludedPackages` is force-strip only. HOST_ONLY always merges.
+ */
+export function resolveNativeUnlink(
+  input: ResolveExcludedPackagesInput
+): ResolvedNativeUnlink | undefined {
+  const { type, entry, excludedPackages, projectRoot } = input;
+  if (!(entry && isRnNativeType(type))) {
+    if (!excludedPackages?.length) {
+      return;
+    }
+    return {
+      packages: [...excludedPackages],
+      linkerTokens: linkerTokensForPackages(excludedPackages, []),
+    };
+  }
+
+  const nativeLink = input.nativeLink ?? 'entry';
+  const autolinked = loadAutolinked(input);
+  const inferred =
+    nativeLink === 'entry' && projectRoot
+      ? unusedAutolinkedPackages({
+          projectRoot,
+          entry,
+          autolinked: autolinked.map((pkg) => pkg.packageName),
+          linkedPackages: input.linkedPackages,
+        })
+      : [];
+
+  const packages = [
+    ...new Set<string>([
+      ...HOST_ONLY_EXCLUDED_PACKAGES,
+      ...(excludedPackages ?? []),
+      ...inferred,
+    ]),
+  ];
+
+  return {
+    packages,
+    linkerTokens:
+      nativeLink === 'host'
+        ? []
+        : linkerTokensForPackages(packages, autolinked),
+  };
+}
+
 /**
  * Resolve Expo packages to strip from a nested RN extension's ExpoModulesProvider.
  * For RN-native targets with an `entry`, always union-merge HOST_ONLY_EXCLUDED_PACKAGES
- * (no escape hatch). User lists are additive only.
+ * (no escape hatch). User lists are force-strip only.
  */
 export function resolveExcludedPackages(
   input: ResolveExcludedPackagesInput
 ): string[] | undefined {
-  const { type, entry, excludedPackages, projectRoot } = input;
-  if (!(entry && isRnNativeType(type))) {
-    return excludedPackages?.length ? [...excludedPackages] : undefined;
-  }
-
-  const inferred =
-    projectRoot && entry ? unusedHeavyPackages({ projectRoot, entry }) : [];
-
-  const merged = new Set<string>([
-    ...HOST_ONLY_EXCLUDED_PACKAGES,
-    ...(excludedPackages ?? []),
-    ...inferred,
-  ]);
-  return [...merged];
+  return resolveNativeUnlink(input)?.packages;
 }

--- a/packages/expo-targets/plugin/src/withTargetsDir.ts
+++ b/packages/expo-targets/plugin/src/withTargetsDir.ts
@@ -19,7 +19,7 @@ import { ensureHostLiveActivities } from './ensureHostLiveActivities';
 import { withIOSTarget } from './ios/config-plugins/withIOSTarget';
 import { resolveLiveActivityConfig } from './ios/utils/resolveIosKinds';
 import { Logger } from './logger';
-import { resolveExcludedPackages } from './resolveExcludedPackages';
+import { resolveNativeUnlink } from './resolveExcludedPackages';
 
 interface EvaluatedTarget {
   config: any;
@@ -273,6 +273,24 @@ function applyIosCompanionTargets(opts: {
   return next;
 }
 
+function nativeUnlinkProps(
+  evaluatedConfig: EvaluatedTarget['config'],
+  projectRoot: string
+) {
+  const nativeUnlink = resolveNativeUnlink({
+    type: evaluatedConfig.type,
+    entry: evaluatedConfig.entry,
+    excludedPackages: evaluatedConfig.excludedPackages,
+    linkedPackages: evaluatedConfig.linkedPackages,
+    nativeLink: evaluatedConfig.ios?.nativeLink,
+    projectRoot,
+  });
+  return {
+    excludedPackages: nativeUnlink?.packages,
+    linkerTokens: nativeUnlink?.linkerTokens,
+  };
+}
+
 const withTargetIos: ConfigPlugin<{
   context: TargetContext;
   runtimeConfigs: any[];
@@ -289,12 +307,10 @@ const withTargetIos: ConfigPlugin<{
         }
       : undefined;
 
-  const excludedPackages = resolveExcludedPackages({
-    type: evaluatedConfig.type,
-    entry: evaluatedConfig.entry,
-    excludedPackages: evaluatedConfig.excludedPackages,
-    projectRoot: context.projectRoot,
-  });
+  const { excludedPackages, linkerTokens } = nativeUnlinkProps(
+    evaluatedConfig,
+    context.projectRoot
+  );
 
   const runtimeVersion = resolveRuntimeVersionFromExpoConfig(config);
   warnMissingRuntimeForSideload({
@@ -314,6 +330,7 @@ const withTargetIos: ConfigPlugin<{
     ui: evaluatedConfig.ui,
     liveActivity: resolveLiveActivityConfig(evaluatedConfig),
     excludedPackages,
+    linkerTokens,
     runtimeVersion: runtimeVersion || undefined,
     directory: targetDirectory,
     configPath: target.targetPath,


### PR DESCRIPTION
## Summary
- Invert RN `entry` native strip: `autolinked − (core ∪ entry imports ∪ linkedPackages)` on both `ExpoModulesProvider` and `Pods-<Target>` linker flags (`-l` / `-framework` / module maps).
- Default on for RN `entry` targets. `excludedPackages` is force-strip only. `linkedPackages` force-keeps. `ios.nativeLink: "host"` restores the old fat host copy.
- Doctor reports unlink count. Host embed of frameworks can stay.

## Test plan
- [x] `bun test` invert / autolink parsers / podfile hook / doctor unlink
- [ ] Merge publishes next patch (`1.8.3` unless labeled otherwise)
- [ ] Popl bump: no Messages `excludedPackages` deny-list; prebuild + pod install; confirm Intercom/LogRocket gone from `Pods-PoplMessagesTarget` `OTHER_LDFLAGS`