### PR TITLE
fix(ios): strip invert companion pods with unused packages

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ Add the plugin and App Groups to your `app.json`:
 
 Update the placeholder `appGroup` to match your `app.json`.
 
-For RN `entry` targets, the plugin strips unused autolinked host packages from the nested `ExpoModulesProvider` and from the extension linker. It always strips `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` (they crash appex processes). Keep a package with `linkedPackages` when the entry does not import it. Set `ios.nativeLink` to `"host"` only when you need the old fat host link. `excludedPackages` is force-strip only. Do not add a long deny-list in the target config.
+For RN `entry` targets, the plugin strips unused autolinked host packages from the nested `ExpoModulesProvider` and from the extension linker. Companion frameworks that live on a kept package but require a stripped package (for example `ExpoModulesWorkletsAdapter` with `RNWorklets`) strip together. It always strips `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` (they crash appex processes). Keep a package with `linkedPackages` when the entry does not import it. Set `ios.nativeLink` to `"host"` only when you need the old fat host link. `excludedPackages` is force-strip only. Do not add a long deny-list in the target config.
 
 Extension JS can still OTA without linking Updates in the appex: the host runs `eas update`, then sideloads Hermes bundles into the App Group. Set a string `expo.runtimeVersion`, run `npx expo-targets export-extension-bundles` before each update, and use a **Release** build to verify the share sheet. Full flow: [Extension bundle sideload](./react-native-extensions.md#extension-bundle-sideload-with-expo-updates).
 

--- a/docs/react-native-extensions.md
+++ b/docs/react-native-extensions.md
@@ -371,7 +371,10 @@ Core keep is React Native, Hermes, Yoga, ExpoModulesCore, and `expo-targets`.
 The same strip set is applied to `ExpoModulesProvider` and to `Pods-<Target>`
 linker flags (`-l`, `-framework`, module maps). Linker tokens include XCFramework
 names from each unused package podspec (`s.dependency "Intercom"` → `-framework Intercom`),
-not only the npm or wrapper-pod name. Each `-framework NAME` stays its own argv
+not only the npm or wrapper-pod name. Optional companion pods that live on a
+kept package but require a stripped package (for example
+`ExpoModulesWorkletsAdapter` on `expo-modules-core` requires `RNWorklets`)
+are stripped with that package. Each `-framework NAME` stays its own argv
 (a shorter token such as `ExpoImage` does not eat `ExpoImageManipulator`).
 The host can still embed those frameworks in the app. The plugin does not copy
 host `OTHER_LDFLAGS`.

--- a/packages/expo-targets/plugin/src/autolinkedPackages.ts
+++ b/packages/expo-targets/plugin/src/autolinkedPackages.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
+import { companionTokensForUnused } from './linkerCompanions';
+
 export type AutolinkedNativePackage = {
   packageName: string;
   linkerTokens: string[];
@@ -304,6 +306,14 @@ export function linkerTokensForPackages(
       if (!isBlockedLinkerToken(token)) {
         tokens.add(token);
       }
+    }
+  }
+  for (const token of companionTokensForUnused({
+    unusedPackages: packageNames,
+    unusedTokens: [...tokens],
+  })) {
+    if (!isBlockedLinkerToken(token)) {
+      tokens.add(token);
     }
   }
   return [...tokens];

--- a/packages/expo-targets/plugin/src/ios/apply/podfile/stripLinkerTokens.test.ts
+++ b/packages/expo-targets/plugin/src/ios/apply/podfile/stripLinkerTokens.test.ts
@@ -95,3 +95,27 @@ describe('invert linker strip argv', () => {
     );
   });
 });
+
+describe('invert linker strip worklets argv', () => {
+  test('ExpoModulesWorkletsAdapter does not glue ExpoModulesWorklets', () => {
+    const flags = [
+      'OTHER_LDFLAGS = $(inherited)',
+      '-l"RNWorklets"',
+      '-framework "ExpoModulesCore"',
+      '-framework "ExpoModulesWorklets"',
+      '-framework "ExpoModulesWorkletsAdapter"',
+    ].join(' ');
+    const stripped = stripLinkerTokens(flags, [
+      'RNWorklets',
+      'ExpoModulesWorkletsAdapter',
+    ]);
+    expect(stripped).toContain('-framework "ExpoModulesCore"');
+    expect(stripped).toContain('-framework "ExpoModulesWorklets"');
+    expect(stripped).not.toContain('-l"RNWorklets"');
+    expect(stripped).not.toContain('ExpoModulesWorkletsAdapter');
+    expect(frameworkArgv(stripped)).toEqual([
+      'ExpoModulesCore',
+      'ExpoModulesWorklets',
+    ]);
+  });
+});

