### PR TITLE
fix(ios): XCFramework invert tokens, stable product name, Podfile insert

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ targets/my-widget/
 
 | Field              | Default     | Description                                                                                                                                                      |
 | ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `displayName`      | `name`      | Human-readable name (`CFBundleDisplayName` or `CFBundleName` on iOS; widget picker label)                                                                          |
+| `displayName`      | `name`      | Drawer label only (`CFBundleDisplayName` / `CFBundleName` on iOS; widget picker). Xcode product, Pod target, and pbx name use `name` (`Messages` → `MessagesTarget`). |
 | `appGroup`         | _inherited_ | App Group ID. When omitted, inherits from your main app's `app.json` entitlements (see [App Group Inheritance](#app-group-inheritance) below) |
 | `entry`            | —           | React Native entry point for share, action, clip, and messages (see [Entry Field](#entry-field) below)                                                                  |
 | `excludedPackages` | auto for RN `entry` | Force-strip extra packages from the nested `ExpoModulesProvider` and the extension linker. For RN `entry` targets, unused autolinked host packages are stripped by default. Crash-class packages (`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) always merge. Do not use this field as a keep-list. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,8 @@ Extension JS can still OTA without linking Updates in the appex: the host runs `
 | Location            | Format     | Example                        | Notes                     |
 | ------------------- | ---------- | ------------------------------ | ------------------------- |
 | Target folder       | kebab-case | `targets/my-share/`            | Organizational            |
-| Config `name` field | PascalCase | `"name": "MyShare"`            | Canonical identifier      |
+| Config `name` field | PascalCase | `"name": "MyShare"`            | Canonical identifier; Xcode / Pod product is `MyShareTarget` |
+| `displayName`       | Any        | `"displayName": "My Share"`    | Drawer / `CFBundleDisplayName` only |
 | `createTarget()`    | Same name  | `createTarget('MyShare', …)`   | Must match config exactly |
 | `entry`             | Path       | `./targets/my-share/index.tsx` | Relative to project root  |
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -2,7 +2,7 @@
 
 **Source of truth for** React Native extensions (runtime contract, Metro, type support).
 
-<!-- doc-meta: owner=eng | last-reviewed=2026-08-10 -->
+<!-- doc-meta: owner=eng | last-reviewed=2026-08-31 -->
 
 Build share extensions, action extensions, App Clips, iMessage apps, rich notification UI, and Safari popups with React Native instead of native Swift or Kotlin.
 
@@ -369,7 +369,9 @@ For RN-native targets with `entry`, the plugin inverts the host autolink set:
 
 Core keep is React Native, Hermes, Yoga, ExpoModulesCore, and `expo-targets`.
 The same strip set is applied to `ExpoModulesProvider` and to `Pods-<Target>`
-linker flags (`-l`, `-framework`, module maps). The host can still embed those
+linker flags (`-l`, `-framework`, module maps). Linker tokens include XCFramework
+names from each unused package podspec (`s.dependency "Intercom"` → `-framework Intercom`),
+not only the npm or wrapper-pod name. The host can still embed those
 frameworks in the app. The plugin does not copy host `OTHER_LDFLAGS`.
 
 **Always stripped (no escape hatch):**

--- a/packages/expo-targets/cli/src/checks/easCredentials.test.ts
+++ b/packages/expo-targets/cli/src/checks/easCredentials.test.ts
@@ -82,7 +82,7 @@ describe('checkEasCredentials errors', () => {
   });
 });
 
-describe('checkEasCredentials displayName product', () => {
+describe('checkEasCredentials product from name', () => {
   test('warns when committed appExtensions misses a target', () => {
     const results = checkEasCredentials(
       withAppExtensions([
@@ -99,12 +99,12 @@ describe('checkEasCredentials displayName product', () => {
     ).toBe(true);
   });
 
-  test('matches plugin product from displayName || name', () => {
+  test('matches plugin product from name, not displayName', () => {
     const results = checkEasCredentials(
       withAppExtensions(
         [
           {
-            targetName: 'ExampleShareTarget',
+            targetName: 'ShareTarget',
             bundleIdentifier: 'com.example.app.share',
             entitlements: {
               'com.apple.security.application-groups': [
@@ -118,5 +118,18 @@ describe('checkEasCredentials displayName product', () => {
     );
     expect(results.some((r) => r.message.includes('missing'))).toBe(false);
     expect(results.some((r) => r.level === 'error')).toBe(false);
+    expect(
+      checkEasCredentials(
+        withAppExtensions(
+          [
+            {
+              targetName: 'ExampleShareTarget',
+              bundleIdentifier: 'com.example.app.share',
+            },
+          ],
+          { displayName: 'Example Share' }
+        )
+      ).some((r) => r.message.includes('ShareTarget'))
+    ).toBe(true);
   });
 });

--- a/packages/expo-targets/cli/src/checks/easCredentials.ts
+++ b/packages/expo-targets/cli/src/checks/easCredentials.ts
@@ -19,13 +19,12 @@ function sanitizeTargetName(name: string): string {
   return `${name.replace(/[^a-zA-Z0-9]/g, '')}Target`;
 }
 
-/** Same input as `withIOSTarget`: displayName || name. */
+/** Same input as `withIOSTarget`: config `name` (displayName is CFBundle only). */
 function productNameForTarget(
   target: ProjectContext['targets'][number]
 ): string {
   const configName = target.config.name as string;
-  const label = target.config.displayName || configName;
-  return sanitizeTargetName(label);
+  return sanitizeTargetName(configName);
 }
 
 function readAppExtensions(

--- a/packages/expo-targets/cli/src/exportSafari.ts
+++ b/packages/expo-targets/cli/src/exportSafari.ts
@@ -28,7 +28,9 @@ export function runExportSafari(projectRoot = process.cwd()): number {
   for (const target of targets) {
     const displayName =
       target.config.displayName || target.config.name || target.dirName;
-    const productName = sanitizeTargetName(displayName);
+    const productName = sanitizeTargetName(
+      target.config.name || target.dirName
+    );
     const entryFile = target.config.entry!.replace(/^\.\//, '');
 
     const result = exportSafariWebBundle({

--- a/packages/expo-targets/cli/src/orphans.ts
+++ b/packages/expo-targets/cli/src/orphans.ts
@@ -28,9 +28,8 @@ function configuredProductNames(ctx: ProjectContext): Set<string> {
     if (!target.config.platforms?.includes('ios')) {
       continue;
     }
-    const displayName =
-      target.config.displayName || target.config.name || target.dirName;
-    names.add(sanitizeTargetName(displayName));
+    const configName = target.config.name || target.dirName;
+    names.add(sanitizeTargetName(configName));
   }
   return names;
 }

--- a/packages/expo-targets/plugin/src/autolinkedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/autolinkedPackages.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import {
+  frameworkNamesFromPodspec,
   mergeAutolinkedPackages,
   parseExpoAutolinkingResolve,
   parseReactNativeConfig,
@@ -27,7 +31,76 @@ describe('parseExpoAutolinkingResolve', () => {
   });
 });
 
-describe('parseReactNativeConfig', () => {
+describe('frameworkNamesFromPodspec', () => {
+  test('maps wrapper pod dependencies to XCFramework names, not React runtime pods', () => {
+    expect(
+      frameworkNamesFromPodspec(`
+Pod::Spec.new do |s|
+  s.name = "intercom-react-native"
+  s.dependency "Intercom", '~> 19.3.0'
+  s.dependency "React-Core"
+end
+`)
+    ).toEqual(['Intercom']);
+
+    expect(
+      frameworkNamesFromPodspec(`
+Pod::Spec.new do |s|
+  s.name = "logrocket-react-native"
+  s.dependency "LogRocket", "3.6.0"
+  s.dependency "React"
+end
+`)
+    ).toEqual(['LogRocket']);
+  });
+
+  test('maps vendored xcframework basenames', () => {
+    expect(
+      frameworkNamesFromPodspec(`
+s.vendored_frameworks = "ios/SomeSDK.xcframework"
+`)
+    ).toEqual(['SomeSDK']);
+  });
+});
+
+describe('parseReactNativeConfig podspec file', () => {
+  test('reads framework names from the podspec on disk', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-podspec-'));
+    const podspecPath = path.join(dir, 'intercom-react-native.podspec');
+    fs.writeFileSync(
+      podspecPath,
+      `
+Pod::Spec.new do |s|
+  s.dependency "Intercom", '~> 19.3.0'
+  s.dependency "React-Core"
+end
+`
+    );
+    expect(
+      parseReactNativeConfig({
+        dependencies: {
+          '@intercom/intercom-react-native': {
+            platforms: {
+              ios: { podspecPath },
+            },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        packageName: '@intercom/intercom-react-native',
+        linkerTokens: [
+          '@intercom/intercom-react-native',
+          'intercom-react-native',
+          'Intercom',
+        ],
+      },
+    ]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('parseReactNativeConfig basename', () => {
   test('maps RN community deps from podspec basename', () => {
     expect(
       parseReactNativeConfig({

--- a/packages/expo-targets/plugin/src/autolinkedPackages.ts
+++ b/packages/expo-targets/plugin/src/autolinkedPackages.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -23,12 +24,63 @@ const CORE_LINKER_BLOCKLIST = new Set([
   'expo',
 ]);
 
+function isBlockedLinkerToken(token: string): boolean {
+  if (CORE_LINKER_BLOCKLIST.has(token)) {
+    return true;
+  }
+  return /^(React([-_A-Z].*)?|RCT|Folly|glog|fmt|boost|Yoga|hermes)/.test(
+    token
+  );
+}
+
 function lastSegment(packageName: string): string {
   if (packageName.startsWith('@')) {
     const parts = packageName.split('/');
     return parts[1] ?? packageName;
   }
   return packageName.split('/')[0] ?? packageName;
+}
+
+function frameworkStem(file: string): string | undefined {
+  const base = path.basename(file.trim());
+  if (base.endsWith('.xcframework')) {
+    return base.slice(0, -'.xcframework'.length);
+  }
+  if (base.endsWith('.framework')) {
+    return base.slice(0, -'.framework'.length);
+  }
+}
+
+/**
+ * XCFramework / CocoaPod names that appear as `-framework X` on OTHER_LDFLAGS.
+ * Wrapper pods (`intercom-react-native`) depend on `Intercom`; the npm name
+ * does not match the linker flag.
+ */
+export function frameworkNamesFromPodspec(source: string): string[] {
+  const names = new Set<string>();
+  const dependency = /(?:^|\n)\s*(?:s|spec)\.dependency\s+["']([^"']+)["']/g;
+  for (const match of source.matchAll(dependency)) {
+    const name = (match[1] ?? '').split('/')[0];
+    if (name && !isBlockedLinkerToken(name)) {
+      names.add(name);
+    }
+  }
+  const vendored = /['"]([^'"]+\.(?:xcframework|framework))['"]/g;
+  for (const match of source.matchAll(vendored)) {
+    const stem = frameworkStem(match[1] ?? '');
+    if (stem && !isBlockedLinkerToken(stem)) {
+      names.add(stem);
+    }
+  }
+  return [...names];
+}
+
+function readPodspecFrameworkNames(podspecPath: string): string[] {
+  try {
+    return frameworkNamesFromPodspec(fs.readFileSync(podspecPath, 'utf8'));
+  } catch {
+    return [];
+  }
 }
 
 export function linkerTokensForPackageName(packageName: string): string[] {
@@ -135,12 +187,13 @@ function rnDepToPackage(
   }
   const tokens = new Set(linkerTokensForPackageName(packageName));
   if (typeof ios === 'object') {
-    const token = podspecToken(
-      stringField((ios as { podspecPath?: unknown }).podspecPath) ?? ''
-    );
+    const podspecPath =
+      stringField((ios as { podspecPath?: unknown }).podspecPath) ?? '';
+    const token = podspecToken(podspecPath);
     if (token) {
       tokens.add(token);
     }
+    addTokens(tokens, readPodspecFrameworkNames(podspecPath));
   }
   return { packageName, linkerTokens: [...tokens] };
 }
@@ -248,7 +301,7 @@ export function linkerTokensForPackages(
   const tokens = new Set<string>();
   for (const name of packageNames) {
     for (const token of byName.get(name) ?? linkerTokensForPackageName(name)) {
-      if (!CORE_LINKER_BLOCKLIST.has(token)) {
+      if (!isBlockedLinkerToken(token)) {
         tokens.add(token);
       }
     }

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/applyPodfilePlan.ts
@@ -141,6 +141,7 @@ export function applyPodfilePlan(
   next = insertTargetBlock(next, targetBlockFor(next, plan, mainTargetName), {
     standalone: plan.standalone,
     logger,
+    mainTargetName,
   });
 
   if (plan.expoUiWidget) {

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
@@ -214,6 +214,57 @@ describe('insertTargetBlock + removeTargetBlock', () => {
   });
 });
 
+const onesignalSiblingPodfile = `${plainPodfile.trimEnd()}
+
+target 'OneSignalNotificationServiceExtension' do
+  pod 'OneSignalXCFramework/OneSignal', '>= 5.0', '< 6.0'
+end
+`;
+
+describe('insertTargetBlock OneSignal sibling', () => {
+  test('does not glue end onto the next top-level target', () => {
+    const logger = new Logger();
+    const afterMessages = applyPodfilePlan(
+      onesignalSiblingPodfile,
+      {
+        targetName: 'MessagesTarget',
+        deploymentTarget: '16.4',
+        extensionType: 'messages',
+        standalone: false,
+        excludedPackages: ['expo-updates'],
+        linkerTokens: ['Intercom'],
+      },
+      { mainTargetName: 'App', logger }
+    );
+    const afterClip = applyPodfilePlan(
+      afterMessages,
+      {
+        targetName: 'ClipTarget',
+        deploymentTarget: '16.4',
+        extensionType: 'clip',
+        standalone: true,
+      },
+      { mainTargetName: 'App', logger }
+    );
+
+    expect(afterClip).not.toMatch(/endend/);
+    expect(afterClip).not.toMatch(/endtarget/);
+    for (const line of afterClip.split('\n')) {
+      if (line.includes("target '")) {
+        expect(line).toMatch(/^\s*target '/);
+      }
+    }
+    expect(afterClip).toMatch(
+      /\n[ \t]*end\n+target 'OneSignalNotificationServiceExtension'/
+    );
+    expect(afterClip).toContain("target 'MessagesTarget' do");
+    expect(afterClip).toContain("target 'ClipTarget' do");
+    expect(afterClip.indexOf("target 'ClipTarget'")).toBeLessThan(
+      afterClip.indexOf("target 'OneSignalNotificationServiceExtension'")
+    );
+  });
+});
+
 describe('applyPodfilePlan messages then clip', () => {
   test('keeps fence markers intact after a later standalone target', () => {
     const logger = new Logger();

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -368,16 +368,58 @@ function findLastLineLevelEndIndex(podfileContent: string): number {
   return last.index + last[0].length;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Index just past the `end` that closes `target 'name' do`. */
+function findNamedTargetEndIndex(
+  podfileContent: string,
+  targetName: string
+): number {
+  const targetRegex = new RegExp(
+    `target\\s+['"]${escapeRegExp(targetName)}['"]\\s+do`
+  );
+  const match = targetRegex.exec(podfileContent);
+  if (!match) {
+    return -1;
+  }
+  return findBlockEndIndex(podfileContent, match.index + match[0].length);
+}
+
+function spliceAfter(podfileContent: string, index: number, insertion: string) {
+  return (
+    podfileContent.slice(0, index) + insertion + podfileContent.slice(index)
+  );
+}
+
 /**
  * Standalone targets are inserted as siblings AFTER the main target's closing
  * `end`, which prevents CocoaPods from auto-generating Expo module providers.
+ * Always keep a newline after the block so `end` cannot glue onto the next
+ * `target` (OneSignal NSE and similar siblings).
  */
 function insertStandaloneTargetBlock(
   podfileContent: string,
   targetBlock: string,
-  logger?: { log: (message: string) => void }
+  options: {
+    logger?: { log: (message: string) => void };
+    mainTargetName?: string;
+  }
 ): string {
-  const insertion = `\n\n${targetBlock.trim()}`;
+  const { logger, mainTargetName } = options;
+  const insertion = `\n\n${targetBlock.trim()}\n`;
+
+  if (mainTargetName) {
+    const mainEnd = findNamedTargetEndIndex(podfileContent, mainTargetName);
+    if (mainEnd !== -1) {
+      logger?.log(
+        `Inserting standalone target after '${mainTargetName}' closing end`
+      );
+      return spliceAfter(podfileContent, mainEnd, insertion);
+    }
+  }
+
   const hookStart = podfileContent.indexOf(
     EXCLUDED_PACKAGES_POST_INTEGRATE_START
   );
@@ -385,7 +427,7 @@ function insertStandaloneTargetBlock(
     logger?.log(
       'Inserting standalone target before excluded-packages post_integrate hook'
     );
-    return `${podfileContent.slice(0, hookStart).trimEnd()}${insertion}\n\n${podfileContent.slice(hookStart)}`;
+    return `${podfileContent.slice(0, hookStart).trimEnd()}${insertion}\n${podfileContent.slice(hookStart)}`;
   }
 
   const mainTargetEndIndex = findLastLineLevelEndIndex(podfileContent);
@@ -394,11 +436,7 @@ function insertStandaloneTargetBlock(
     `Inserting standalone target after last line-level 'end' at position ${mainTargetEndIndex}`
   );
 
-  return (
-    podfileContent.slice(0, mainTargetEndIndex) +
-    insertion +
-    podfileContent.slice(mainTargetEndIndex)
-  );
+  return spliceAfter(podfileContent, mainTargetEndIndex, insertion);
 }
 
 /**
@@ -412,12 +450,16 @@ export function insertTargetBlock(
   options: {
     standalone?: boolean;
     logger?: { log: (message: string) => void };
+    mainTargetName?: string;
   } = {}
 ): string {
-  const { standalone = false, logger } = options;
+  const { standalone = false, logger, mainTargetName } = options;
 
   if (standalone) {
-    return insertStandaloneTargetBlock(podfileContent, targetBlock, logger);
+    return insertStandaloneTargetBlock(podfileContent, targetBlock, {
+      logger,
+      mainTargetName,
+    });
   }
 
   logger?.log('Inserting React Native target nested inside main target');
@@ -432,6 +474,13 @@ export function insertTargetBlock(
       '\n  ' +
       podfileContent.slice(postInstallIndex)
     );
+  }
+
+  if (mainTargetName) {
+    const mainEnd = findNamedTargetEndIndex(podfileContent, mainTargetName);
+    if (mainEnd !== -1) {
+      return spliceAfter(podfileContent, mainEnd - 'end'.length, targetBlock);
+    }
   }
 
   // Fallback: insert before the last 'end' of main target

--- a/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
+++ b/packages/expo-targets/plugin/src/ios/cng/withExpoTargetsGenerated.ts
@@ -45,7 +45,7 @@ type WrittenGeneratedFile = {
 };
 
 function widgetProductName(target: TargetConfig): string {
-  return Paths.sanitizeTargetName(target.displayName || target.name);
+  return Paths.sanitizeTargetName(target.name);
 }
 
 function pushLiveActivityPlans(

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withIOSTarget.ts
@@ -440,8 +440,12 @@ function withExpoWidgetsAppGroupKeys(
 }
 
 export const withIOSTarget: ConfigPlugin<IosTargetProps> = (config, props) => {
-  const targetName = props.displayName || props.name;
-  props.logger.log(`Configuring iOS target: ${targetName} (${props.type})`);
+  const targetName = props.name;
+  props.logger.log(
+    `Configuring iOS target: ${targetName} (${props.type}${
+      props.displayName ? `, display ${props.displayName}` : ''
+    })`
+  );
 
   validateEntry(props, config._internal?.projectRoot || process.cwd());
   validateAppGroup(

--- a/packages/expo-targets/plugin/src/ios/config-plugins/withXcodeChanges.ts
+++ b/packages/expo-targets/plugin/src/ios/config-plugins/withXcodeChanges.ts
@@ -26,12 +26,12 @@ export const withXcodeChanges: ConfigPlugin<IOSTargetProps> = (config, props) =>
     const project = config.modResults;
     const projectName =
       config.modRequest.projectName || getProjectName(platformProjectRoot);
-    const productName = Paths.sanitizeTargetName(
-      props.displayName || props.name
-    );
+    const productName = Paths.sanitizeTargetName(props.name);
 
     props.logger.log(
-      `Adding Xcode target: ${props.displayName || props.name} (${props.type})`
+      `Adding Xcode target: ${productName} (${props.type}${
+        props.displayName ? `, display ${props.displayName}` : ''
+      })`
     );
 
     const workspace = buildTargetWorkspace({

--- a/packages/expo-targets/plugin/src/ios/plan/assets.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/assets.ts
@@ -27,7 +27,7 @@ function planColorsets({
     const colorsetPath = Paths.getTargetColorsetPath({
       platformProjectRoot: paths.platformProjectRoot,
       projectName: paths.projectName,
-      productName: Paths.sanitizeTargetName(props.displayName || props.name),
+      productName: Paths.sanitizeTargetName(props.name),
       colorName: name,
     });
 
@@ -71,7 +71,7 @@ function planImagesets({
     imagesetPath: Paths.getTargetImagesetPath({
       platformProjectRoot: paths.platformProjectRoot,
       projectName: paths.projectName,
-      productName: Paths.sanitizeTargetName(props.displayName || props.name),
+      productName: Paths.sanitizeTargetName(props.name),
       imageName: name,
     }),
     sourcePath: resolveTargetRelativePath({ assetPath, props, paths }),
@@ -166,7 +166,7 @@ export function planAssets({
   const buildAssetsPath = Paths.getTargetAssetsPath({
     platformProjectRoot: paths.platformProjectRoot,
     projectName: paths.projectName,
-    productName: Paths.sanitizeTargetName(props.displayName || props.name),
+    productName: Paths.sanitizeTargetName(props.name),
     isStickers,
   });
 

--- a/packages/expo-targets/plugin/src/ios/plan/buildSettings.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/buildSettings.ts
@@ -69,7 +69,7 @@ function planEntitlementsSetting({
   const entitlementsPath = Paths.getTargetEntitlementsPath({
     platformProjectRoot: paths.platformProjectRoot,
     projectName: paths.projectName,
-    productName: Paths.sanitizeTargetName(props.displayName || props.name),
+    productName: Paths.sanitizeTargetName(props.name),
   });
 
   return {

--- a/packages/expo-targets/plugin/src/ios/plan/identity.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/identity.ts
@@ -24,7 +24,7 @@ export function resolveIdentity({
   }
 
   const typeConfig = TYPE_CHARACTERISTICS[props.type];
-  const targetName = props.displayName || props.name;
+  const targetName = props.name;
 
   // Use type-specific suffix, falling back to sanitized target name if not in map
   const bundleIdentifierSuffix =

--- a/packages/expo-targets/plugin/src/ios/plan/infoPlist.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/infoPlist.ts
@@ -77,7 +77,7 @@ export function planInfoPlist({
   const infoPlistPath = Paths.getTargetInfoPlistPath({
     platformProjectRoot: paths.platformProjectRoot,
     projectName: paths.projectName,
-    productName: Paths.sanitizeTargetName(props.displayName || props.name),
+    productName: Paths.sanitizeTargetName(props.name),
   });
   const mainAppSchemes = resolveMainAppSchemes(expoConfig);
   const targetsConfig = expoConfig.extra?.targets as any[] | undefined;

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -342,9 +342,8 @@ describe('planSwiftSources React Native generation', () => {
       targetName: 'Action',
     });
     expect(
-      identityFor(
-        makeProps({ name: 'Action', displayName: 'Example Action' })
-      ).targetProductName
+      identityFor(makeProps({ name: 'Action', displayName: 'Example Action' }))
+        .targetProductName
     ).toBe('ActionTarget');
   });
 });

--- a/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/planners.test.ts
@@ -137,11 +137,21 @@ function assetsFor(
 }
 
 describe('resolveIdentity', () => {
+  test('product and pbx name follow config name; displayName is not the product', () => {
+    const identity = identityFor(
+      makeProps({ name: 'Messages', displayName: 'Popl' })
+    );
+    expect(identity.targetName).toBe('Messages');
+    expect(identity.targetProductName).toBe('MessagesTarget');
+    expect(identity.displayName).toBe('Popl');
+  });
+
   test('derives product name, bundle id and frameworks from the type', () => {
     const identity = identityFor(makeProps({ displayName: 'My Share' }));
 
-    expect(identity.targetName).toBe('My Share');
+    expect(identity.targetName).toBe('MyShare');
     expect(identity.targetProductName).toBe('MyShareTarget');
+    expect(identity.displayName).toBe('My Share');
     expect(identity.bundleIdentifier).toBe('com.example.app.share');
     expect(identity.productType).toBe('com.apple.product-type.app-extension');
     expect(identity.targetType).toBe('app_extension');
@@ -332,9 +342,10 @@ describe('planSwiftSources React Native generation', () => {
       targetName: 'Action',
     });
     expect(
-      identityFor(makeProps({ displayName: 'Example Action' }))
-        .targetProductName
-    ).toBe('ExampleActionTarget');
+      identityFor(
+        makeProps({ name: 'Action', displayName: 'Example Action' })
+      ).targetProductName
+    ).toBe('ActionTarget');
   });
 });
 

--- a/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
+++ b/packages/expo-targets/plugin/src/ios/plan/swiftSources.ts
@@ -162,8 +162,7 @@ function reactNativeTemplate(
     template: 'reactNativeViewController',
     options: {
       type: props.type,
-      // AppRegistry / createTarget(name) — must NOT use displayName product
-      // (Example Action → ExampleActionTarget). Mismatch aborts the extension.
+      // AppRegistry / createTarget(name) — config `name`, not displayName.
       moduleName: identity.name,
       targetName: props.name,
       preprocessingFile: props.preprocessingFile,


### PR DESCRIPTION
## Summary
- Map invert linker strip tokens to XCFramework / pod dependency names (`Intercom`, `LogRocket`), not npm or wrapper-pod names.
- Derive Xcode / Pod / pbx product from config `name` (`Messages` → `MessagesTarget`). `displayName` is CFBundle / drawer only.
- Insert standalone Podfile targets after the main target `end` with a trailing newline so `end` cannot glue onto a sibling `target` (OneSignal).

## Test plan
- [x] `bun test` on autolinkedPackages, planners, easCredentials, podfile, resolveExcludedPackages
- [ ] After publish: consumer re-prebuild + `pod install` on the name-based product; confirm Intercom / LogRocket absent from that target’s `OTHER_LDFLAGS`