### PR TITLE
docs: add public adoption evidence

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase.yml
+++ b/.github/ISSUE_TEMPLATE/showcase.yml
@@ -1,0 +1,64 @@
+name: Share a project
+description: Share a public project or implementation that uses expo-targets
+title: "[Showcase]: "
+labels:
+  - showcase
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing what you built. This form creates a public issue. Do not include private code, credentials, customer information, or anything you cannot publish.
+  - type: input
+    id: project
+    attributes:
+      label: Project or organization
+      description: The public name you want associated with this implementation.
+      placeholder: Project name
+    validations:
+      required: true
+  - type: input
+    id: public_url
+    attributes:
+      label: Public project URL
+      description: A repository, product page, App Store listing, Play Store listing, or other public source.
+      placeholder: https://...
+    validations:
+      required: true
+  - type: input
+    id: package_version
+    attributes:
+      label: expo-targets version
+      placeholder: 0.2.7
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What did expo-targets enable or make easier?
+      description: Describe the concrete extension, workflow, or problem the package helped with.
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Integration status
+      options:
+        - Experimental or prototype
+        - Open-source project
+        - Internal project
+        - Production
+    validations:
+      required: true
+  - type: input
+    id: production_evidence
+    attributes:
+      label: Public evidence for a production claim
+      description: Required only if you selected Production. Link to a public store listing, product page, release, or statement that supports the claim.
+      placeholder: https://...
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Permission
+      options:
+        - label: I give permission to quote this submission and link it from expo-targets and Christopher Sarkissian's public GitHub profile.
+          required: true

--- a/.skeleton/registry.md
+++ b/.skeleton/registry.md
@@ -9,6 +9,7 @@
 | Topic | Canonical file |
 | --- | --- |
 | Package overview | [README.md](../README.md) |
+| Community adoption evidence | [adoption.md](../docs/adoption.md) |
 | Contributing (humans) | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Agent cold-start | [AGENTS.md](../AGENTS.md) |
 | Getting started | [getting-started.md](../docs/getting-started.md) |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See [examples/README.md](./examples/README.md) for the full suite (~48 hosts), D
 ## Documentation
 
 - **[Getting Started](./docs/getting-started.md)** — Build a React Native share extension
+- **[Community and adoption](./docs/adoption.md)** — Public implementation reports, maintenance loops, and independently verifiable signals
 - **[React Native Extensions](./docs/react-native-extensions.md)** — RN runtime contract + Metro; [App Group OTA / eas update](./docs/react-native-extensions.md#extension-bundle-sideload-with-expo-updates)
 - **[Widgets](./docs/widgets.md)** — WidgetKit / Live Activities ownership vs `expo-widgets`
 - **[Configuration](./docs/configuration.md)** — All config options
@@ -207,6 +208,8 @@ target.refresh();
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) (humans) and [AGENTS.md](./AGENTS.md) (agent posture).
+
+Built something with expo-targets? Use the [project showcase form](https://github.com/csark0812/expo-targets/issues/new?template=showcase.yml) to share a public implementation without implying endorsement or production use.
 
 ## License
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,49 @@
+# Community and adoption
+
+**Source of truth for** public adoption evidence for expo-targets.
+
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-31 -->
+
+This page records claims that can be checked against public sources. It distinguishes implementation reports, maintenance outcomes, external recognition, and download activity. None of the evidence below establishes a named company's production deployment.
+
+## Evidence snapshot
+
+Verified on 2026-08-31.
+
+| Signal | Snapshot | Source | What it establishes |
+| --- | ---: | --- | --- |
+| npm download events, latest 30-day window | 6,550 (2026-07-31 through 2026-08-29) | [npm downloads API](https://api.npmjs.org/downloads/point/last-month/expo-targets) | Registry download activity, not unique users or installations |
+| npm download events, trailing year | 13,992 (2025-08-30 through 2026-08-29) | [npm downloads API](https://api.npmjs.org/downloads/point/last-year/expo-targets) | Registry download activity, not retention or production use |
+| GitHub stars | 96 | [Repository](https://github.com/csark0812/expo-targets) | Public interest |
+| GitHub releases | 38 | [Releases](https://github.com/csark0812/expo-targets/releases) | Published maintenance history |
+
+## Public implementation report
+
+In [issue #15](https://github.com/csark0812/expo-targets/issues/15), [kitze](https://github.com/kitze) wrote:
+
+> "Thank you for the amazing library. I implemented widgets and love it already!"
+
+The same thread later reported EAS build trouble and temporarily moved the widget work to another branch. The maintainer reproduced the EAS failure and released a fix in `0.2.5`. The thread supports a public implementation report and maintenance response; it does not confirm that the implementation later shipped to production.
+
+## Maintenance loop
+
+[Issue #14](https://github.com/csark0812/expo-targets/issues/14) reported an incorrect module path on 2025-11-29. A new package version was published that day, and the reporter confirmed: ["Fixed. Thank you!"](https://github.com/csark0812/expo-targets/issues/14#issuecomment-3591584321)
+
+This establishes a publicly visible report-to-release-to-confirmation loop. It does not establish the reporter's deployment environment.
+
+## External recognition
+
+- [This Week in React #261](https://github.com/slorber/this-week-in-react/blob/main/website/newsletter/261/index.mdx) included Expo Targets in its React Native package roundup.
+- The [React Native Community Directory compatibility data](https://github.com/react-native-community/directory/blob/main/assets/check-data.json) includes `expo-targets` with New Architecture support recorded.
+- The independent [React Native iOS widgets blueprint](https://github.com/alexklyuev/rn-ios-widgets-blueprint/blob/main/README.md) includes `expo-targets` in its implementation plan.
+
+These are independent references. They are not testimonials, customer endorsements, or proof of production deployment.
+
+## Evidence boundary
+
+- **Confirmed production use** requires an explicit, attributable public statement that expo-targets is used in production.
+- **Public implementation report** means a developer publicly said they implemented or used the package.
+- **External recognition** means an independent public source included the package.
+- **Download activity** counts npm download events, not people, applications, or companies.
+
+Have a public implementation to share? Use the [project showcase form](https://github.com/csark0812/expo-targets/issues/new?template=showcase.yml). Submissions are not described as production use unless the submission includes public supporting evidence and permission to quote it.


### PR DESCRIPTION
Adds a source-backed adoption page, explicit evidence boundaries, and an inbound-only project showcase form.

Validated with the repository Skeleton 1.5.7 audits and docs guard.