### PR TITLE
fix(ios): keep invert -framework flags as whole argv

### DIFF
--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -371,8 +371,10 @@ Core keep is React Native, Hermes, Yoga, ExpoModulesCore, and `expo-targets`.
 The same strip set is applied to `ExpoModulesProvider` and to `Pods-<Target>`
 linker flags (`-l`, `-framework`, module maps). Linker tokens include XCFramework
 names from each unused package podspec (`s.dependency "Intercom"` → `-framework Intercom`),
-not only the npm or wrapper-pod name. The host can still embed those
-frameworks in the app. The plugin does not copy host `OTHER_LDFLAGS`.
+not only the npm or wrapper-pod name. Each `-framework NAME` stays its own argv
+(a shorter token such as `ExpoImage` does not eat `ExpoImageManipulator`).
+The host can still embed those frameworks in the app. The plugin does not copy
+host `OTHER_LDFLAGS`.
 
 **Always stripped (no escape hatch):**
 

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.test.ts
@@ -125,6 +125,7 @@ describe('ensureExcludedPackagesPostIntegrate', () => {
     expect(once).toContain('ExpoTargetsExtensionBundleModule');
     expect(once).toContain('OTHER_LDFLAGS');
     expect(once).toContain('-framework');
+    expect(once).toContain('one argv');
 
     const twice = ensureExcludedPackagesPostIntegrate(once, [
       {

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/podfile.ts
@@ -888,8 +888,24 @@ const EXCLUDED_PACKAGES_RUBY_PREFIX = [
   '# Expo regenerates the provider during integrate_user_targets after post_install.',
   '# Do not copy host OTHER_LDFLAGS onto the appex — inherit! :search_paths already',
   '# did; subtract unused -l / -framework / module maps from Pods-<target> xcconfigs.',
+  '# Match each -framework NAME / -lNAME as one argv — a prefix token must not glue the rest.',
   'post_integrate do |installer|',
   '  exclusions = {',
+] as const;
+
+/**
+ * Ruby that mutates `xc` for each linker `token`. Exported so tests run the
+ * same gsub as `pod install` (unanchored `"?token"?` smashed OTHER_LDFLAGS).
+ */
+export const EXCLUDED_LINKER_STRIP_RUBY = [
+  '        tokens.each do |token|',
+  '          next if token.to_s.empty?',
+  '          escaped = Regexp.escape(token)',
+  '          xc.gsub!(/\\s*-l(?:"#{escaped}"|#{escaped}(?=[\\s"]|$))/, \'\')',
+  '          xc.gsub!(/\\s*-framework\\s+(?:"#{escaped}"|#{escaped}(?=[\\s"]|$))/, \'\')',
+  '          xc.gsub!(/\\s*-Xcc\\s+-fmodule-map-file="[^"]*[\\/"]#{escaped}(?:\\.modulemap|[\\/"])[^"]*"/, \'\')',
+  '          xc.gsub!(/\\s*-fmodule-map-file="[^"]*[\\/"]#{escaped}(?:\\.modulemap|[\\/"])[^"]*"/, \'\')',
+  '        end',
 ] as const;
 
 const EXCLUDED_PACKAGES_RUBY_SUFFIX = [
@@ -926,12 +942,7 @@ const EXCLUDED_PACKAGES_RUBY_SUFFIX = [
   '    unless tokens.empty?',
   "      Dir.glob(File.join(support_dir, '*.xcconfig')).each do |xcconfig_path|",
   '        xc = File.read(xcconfig_path)',
-  '        tokens.each do |token|',
-  '          xc.gsub!(/\\s*-l"?#{Regexp.escape(token)}"?/, \'\')',
-  '          xc.gsub!(/\\s*-framework\\s+"?#{Regexp.escape(token)}"?/, \'\')',
-  '          xc.gsub!(/\\s*-Xcc\\s+-fmodule-map-file="[^"]*#{Regexp.escape(token)}[^"]*"/, \'\')',
-  '          xc.gsub!(/\\s*-fmodule-map-file="[^"]*#{Regexp.escape(token)}[^"]*"/, \'\')',
-  '        end',
+  ...EXCLUDED_LINKER_STRIP_RUBY,
   '        File.write(xcconfig_path, xc)',
   '      end',
   '      Pod::UI.puts "[expo-targets] Stripped #{tokens.length} linker tokens from Pods-#{target_name}"',

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/stripLinkerTokens.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/stripLinkerTokens.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+
+import {
+  EXCLUDED_LINKER_STRIP_RUBY,
+  ensureExcludedPackagesPostIntegrate,
+} from './podfile';
+
+const MESSAGES_LDFLAGS = [
+  'OTHER_LDFLAGS = $(inherited) -ObjC',
+  '-l"logrocket_react_native" -l"Intercom"',
+  '-framework "CoreText" -framework "ExpoImageManipulator"',
+  '-framework "ExpoImagePicker" -framework "ExpoModulesCore"',
+  '-framework "Intercom" -framework "AppCheckInterop"',
+  '-fmodule-map-file="$(PODS_ROOT)/Headers/Public/Intercom/Intercom.modulemap"',
+  '-fmodule-map-file="$(PODS_ROOT)/Headers/Public/ExpoModulesCore/ExpoModulesCore.modulemap"',
+].join(' ');
+
+function stripLinkerTokens(xc: string, tokens: string[]): string {
+  const script = [
+    'tokens = ARGV',
+    'xc = STDIN.read',
+    ...EXCLUDED_LINKER_STRIP_RUBY,
+    'print xc',
+  ].join('\n');
+  const result = spawnSync('ruby', ['-e', script, ...tokens], {
+    input: xc,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `ruby exited ${result.status}`);
+  }
+  return result.stdout;
+}
+
+function frameworkArgv(flags: string): string[] {
+  const names: string[] = [];
+  const quoted = /-framework\s+"([^"]+)"/g;
+  const unquoted = /-framework\s+(\S+)/g;
+  for (const match of flags.matchAll(quoted)) {
+    names.push(match[1] ?? '');
+  }
+  for (const match of flags.matchAll(unquoted)) {
+    const name = match[1] ?? '';
+    if (!name.startsWith('"')) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+describe('invert linker strip argv', () => {
+  test('ExpoImage does not glue CoreText onto ExpoImageManipulator', () => {
+    const stripped = stripLinkerTokens(MESSAGES_LDFLAGS, [
+      'ExpoImage',
+      'Intercom',
+    ]);
+
+    expect(stripped).toContain('-framework "CoreText"');
+    expect(stripped).toContain('-framework "ExpoImageManipulator"');
+    expect(stripped).toContain('-framework "ExpoImagePicker"');
+    expect(stripped).toContain('-framework "ExpoModulesCore"');
+    expect(stripped).toContain('-framework "AppCheckInterop"');
+    expect(stripped).toContain('-l"logrocket_react_native"');
+    expect(stripped).not.toContain('-framework "Intercom"');
+    expect(stripped).not.toContain('-l"Intercom"');
+    expect(stripped).not.toContain('Intercom.modulemap');
+    expect(stripped).toContain('ExpoModulesCore.modulemap');
+
+    const names = frameworkArgv(stripped);
+    expect(names).toEqual([
+      'CoreText',
+      'ExpoImageManipulator',
+      'ExpoImagePicker',
+      'ExpoModulesCore',
+      'AppCheckInterop',
+    ]);
+    for (const name of names) {
+      expect(name.includes(' ')).toBe(false);
+      expect(name.includes('-framework')).toBe(false);
+    }
+  });
+
+  test('post_integrate embeds whole-token framework gsub', () => {
+    const hook = ensureExcludedPackagesPostIntegrate('', [
+      {
+        targetName: 'MessagesTarget',
+        packages: ['expo-image'],
+        linkerTokens: ['ExpoImage'],
+      },
+    ]);
+    expect(hook).toContain(EXCLUDED_LINKER_STRIP_RUBY[3]);
+    expect(hook).not.toMatch(
+      /xc\.gsub!\(\/\\s\*-framework\\s\+"\?#\{Regexp\.escape\(token\)\}"\?\//
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Invert `post_integrate` no longer prefix-matches `-framework` / `-l` tokens, so `ExpoImage` cannot glue `CoreText` onto `ExpoImageManipulator`.
- That smash is what failed MessagesTarget `ld` on Popl EAS qa `8632ae89` (`expo-targets@1.8.5`).
- Ruby strip is tested against a Messages-like OTHER_LDFLAGS line.

## Test plan
- [x] `bun test --cwd packages/expo-targets plugin/src/ios/apply/podfile/stripLinkerTokens.test.ts`
- [x] `bun test --cwd packages/expo-targets plugin/src/ios/apply/podfile/podfile.test.ts`
- [ ] After publish `1.8.6`, Popl 2435 pin + prebuild: `Pods-MessagesTarget` OTHER_LDFLAGS has no glued tokens
- [ ] Re-run iOS `qa` only after that prebuild check