--- a/packages/expo-targets/plugin/src/linkerCompanions.test.ts
+++ b/packages/expo-targets/plugin/src/linkerCompanions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  companionTokensForUnused,
+  knownCompanionTokensForPackage,
+} from './linkerCompanions';
+
+describe('companionTokensForUnused', () => {
+  test('pairs ExpoModulesWorkletsAdapter with unused react-native-worklets', () => {
+    expect(
+      companionTokensForUnused({
+        unusedPackages: ['react-native-worklets'],
+        unusedTokens: ['RNWorklets'],
+      })
+    ).toEqual(['ExpoModulesWorkletsAdapter']);
+  });
+
+  test('pairs from RNWorklets token when the npm name differs', () => {
+    expect(
+      companionTokensForUnused({
+        unusedPackages: ['react-native-worklets-core'],
+        unusedTokens: ['RNWorklets'],
+      })
+    ).toEqual(['ExpoModulesWorkletsAdapter']);
+  });
+
+  test('does not pair when worklets stays', () => {
+    expect(
+      companionTokensForUnused({
+        unusedPackages: ['@sentry/react-native'],
+        unusedTokens: ['RNSentry'],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('knownCompanionTokensForPackage', () => {
+  test('attaches the adapter to both worklets package names', () => {
+    expect(knownCompanionTokensForPackage('react-native-worklets')).toEqual([
+      'ExpoModulesWorkletsAdapter',
+    ]);
+    expect(
+      knownCompanionTokensForPackage('react-native-worklets-core')
+    ).toEqual(['ExpoModulesWorkletsAdapter']);
+    expect(knownCompanionTokensForPackage('expo-modules-core')).toEqual([]);
+  });
+});

--- a/packages/expo-targets/plugin/src/linkerCompanions.ts
+++ b/packages/expo-targets/plugin/src/linkerCompanions.ts
@@ -16,10 +16,7 @@ export type LinkerCompanion = {
 export const OPTIONAL_LINKER_COMPANIONS: readonly LinkerCompanion[] = [
   {
     tokens: ['ExpoModulesWorkletsAdapter'],
-    requiresAnyPackage: [
-      'react-native-worklets',
-      'react-native-worklets-core',
-    ],
+      requiresAnyPackage: ['react-native-worklets', 'react-native-worklets-core'],
     requiresAnyToken: ['RNWorklets'],
   },
 ];

--- a/packages/expo-targets/plugin/src/linkerCompanions.ts
+++ b/packages/expo-targets/plugin/src/linkerCompanions.ts
@@ -16,7 +16,7 @@ export type LinkerCompanion = {
 export const OPTIONAL_LINKER_COMPANIONS: readonly LinkerCompanion[] = [
   {
     tokens: ['ExpoModulesWorkletsAdapter'],
-      requiresAnyPackage: ['react-native-worklets', 'react-native-worklets-core'],
+    requiresAnyPackage: ['react-native-worklets', 'react-native-worklets-core'],
     requiresAnyToken: ['RNWorklets'],
   },
 ];

--- a/packages/expo-targets/plugin/src/linkerCompanions.ts
+++ b/packages/expo-targets/plugin/src/linkerCompanions.ts
@@ -1,0 +1,73 @@
+/**
+ * Optional native pods that live on a kept package (often expo-modules-core)
+ * but only link when another autolinked package is present.
+ *
+ * Invert is package-granular. Without this closure, stripping `react-native-worklets`
+ * drops `-lRNWorklets` while `-framework ExpoModulesWorkletsAdapter` stays and
+ * ld fails on `worklets::`.
+ */
+
+export type LinkerCompanion = {
+  tokens: readonly string[];
+  requiresAnyPackage: readonly string[];
+  requiresAnyToken?: readonly string[];
+};
+
+export const OPTIONAL_LINKER_COMPANIONS: readonly LinkerCompanion[] = [
+  {
+    tokens: ['ExpoModulesWorkletsAdapter'],
+    requiresAnyPackage: [
+      'react-native-worklets',
+      'react-native-worklets-core',
+    ],
+    requiresAnyToken: ['RNWorklets'],
+  },
+];
+
+function companionApplies(
+  companion: LinkerCompanion,
+  unusedPackages: ReadonlySet<string>,
+  unusedTokens: ReadonlySet<string>
+): boolean {
+  for (const name of companion.requiresAnyPackage) {
+    if (unusedPackages.has(name)) {
+      return true;
+    }
+  }
+  for (const token of companion.requiresAnyToken ?? []) {
+    if (unusedTokens.has(token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Extra strip tokens for unused packages, even when a kept package owns them. */
+export function companionTokensForUnused(opts: {
+  unusedPackages: readonly string[];
+  unusedTokens?: readonly string[];
+}): string[] {
+  const unusedPackages = new Set(opts.unusedPackages);
+  const unusedTokens = new Set(opts.unusedTokens ?? []);
+  const extra = new Set<string>();
+  for (const companion of OPTIONAL_LINKER_COMPANIONS) {
+    if (companionApplies(companion, unusedPackages, unusedTokens)) {
+      for (const token of companion.tokens) {
+        extra.add(token);
+      }
+    }
+  }
+  return [...extra];
+}
+
+export function knownCompanionTokensForPackage(packageName: string): string[] {
+  const tokens = new Set<string>();
+  for (const companion of OPTIONAL_LINKER_COMPANIONS) {
+    if (companion.requiresAnyPackage.includes(packageName)) {
+      for (const token of companion.tokens) {
+        tokens.add(token);
+      }
+    }
+  }
+  return [...tokens];
+}

--- a/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
+++ b/packages/expo-targets/plugin/src/resolveExcludedPackages.test.ts
@@ -168,6 +168,79 @@ describe('resolveNativeUnlink linker tokens', () => {
   });
 });
 
+describe('resolveNativeUnlink unused worklets companion', () => {
+  test('unused worklets strips RNWorklets and ExpoModulesWorkletsAdapter', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import { View } from 'react-native';\nexport default function App() { return null; }\n"
+    );
+    const resolved = resolveNativeUnlink({
+      type: 'messages',
+      entry: './targets/messages/index.tsx',
+      projectRoot: root,
+      autolinkedPackages: [
+        {
+          packageName: 'expo-modules-core',
+          linkerTokens: [
+            'expo-modules-core',
+            'ExpoModulesCore',
+            'ExpoModulesWorklets',
+            'ExpoModulesWorkletsAdapter',
+          ],
+        },
+        {
+          packageName: 'react-native-worklets',
+          linkerTokens: ['react-native-worklets', 'RNWorklets'],
+        },
+      ],
+    });
+    expect(resolved?.packages).toContain('react-native-worklets');
+    expect(resolved?.packages).not.toContain('expo-modules-core');
+    expect(resolved?.linkerTokens).toEqual(
+      expect.arrayContaining(['RNWorklets', 'ExpoModulesWorkletsAdapter'])
+    );
+    expect(resolved?.linkerTokens).not.toContain('ExpoModulesCore');
+    expect(resolved?.linkerTokens).not.toContain('ExpoModulesWorklets');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('resolveNativeUnlink imported worklets companion', () => {
+  test('imported worklets keeps RNWorklets and the adapter', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));
+    fs.mkdirSync(path.join(root, 'targets', 'messages'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'targets', 'messages', 'index.tsx'),
+      "import { createSerializable } from 'react-native-worklets';\nexport default function App() { return null; }\n"
+    );
+    const resolved = resolveNativeUnlink({
+      type: 'messages',
+      entry: './targets/messages/index.tsx',
+      projectRoot: root,
+      autolinkedPackages: [
+        {
+          packageName: 'expo-modules-core',
+          linkerTokens: [
+            'expo-modules-core',
+            'ExpoModulesCore',
+            'ExpoModulesWorkletsAdapter',
+          ],
+        },
+        {
+          packageName: 'react-native-worklets',
+          linkerTokens: ['react-native-worklets', 'RNWorklets'],
+        },
+      ],
+    });
+    expect(resolved?.packages).not.toContain('react-native-worklets');
+    expect(resolved?.linkerTokens).not.toContain('RNWorklets');
+    expect(resolved?.linkerTokens).not.toContain('ExpoModulesWorkletsAdapter');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
 describe('resolveNativeUnlink nativeLink host', () => {
   test('nativeLink host skips invert; user excludedPackages still strip', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-targets-excl-'));


### PR DESCRIPTION
## Summary
- Invert now closes optional companion pods that live on a kept package but require a stripped package (`ExpoModulesWorkletsAdapter` with `RNWorklets`).
- This is the MessagesTarget ld failure after 1.8.6: the adapter stayed while `-lRNWorklets` was stripped (`worklets::`).
- Whole-token `-framework` argv from PR 95 is unchanged. Do not set `ios.nativeLink: host`.

## Test plan
- [x] `resolveNativeUnlink` unused worklets → strip `RNWorklets` + `ExpoModulesWorkletsAdapter`
- [x] imported worklets → keep both
- [x] Ruby argv: adapter strip does not glue `ExpoModulesWorklets`
- [ ] After npm cut (1.8.7), popl re-pin and iOS qa only (382377ab class)